### PR TITLE
Toggle polygon to mask conversion

### DIFF
--- a/darwin/torch/__init__.py
+++ b/darwin/torch/__init__.py
@@ -1,1 +1,2 @@
 # Requirements: pytorch, torchvision, pycocotools, sklearn
+from .dataset import Dataset, ClassificationDataset, InstanceSegmentationDataset, SemanticSegmentationDataset

--- a/darwin/torch/transforms.py
+++ b/darwin/torch/transforms.py
@@ -66,7 +66,7 @@ class ConvertPolygonsToInstanceMasks(object):
 
         # conversion to coco api
         area = torch.tensor([obj["area"] for obj in annotations])
-        iscrowd = torch.tensor([obj["iscrowd"] for obj in annotations])
+        iscrowd = torch.tensor([obj.get("iscrowd", 0) for obj in annotations])
         target["area"] = area
         target["iscrowd"] = iscrowd
 


### PR DESCRIPTION
This PR adds an option to disable the polygon to mask conversion in segmentation datasets. It also splits the `get_height_and_width` function into two, adding as a results a new function `get_img_info`, and fixes a couple of bugs.