### PR TITLE
Download dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ Downloads a remote project, images and annotations, in the projects directory (s
 from darwin.client import Client
 
 client = Client.default()
-dataset = client.get_remote_dataset(slug="example-dataset").pull()
+dataset = client.get_remote_dataset(slug="example-dataset")
+dataset.pull()
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -85,15 +85,12 @@ for _ in progress():
 #### Pull a [remote] project
 
 Downloads a remote project, images and annotations, in the projects directory (specified in the authentication process [default: ~/.darwin/projects]).
+
 ```python
 from darwin.client import Client
 
 client = Client.default()
-dataset = client.get_remote_dataset(slug="example-dataset")
-progress, _count = dataset.pull()
-for f in progress():
-    f()
-    print("file synced")
+dataset = client.get_remote_dataset(slug="example-dataset").pull()
 ```
 
 ### Command line

--- a/README.md
+++ b/README.md
@@ -94,11 +94,9 @@ dataset = client.get_remote_dataset(slug="example-dataset")
 dataset.pull()
 ```
 
-
 ### Command line
 
 `darwin` is also accessible as a command line tool.
-
 
 #### Authentication
 A username (email address) and password is required to authenticate. If you do not already have a Darwin account, register for free at [https://darwin.v7labs.com](https://darwin.v7labs.com).

--- a/darwin/cli_functions.py
+++ b/darwin/cli_functions.py
@@ -157,17 +157,14 @@ def pull_project(project_slug: str):
     client = load_client()
     try:
         dataset = client.get_remote_dataset(slug=project_slug)
+        print(f"Pulling project {project_slug}:latest")
+        dataset.pull()
+        return dataset.local()
     except NotFound:
         error(f"project '{project_slug}' does not exist at {client.url}. "
               f"Use 'darwin remote' to list all the remote projects.")
     except Unauthenticated:
         error(f"please re-authenticate")
-    print(f"Pulling project {project_slug}:latest")
-    progress, count = dataset.pull(blocking=False)
-    for f in tqdm(progress(), total=count, desc="Downloading"):
-        f()
-
-    return dataset.local()
 
 
 def remote():

--- a/darwin/cli_functions.py
+++ b/darwin/cli_functions.py
@@ -158,14 +158,12 @@ def pull_project(project_slug: str):
     try:
         dataset = client.get_remote_dataset(slug=project_slug)
     except NotFound:
-        error(
-            f"project '{project_slug}' does not exist at {client.url}. "
-            f"Use 'darwin remote' to list all the remote projects."
-        )
+        error(f"project '{project_slug}' does not exist at {client.url}. "
+              f"Use 'darwin remote' to list all the remote projects.")
     except Unauthenticated:
         error(f"please re-authenticate")
     print(f"Pulling project {project_slug}:latest")
-    progress, count = dataset.pull()
+    progress, count = dataset.pull(blocking=False)
     for f in tqdm(progress(), total=count, desc="Downloading"):
         f()
 
@@ -225,7 +223,7 @@ def remove_local_project(project_slug: str):
 
 
 def upload_data(
-    project_slug: str, files: List[str], extensions_to_exclude: List[str], fps: int, recursive: bool
+        project_slug: str, files: List[str], extensions_to_exclude: List[str], fps: int, recursive: bool
 ):
     client = load_client()
     try:
@@ -245,7 +243,7 @@ def upload_data(
         return
 
     for _ in tqdm(
-        dataset.upload_files(files_to_upload, fps=fps), total=len(files_to_upload), desc="Uploading"
+            dataset.upload_files(files_to_upload, fps=fps), total=len(files_to_upload), desc="Uploading"
     ):
         pass
 
@@ -253,8 +251,8 @@ def upload_data(
 def find_files(root: Path, recursive: bool, exclude: List[str]) -> List[Path]:
     if not root.is_dir():
         if (
-            root.suffix in SUPPORTED_IMAGE_EXTENSIONS + SUPPORTED_VIDEO_EXTENSIONS
-            and root.suffix not in exclude
+                root.suffix in SUPPORTED_IMAGE_EXTENSIONS + SUPPORTED_VIDEO_EXTENSIONS
+                and root.suffix not in exclude
         ):
             return [root]
         else:
@@ -267,8 +265,8 @@ def find_files(root: Path, recursive: bool, exclude: List[str]) -> List[Path]:
                 files += find_files(file, recursive, exclude)
         else:
             if (
-                file.suffix in SUPPORTED_IMAGE_EXTENSIONS + SUPPORTED_VIDEO_EXTENSIONS
-                and file.suffix not in exclude
+                    file.suffix in SUPPORTED_IMAGE_EXTENSIONS + SUPPORTED_VIDEO_EXTENSIONS
+                    and file.suffix not in exclude
             ):
                 files += [file]
     return files

--- a/darwin/dataset/remote_dataset.py
+++ b/darwin/dataset/remote_dataset.py
@@ -61,7 +61,7 @@ class RemoteDataset:
             yield
 
     def pull(self):
-        """Downloads a rermote project (images and annotations) in the projects directory. """
+        """Downloads a remote project (images and annotations) in the projects directory. """
         response = self._client.get(f"/datasets/{self.dataset_id}/export?format=json", raw=True)
         zip_file = io.BytesIO(response.content)
         if zipfile.is_zipfile(zip_file):

--- a/darwin/dataset/remote_dataset.py
+++ b/darwin/dataset/remote_dataset.py
@@ -107,9 +107,8 @@ class RemoteDataset:
                     for f in progress():
                         f()
                 return None, count
-            return progress
-
-            return progress if not blocking else None, count
+            else:
+                return progress, count
 
     def local(self):
         return darwin.dataset.LocalDataset(

--- a/darwin/dataset/remote_dataset.py
+++ b/darwin/dataset/remote_dataset.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import multiprocessing as mp
+import shutil
 import zipfile
 from pathlib import Path
 from typing import List, Optional, TYPE_CHECKING
@@ -92,8 +93,12 @@ class RemoteDataset:
             project_dir = Path(self._client.project_dir) / self.slug
             images_dir = project_dir / "images"
             annotations_dir = project_dir / "annotations"
-            annotations_dir.mkdir(parents=True, exist_ok=True)
-
+            if annotations_dir.exists():
+                try:
+                    shutil.rmtree(annotations_dir)
+                except PermissionError:
+                    print(f"Could not remove dataset in {annotations_dir}. Permission denied.")
+            annotations_dir.mkdir(parents=True, exist_ok=False)
             z.extractall(annotations_dir)
             annotation_format = "json"
             progress, count = download_all_images_from_annotations(

--- a/darwin/dataset/remote_dataset.py
+++ b/darwin/dataset/remote_dataset.py
@@ -106,6 +106,8 @@ class RemoteDataset:
                 else:
                     for f in progress():
                         f()
+                return None, count
+            return progress
 
             return progress if not blocking else None, count
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setuptools.setup(
     name="darwin-py",
-    version="0.0.4",
+    version="0.0.3",
     author="V7",
     author_email="info@v7labs.com",
     description="Library and command line interface for darwin.v7labs.com",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setuptools.setup(
     name="darwin-py",
-    version="0.0.3",
+    version="0.0.4",
     author="V7",
     author_email="info@v7labs.com",
     description="Library and command line interface for darwin.v7labs.com",


### PR DESCRIPTION
`RemoteDataset.pull()` now matches the functionality of the CLI.
The optional parameters `blocking` and `multi_threaded` allow to either get the iterator or use a single thread to download the data. 