### PR TITLE
Restores get_dataset() function in the darwin.torch toolbox

### DIFF
--- a/darwin/dataset/utils.py
+++ b/darwin/dataset/utils.py
@@ -493,9 +493,9 @@ def get_coco_format_record(
     annotations = data["annotations"]
 
     record = {}
-    if image_path:
+    if image_path is not None:
         record["file_name"] = str(image_path)
-    if image_id:
+    if image_id is not None:
         record["image_id"] = image_id
     record["height"] = height
     record["width"] = width

--- a/darwin/dataset/utils.py
+++ b/darwin/dataset/utils.py
@@ -594,7 +594,13 @@ def get_annotations(
         elif split_type == "stratified":
             split_file = f"{split_type}_{annotation_type}_{partition}.txt"
         split_path = release_path / "lists" / split / split_file
-        stems = (e.strip() for e in split_path.open())
+        if split_path.is_file():
+            stems = (e.strip() for e in split_path.open())
+        else:
+            raise FileNotFoundError(
+                f"Could not find a dataset partition. ",
+                f"To split the dataset you can use 'split_dataset' from darwin.dataset.utils"
+            )
     else:
         # If the split is not specified, get all the annotations
         stems = [e.stem for e in annotations_dir.glob("*.json")]

--- a/darwin/dataset/utils.py
+++ b/darwin/dataset/utils.py
@@ -357,15 +357,15 @@ def split_dataset(
     splits = {}
     splits["random"] = {
         "train": Path(split_path / "random_train.txt"),
-        "val": Path(split_path / "random_validation.txt"),
+        "val": Path(split_path / "random_val.txt"),
     }
     splits["stratified_tag"] = {
         "train": Path(split_path / "stratified_tag_train.txt"),
-        "val": Path(split_path / "stratified_tag_validation.txt"),
+        "val": Path(split_path / "stratified_tag_val.txt"),
     }
     splits["stratified_polygon"] = {
         "train": Path(split_path / "stratified_polygon_train.txt"),
-        "val": Path(split_path / "stratified_polygon_validation.txt"),
+        "val": Path(split_path / "stratified_polygon_val.txt"),
     }
     if test_percentage > 0.0:
         splits["random"]["test"] = Path(split_path) / "random_test.txt"
@@ -536,7 +536,7 @@ def get_coco_format_record(
 
 def get_annotations(
     dataset_path: Path,
-    partition: str,
+    partition: Optional[str] = None,
     split: Optional[str] = None,
     split_type: Optional[str] = None,
     annotation_type: str = "polygon",
@@ -575,10 +575,10 @@ def get_annotations(
     images_dir = dataset_path / "images"
     assert images_dir.exists()
 
-    if partition not in ["train", "validation", "test"]:
-        raise ValueError("partition should be either 'train', 'valildation', or 'test'")
+    if partition not in ["train", "val", "test", None]:
+        raise ValueError("partition should be either 'train', 'val', 'test', or None")
     if split_type not in ["random", "stratified", None]:
-        raise ValueError("split_type should be either 'random', 'stratified'")
+        raise ValueError("split_type should be either 'random', 'stratified', or None")
     if annotation_type not in ["tag", "polygon", "box"]:
         raise ValueError("annotation_type should be either 'tag', 'box', or 'polygon'")
 

--- a/darwin/dataset/utils.py
+++ b/darwin/dataset/utils.py
@@ -422,7 +422,7 @@ def split_dataset(
                     _write_to_file(annotation_files, splits["stratified_polygon"]["test"], test_indices)
 
     # Create symlink for default split
-    split = lists_path / "split"
+    split = lists_path / "default"
     if make_default_split or not split.exists():
         if split.exists():
             split.unlink()

--- a/darwin/dataset/utils.py
+++ b/darwin/dataset/utils.py
@@ -37,8 +37,8 @@ def get_release_path(dataset_path: Path, release_name: Optional[str] = None):
     release_path = dataset_path / "releases" / release_name
     if not release_path.exists():
         raise NotFound(
-            f"Local copy of release {release_name} not found: Pull this release from Darwin using pull() \
-            or use a different version"
+            f"Local copy of release {release_name} not found: Pull this release from Darwin using pull() "
+            "or use a different version"
         )
     return release_path
 

--- a/darwin/dataset/utils.py
+++ b/darwin/dataset/utils.py
@@ -289,7 +289,7 @@ def _stratify_samples(idx_to_classes, split_seed, test_percentage, val_percentag
 
 
 def split_dataset(
-    dataset_path: Path,
+    dataset_path: Union[Path, str],
     release_name: Optional[str] = None,
     val_percentage: Optional[float] = 0.1,
     test_percentage: Optional[float] = 0.2,
@@ -324,6 +324,8 @@ def split_dataset(
         Keys are the different splits (random, tags, ...) and values are the relative file names
     """
     assert dataset_path is not None
+    if isinstance(dataset_path, str):
+        dataset_path = Path(dataset_path)
     release_path = get_release_path(dataset_path, release_name)
 
     annotation_path = release_path / "annotations"

--- a/darwin/dataset/utils.py
+++ b/darwin/dataset/utils.py
@@ -522,7 +522,7 @@ def get_record(
             poly = [(x, y) for x, y in zip(px, py)]
             if len(poly) < 3:  # Discard polyhons with less than 3 points
                 continue
-            new_obj["segmentation"] = list(itertools.chain.from_iterable(poly))
+            new_obj["segmentation"] = [list(itertools.chain.from_iterable(poly))]
             new_obj["bbox"] = [np.min(px), np.min(py), np.max(px), np.max(py)]
         elif annotation_type == "bounding_box":
             bbox = obj["bounding_box"]

--- a/darwin/torch/README.md
+++ b/darwin/torch/README.md
@@ -6,7 +6,7 @@ This toolbox include some funcitonality to load your datasets ready to be plugge
 get_dataset("/PATH/TO/YOUR/DATASET", DATASET_TYPE [, PARTITION, SPLIT_TYPE, RELEASE_NAME, TRANSFORMS])
 ```
 
-Here is an example of how to load the `bird-species` dataset ready for instance segmentation using the `dataset_type = "instance_segmentation"` (alternatively you can use `"classification"` or `"semantic_segmentation"` for different taks):
+Here is an example of how to load the `bird-species` dataset ready for instance segmentation using `"instance_segmentation"` as `dataset_type` (alternatively you can use `"classification"` or `"semantic_segmentation"` for those other tasks):
 
 ```python
 from darwin.torch import get_dataset

--- a/darwin/torch/README.md
+++ b/darwin/torch/README.md
@@ -24,7 +24,7 @@ import darwin.torch.transforms as T
 split_dataset("/datasets/bird-species", val_percentage=0.2, test_percentage=0)
 
 trfs_train = T.Compose([T.RandomHorizontalFlip(), T.ToTensor()])
-db_train = get_dataset("/datasets/bird-species", dataset_type="instance_segmentation", partition="train", split_type="random", transform=trfs_val)
+db_train = get_dataset("/datasets/bird-species", dataset_type="instance_segmentation", partition="train", split_type="random", transform=trfs_train)
 
 trfs_val = T.Compose([T.ToTensor()])
 db_val = get_dataset("/datasets/bird-species", dataset_type="instance_segmentation", partition="val", split_type="random", transform=trfs_train)

--- a/darwin/torch/README.md
+++ b/darwin/torch/README.md
@@ -3,7 +3,7 @@
 This toolbox include some funcitonality to load your datasets ready to be plugged into Pytorch's DataLoaders. For that you can use the function `get_dataset`:
 
 ```
-get_dataset("/PATH/TO/YOUR/DATASET", DATASET_TYPE [, PARTITION, RELEASE_NAME, TRANSFORMS])
+get_dataset("/PATH/TO/YOUR/DATASET", DATASET_TYPE [, PARTITION, SPLIT_TYPE, RELEASE_NAME, TRANSFORMS])
 ```
 
 Here is an example of how to load the `bird-species` dataset ready for instance segmentation using the "instance_segmentation" `dataset_type` (alternatively you can use "classification" or "semantic_segmentation" for different taks):
@@ -17,15 +17,15 @@ db = get_dataset("/datasets/bird-species", dataset_type="instance_segmentation")
 You can use this function in combination with the `split_dataset` function to load only a given partition, and also provide a list of transformations:
 
 ```
-from darwin.dataset import split_dataset
+from darwin.dataset.utils import split_dataset
 from darwin.torch import get_dataset
 import darwin.torch.transforms as T
 
 split_dataset("/datasets/bird-species", val_percentage=0.2, test_percentage=0)
 
 trfs_train = T.Compose([T.RandomHorizontalFlip(), T.ToTensor()])
-db_train = get_dataset("/datasets/bird-species", dataset_type="instance_segmentation", partition="train", transform=trfs_val)
+db_train = get_dataset("/datasets/bird-species", dataset_type="instance_segmentation", partition="train", split_type="random", transform=trfs_val)
 
 trfs_val = T.Compose([T.ToTensor()])
-db_val = get_dataset("/datasets/bird-species", dataset_type="instance_segmentation", partition="val", transform=trfs_train)
+db_val = get_dataset("/datasets/bird-species", dataset_type="instance_segmentation", partition="val", split_type="random", transform=trfs_train)
 ```

--- a/darwin/torch/README.md
+++ b/darwin/torch/README.md
@@ -6,7 +6,7 @@ This toolbox include some funcitonality to load your datasets ready to be plugge
 get_dataset("/PATH/TO/YOUR/DATASET", DATASET_TYPE [, PARTITION, SPLIT_TYPE, RELEASE_NAME, TRANSFORMS])
 ```
 
-Here is an example of how to load the `bird-species` dataset ready for instance segmentation using the "instance_segmentation" `dataset_type` (alternatively you can use "classification" or "semantic_segmentation" for different taks):
+Here is an example of how to load the `bird-species` dataset ready for instance segmentation using the `dataset_type = "instance_segmentation"` (alternatively you can use `"classification"` or `"semantic_segmentation"` for different taks):
 
 ```python
 from darwin.torch import get_dataset
@@ -24,10 +24,12 @@ import darwin.torch.transforms as T
 split_dataset("/datasets/bird-species", val_percentage=0.2, test_percentage=0)
 
 trfs_train = T.Compose([T.RandomHorizontalFlip(), T.ToTensor()])
-db_train = get_dataset("/datasets/bird-species", dataset_type="instance_segmentation", partition="train", split_type="random", transform=trfs_train)
+db_train = get_dataset("/datasets/bird-species", dataset_type="instance_segmentation", \
+    partition="train", split_type="random", transform=trfs_train)
 
 trfs_val = T.Compose([T.ToTensor()])
-db_val = get_dataset("/datasets/bird-species", dataset_type="instance_segmentation", partition="val", split_type="random", transform=trfs_val)
+db_val = get_dataset("/datasets/bird-species", dataset_type="instance_segmentation", \
+    partition="val", split_type="random", transform=trfs_val)
 
 print(db_train)
 # Returns:

--- a/darwin/torch/README.md
+++ b/darwin/torch/README.md
@@ -2,21 +2,21 @@
 
 This toolbox include some funcitonality to load your datasets ready to be plugged into Pytorch's DataLoaders. For that you can use the function `get_dataset`:
 
-```
+```python
 get_dataset("/PATH/TO/YOUR/DATASET", DATASET_TYPE [, PARTITION, SPLIT_TYPE, RELEASE_NAME, TRANSFORMS])
 ```
 
 Here is an example of how to load the `bird-species` dataset ready for instance segmentation using the "instance_segmentation" `dataset_type` (alternatively you can use "classification" or "semantic_segmentation" for different taks):
 
-```
+```python
 from darwin.torch import get_dataset
 
 db = get_dataset("/datasets/bird-species", dataset_type="instance_segmentation")
 ```
 
-You can use this function in combination with the `split_dataset` function to load only a given partition, and also provide a list of transformations:
+You can use this function in combination with the `split_dataset` function to load only a given partition (and optionally provide a list of transformations):
 
-```
+```python
 from darwin.dataset.utils import split_dataset
 from darwin.torch import get_dataset
 import darwin.torch.transforms as T
@@ -27,5 +27,13 @@ trfs_train = T.Compose([T.RandomHorizontalFlip(), T.ToTensor()])
 db_train = get_dataset("/datasets/bird-species", dataset_type="instance_segmentation", partition="train", split_type="random", transform=trfs_train)
 
 trfs_val = T.Compose([T.ToTensor()])
-db_val = get_dataset("/datasets/bird-species", dataset_type="instance_segmentation", partition="val", split_type="random", transform=trfs_train)
+db_val = get_dataset("/datasets/bird-species", dataset_type="instance_segmentation", partition="val", split_type="random", transform=trfs_val)
+
+print(db_train)
+# Returns:
+#
+# InstanceSegmentationDataset():
+#   Root: /datasets/bird-species
+#   Number of images: 1528
+#   Number of classes: 3
 ```

--- a/darwin/torch/README.md
+++ b/darwin/torch/README.md
@@ -1,36 +1,31 @@
 # PyTorch
 
-
-This is an example on how to fetch a dataset from Darwin, splitting it into 70% for training, 20% for validation, 10% test, and getting the train partition, using the function `get_dataset`:
-
-```
-from darwin.torch.dataset import get_dataset
-
-db = get_dataset('bird-species', image_set="train", val_percentage=0.2, test_percentage=0.1)
-```
-
-The function `get_dataset` also accepts a list of transform as parameter using the parameter `transforms`. It also allows you to select the ground truth data you are interested in, such as `instance_segmentation`, `image_classification`, or `semantic_segmentation`. Finally, it also accepts a Darwin client as a parameter, containing your authenticating credentials in the Darwin.
+This toolbox include some funcitonality to load your datasets ready to be plugged into Pytorch's DataLoaders. For that you can use the function `get_dataset`:
 
 ```
-from darwin.torch.dataset import get_dataset
-from darwin.client import Client
+get_dataset("/PATH/TO/YOUR/DATASET", DATASET_TYPE [, PARTITION, RELEASE_NAME, TRANSFORMS])
+```
+
+Here is an example of how to load the `bird-species` dataset ready for instance segmentation using the "instance_segmentation" `dataset_type` (alternatively you can use "classification" or "semantic_segmentation" for different taks):
+
+```
+from darwin.torch import get_dataset
+
+db = get_dataset("/datasets/bird-species", dataset_type="instance_segmentation")
+```
+
+You can use this function in combination with the `split_dataset` function to load only a given partition, and also provide a list of transformations:
+
+```
+from darwin.dataset import split_dataset
+from darwin.torch import get_dataset
 import darwin.torch.transforms as T
 
-trfs = T.Compose([T.RandomHorizontalFlip(), T.ToTensor()])
-client = Client(...)
+split_dataset("/datasets/bird-species", val_percentage=0.2, test_percentage=0)
 
-db = get_dataset('bird-species', image_set="val", val_percentage=0.2, test_percentage=0.1, transforms=trfs, client=client, mode="instance_segmentation")
-```
+trfs_train = T.Compose([T.RandomHorizontalFlip(), T.ToTensor()])
+db_train = get_dataset("/datasets/bird-species", dataset_type="instance_segmentation", partition="train", transform=trfs_val)
 
-Other advanced options include: fixing the seed for random splitting using `split_seed=INT`, force re-fetching a dataset discarding the local copy using `force_fetching=True`, and force a re-split of the dataset using `force_resplit=True`.
-
-```
-from darwin.torch.dataset import get_dataset
-from darwin.client import Client
-import darwin.torch.transforms as T
-
-trfs = T.Compose([T.RandomHorizontalFlip(), T.ToTensor()])
-client = Client(...)
-
-db = get_dataset('bird-species', image_set="val", val_percentage=0.25, transforms=trfs, client=client, mode="image_classification", force_fetching=True, seed=42)
+trfs_val = T.Compose([T.ToTensor()])
+db_val = get_dataset("/datasets/bird-species", dataset_type="instance_segmentation", partition="val", transform=trfs_train)
 ```

--- a/darwin/torch/README.md
+++ b/darwin/torch/README.md
@@ -1,4 +1,4 @@
-# PyTorch
+# PyTorch toolbox
 
 This toolbox include some funcitonality to load your datasets ready to be plugged into Pytorch's DataLoaders. For that you can use the function `get_dataset`:
 
@@ -33,7 +33,6 @@ db_val = get_dataset("/datasets/bird-species", dataset_type="instance_segmentati
 
 print(db_train)
 # Returns:
-#
 # InstanceSegmentationDataset():
 #   Root: /datasets/bird-species
 #   Number of images: 1528

--- a/darwin/torch/__init__.py
+++ b/darwin/torch/__init__.py
@@ -1,8 +1,19 @@
-# Requirements: pytorch, torchvision, pycocotools, sklearn
+# Requirements: pytorch, torchvision, pycocotools
 from .dataset import (
     get_dataset,
-    ClassificationDataset,
     Dataset,
+    ClassificationDataset,
     InstanceSegmentationDataset,
     SemanticSegmentationDataset,
 )
+
+try:
+    import torch
+    import torchvision
+except ImportError:
+    raise ImportError(f"pytorch and torchvision required. Install it using: pip install torch torchvision")
+
+try:
+    import pycocotools
+except ImportError:
+    raise ImportError(f"pycocotools required. Install it using: pip install cython; pip install -U 'git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI'")

--- a/darwin/torch/__init__.py
+++ b/darwin/torch/__init__.py
@@ -1,5 +1,6 @@
 # Requirements: pytorch, torchvision, pycocotools, sklearn
 from .dataset import (
+    get_dataset,
     ClassificationDataset,
     Dataset,
     InstanceSegmentationDataset,

--- a/darwin/torch/__init__.py
+++ b/darwin/torch/__init__.py
@@ -1,4 +1,21 @@
 # Requirements: pytorch, torchvision, pycocotools
+try:
+    import torch
+    import torchvision
+except ImportError:
+    raise ImportError(
+        f"darwin.torch requires pytorch and torchvision. Install it using:\n"
+        f"pip install torch torchvision"
+    ) from None
+
+try:
+    import pycocotools
+except ImportError:
+    raise ImportError(
+        f"darwin.torch requires pycocotools. Install it using:\n"
+        f"pip install cython; pip install -U 'git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI'"
+    ) from None
+
 from .dataset import (
     get_dataset,
     Dataset,
@@ -6,14 +23,3 @@ from .dataset import (
     InstanceSegmentationDataset,
     SemanticSegmentationDataset,
 )
-
-try:
-    import torch
-    import torchvision
-except ImportError:
-    raise ImportError(f"pytorch and torchvision required. Install it using: pip install torch torchvision")
-
-try:
-    import pycocotools
-except ImportError:
-    raise ImportError(f"pycocotools required. Install it using: pip install cython; pip install -U 'git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI'")

--- a/darwin/torch/dataset.py
+++ b/darwin/torch/dataset.py
@@ -133,7 +133,13 @@ class Dataset(data.Dataset):
             elif split_type == "stratified":
                 split_file = f"{split_type}_{annotation_type}_{partition}.txt"
             split_path = release_path / "lists" / split / split_file
-            stems = (e.strip() for e in split_path.open())
+            if split_path.is_file():
+                stems = (e.strip() for e in split_path.open())
+            else:
+                raise FileNotFoundError(
+                    f"Could not find a dataset partition. ",
+                    f"To split the dataset you can use 'split_dataset' from darwin.dataset.utils"
+                )
         else:
             # If the split is not specified, get all the annotations
             stems = [e.stem for e in annotations_dir.glob("*.json")]

--- a/darwin/torch/dataset.py
+++ b/darwin/torch/dataset.py
@@ -67,7 +67,7 @@ class Dataset(data.Dataset):
         dataset_path: Path,
         annotation_type: str,
         partition: Optional[str] = None,
-        split: Optional[str] = None,
+        split: Optional[str] = "default",
         split_type: Optional[str] = None,
         release_name: Optional[str] = None,
         transform: Optional[List] = None
@@ -128,7 +128,7 @@ class Dataset(data.Dataset):
         )
 
         # Get the list of stems
-        if split:
+        if partition:
             # Get the split
             if split_type is None:
                 split_file = f"{partition}.txt"
@@ -145,7 +145,7 @@ class Dataset(data.Dataset):
                     f"To split the dataset you can use 'split_dataset' from darwin.dataset.utils"
                 )
         else:
-            # If the split is not specified, get all the annotations
+            # If the partition is not specified, get all the annotations
             stems = [e.stem for e in annotations_dir.glob("*.json")]
 
         images_paths = []

--- a/darwin/torch/dataset.py
+++ b/darwin/torch/dataset.py
@@ -9,27 +9,103 @@ import torch.utils.data as data
 from darwin.torch.transforms import Compose, ConvertPolygonsToInstanceMasks, ConvertPolygonToMask
 from darwin.torch.utils import convert_polygons_to_sequences, load_pil_image, polygon_area
 from darwin.utils import SUPPORTED_IMAGE_EXTENSIONS, is_image_extension_allowed
+from darwin.dataset.utils import get_classes, get_release_path
+
+
+def get_dataset(
+    dataset_path: Path,
+    dataset_type: str,
+    partition: Optional[str] = None,
+    split: Optional[str] = None,
+    split_type: Optional[str] = None,
+    release_name: Optional[str] = None,
+    transform: Optional[List] = None
+):
+    """ Creates and returns a dataset
+
+    Parameters
+    ----------
+    dataset_path
+        Path to the location of the dataset on the file system
+    dataset_type
+        The type of dataset [classification, instances_segmentation, semantic_segmentation]
+    partition
+        Selects one of the partitions [train, val, test]
+    split
+        Selects the split that defines the percetages used (use 'split' to select the default split)
+    split_type
+        Heuristic used to do the split [random, stratified, None]
+    release_name: str
+        Version of the dataset
+    transform : list[torchvision.transforms]
+        List of PyTorch transforms
+    """
+    assert dataset_type in ["classification", "instance_segmentation", "semantic_sgmentation"]
+    dataset_functions = {
+        "classification": ClassificationDataset,
+        "instance_segmentation": InstanceSegmentationDataset,
+        "semantic_segmentation": SemanticSegmentationDataset,
+    }
+    dataset_function = dataset_functions[dataset_type]
+
+    return dataset_function(
+        dataset_path=dataset_path,
+        partition=partition,
+        split=split,
+        split_type=split_type,
+        release_name=release_name,
+        transform=transform,
+    )
 
 
 class Dataset(data.Dataset):
-    def __init__(self, root: Path, split: Path, transform: Optional[List] = None):
+    def __init__(
+        self,
+        dataset_path: Path,
+        annotation_type: str,
+        partition: Optional[str] = None,
+        split: Optional[str] = None,
+        split_type: Optional[str] = None,
+        release_name: Optional[str] = None,
+        transform: Optional[List] = None
+    ):
         """ Creates a dataset
 
         Parameters
         ----------
-        root : Path
+        dataset_path
             Path to the location of the dataset on the file system
-        split : Path
-            Path to the *.txt file containing the list of files for this split.
+        annotation_type
+            The type of annotation classes [tag, box, polygon]
+        partition
+            Selects one of the partitions [train, val, test]
+        split
+            Selects the split that defines the percetages used (use 'split' to select the default split)
+        split_type
+            Heuristic used to do the split [random, stratified, None]
+        release_name: str
+            Version of the dataset
         transform : list[torchvision.transforms]
             List of PyTorch transforms
         """
-        self.root = root
-        self.split = split
+        assert dataset_path is not None
+        release_path = get_release_path(dataset_path, release_name)
+        annotations_dir = release_path / "annotations"
+        assert annotations_dir.exists()
+        images_dir = dataset_path / "images"
+        assert images_dir.exists()
+
+        if partition not in ["train", "val", "test", None]:
+            raise ValueError("partition should be either 'train', 'val', or 'test'")
+        if split_type not in ["random", "stratified", None]:
+            raise ValueError("split_type should be either 'random', 'stratified'")
+        if annotation_type not in ["tag", "polygon", "box"]:
+            raise ValueError("annotation_type should be either 'tag', 'box', or 'polygon'")
+
+        self.dataset_path = dataset_path
         self.transform = transform
         self.images_path: List[Path] = []
         self.annotations_path: List[Path] = []
-        self.classes = None
         self.original_classes = None
         self.original_images_path: Optional[List[Path]] = None
         self.original_annotations_path: Optional[List[Path]] = None
@@ -39,31 +115,55 @@ class Dataset(data.Dataset):
         if self.transform is not None and isinstance(self.transform, list):
             self.transform = Compose(transform)
 
-        # Populate internal lists of annotations and images paths
-        if not self.split.exists():
-            raise FileNotFoundError(f"Could not find partition file: {self.split}")
-        stems = (e.strip() for e in split.open())
-        image_extensions_mapping = {
-            image.stem: image.suffix
-            for image in self.root.glob(f"images/*")
-            if is_image_extension_allowed(image.suffix)
-        }
+        # Get the list of classes
+        self.classes = get_classes(
+            self.dataset_path,
+            self.release_name,
+            annotation_type=self.annotation_type,
+            remove_background=True
+        )
+
+        # Get the list of stems
+        if split:
+            # Get the split
+            if split_type is None:
+                split_file = f"{partition}.txt"
+            elif split_type == "random":
+                split_file = f"{split_type}_{partition}.txt"
+            elif split_type == "stratified":
+                split_file = f"{split_type}_{annotation_type}_{partition}.txt"
+            split_path = release_path / "lists" / split / split_file
+            stems = (e.strip() for e in split_path.open())
+        else:
+            # If the split is not specified, get all the annotations
+            stems = [e.stem for e in annotations_dir.glob("*.json")]
+
+        images_paths = []
+        annotations_paths = []
+
+        # Find all the annotations and their corresponding images
         for stem in stems:
-            annotation_path = self.root / f"annotations/{stem}.json"
-            try:
-                extension = image_extensions_mapping[stem]
-            except KeyError:
+            annotation_path = annotations_dir / f"{stem}.json"
+            images = []
+            for ext in SUPPORTED_IMAGE_EXTENSIONS:
+                image_path = images_dir / f"{stem}{ext}"
+                if image_path.exists():
+                    images.append(image_path)
+            if len(images) < 1:
                 raise ValueError(
                     f"Annotation ({annotation_path}) does not have a corresponding image"
                 )
-            image_path = self.root / f"images/{stem}{extension}"
-            self.images_path.append(image_path)
-            self.annotations_path.append(annotation_path)
+            if len(images) > 1:
+                raise ValueError(
+                    f"Image ({stem}) is present with multiple extensions. This is forbidden."
+                )
+            assert len(images) == 1
+            self.images_paths.append(images[0])
+            self.annotations_paths.append(annotation_path)
 
-        if len(self.images_path) == 0:
+        if len(self.images_paths) == 0:
             raise ValueError(
-                f"Could not find any {SUPPORTED_IMAGE_EXTENSIONS} file"
-                f" in {self.root / 'images'}"
+                f"Could not find any {SUPPORTED_IMAGE_EXTENSIONS} file" f" in {dataset_path / 'images'}"
             )
 
         assert len(self.images_path) == len(self.annotations_path)
@@ -83,6 +183,8 @@ class Dataset(data.Dataset):
         Dataset
             self
         """
+        if self.annotation_type != dataset.annotation_type:
+            raise ValueError("Annotation type of both datasets should match")
         if self.classes != dataset.classes and not extend_classes:
             raise ValueError(
                 f"Operation dataset_a + dataset_b could not be computed: classes "
@@ -246,6 +348,8 @@ class Dataset(data.Dataset):
         Dataset
             self
         """
+        if self.annotation_type != dataset.annotation_type:
+            raise ValueError("Annotation type of both datasets should match")
         if self.classes != dataset.classes:
             raise ValueError(
                 f"Operation dataset_a + dataset_b could not be computed: classes should match."
@@ -282,12 +386,9 @@ class Dataset(data.Dataset):
 
 
 class ClassificationDataset(Dataset):
-    def __init__(self, root: Path, split: Path, transform: Optional[List] = None):
+    def __init__(self, **kwargs):
         """See superclass for documentation"""
-        super().__init__(root=root, split=split, transform=transform)
-        self.classes = [
-            e.strip() for e in (self.root / "lists/classes_tag.txt").read_text().split("\n")
-        ]
+        super().__init__(annotation_type="tag", **kwargs)
 
     def _map_annotation(self, index: int):
         """See superclass for documentation
@@ -345,16 +446,11 @@ class ClassificationDataset(Dataset):
 class InstanceSegmentationDataset(Dataset):
     def __init__(
         self,
-        root: Path,
-        split: Path,
-        transform: Optional[List] = None,
         convert_polygons_to_masks: Optional[bool] = True,
+        **kwargs,
     ):
         """See superclass for documentation"""
-        super().__init__(root=root, split=split, transform=transform)
-        self.classes = [
-            e.strip() for e in (self.root / "lists/classes_polygon.txt").read_text().split("\n")
-        ]
+        super().__init__(annotation_type="polygon", **kwargs)
         self.convert_polygons = (
             ConvertPolygonsToInstanceMasks() if convert_polygons_to_masks else None
         )
@@ -453,19 +549,14 @@ class InstanceSegmentationDataset(Dataset):
 class SemanticSegmentationDataset(Dataset):
     def __init__(
         self,
-        root: Path,
-        split: Path,
-        transform: Optional[List] = None,
         convert_polygons_to_masks: Optional[bool] = True,
+        **kwargs,
     ):
         """See superclass for documentation"""
-        super().__init__(root=root, split=split, transform=transform)
-        self.classes = [
-            e.strip() for e in (self.root / "lists/classes_polygon.txt").read_text().split("\n")
-        ]
-        if self.classes[0] == "__background__":
-            self.classes = self.classes[1:]
-        self.convert_polygons = ConvertPolygonToMask() if convert_polygons_to_masks else None
+        super().__init__(annotation_type="polygon", **kwargs)
+        self.convert_polygons = (
+            ConvertPolygonsToInstanceMasks() if convert_polygons_to_masks else None
+        )
 
     def _map_annotation(self, index: int):
         """See superclass for documentation

--- a/darwin/torch/dataset.py
+++ b/darwin/torch/dataset.py
@@ -16,8 +16,8 @@ def get_dataset(
     dataset_path: Union[Path, str],
     dataset_type: str,
     partition: Optional[str] = None,
-    split: Optional[str] = None,
-    split_type: Optional[str] = None,
+    split: str = "default",
+    split_type: str = "random",
     release_name: Optional[str] = None,
     transform: Optional[List] = None
 ):
@@ -34,7 +34,7 @@ def get_dataset(
     split
         Selects the split that defines the percetages used (use 'split' to select the default split)
     split_type
-        Heuristic used to do the split [random, stratified, None]
+        Heuristic used to do the split [random, stratified]
     release_name: str
         Version of the dataset
     transform : list[torchvision.transforms]
@@ -67,8 +67,8 @@ class Dataset(data.Dataset):
         dataset_path: Path,
         annotation_type: str,
         partition: Optional[str] = None,
-        split: Optional[str] = "default",
-        split_type: Optional[str] = None,
+        split: str = "default",
+        split_type: str = "random",
         release_name: Optional[str] = None,
         transform: Optional[List] = None
     ):
@@ -100,7 +100,7 @@ class Dataset(data.Dataset):
 
         if partition not in ["train", "val", "test", None]:
             raise ValueError("partition should be either 'train', 'val', or 'test'")
-        if split_type not in ["random", "stratified", None]:
+        if split_type not in ["random", "stratified"]:
             raise ValueError("split_type should be either 'random', 'stratified'")
         if annotation_type not in ["tag", "polygon", "box"]:
             raise ValueError("annotation_type should be either 'tag', 'box', or 'polygon'")
@@ -130,9 +130,7 @@ class Dataset(data.Dataset):
         # Get the list of stems
         if partition:
             # Get the split
-            if split_type is None:
-                split_file = f"{partition}.txt"
-            elif split_type == "random":
+            if split_type == "random":
                 split_file = f"{split_type}_{partition}.txt"
             elif split_type == "stratified":
                 split_file = f"{split_type}_{annotation_type}_{partition}.txt"

--- a/darwin/torch/dataset.py
+++ b/darwin/torch/dataset.py
@@ -386,8 +386,9 @@ class Dataset(data.Dataset):
     def __str__(self):
         return (
             f"{self.__class__.__name__}():\n"
-            f"  Root: {self.root}\n"
-            f"  Number of images: {len(self.images_path)}"
+            f"  Root: {self.dataset_path}\n"
+            f"  Number of images: {len(self.images_path)}\n"
+            f"  Number of classes: {len(self.classes)}"
         )
 
 

--- a/darwin/torch/dataset.py
+++ b/darwin/torch/dataset.py
@@ -25,28 +25,30 @@ def get_dataset(
 
     Parameters
     ----------
-    dataset_path
+    dataset_path: Path, str
         Path to the location of the dataset on the file system
-    dataset_type
-        The type of dataset [classification, instances_segmentation, semantic_segmentation]
-    partition
+    dataset_type: str
+        The type of dataset [classification, instance_segmentation, semantic_segmentation]
+    partition: str
         Selects one of the partitions [train, val, test]
-    split
-        Selects the split that defines the percetages used (use 'split' to select the default split)
-    split_type
+    split: str
+        Selects the split that defines the percentages used (use 'default' to select the default split)
+    split_type: str
         Heuristic used to do the split [random, stratified]
     release_name: str
         Version of the dataset
     transform : list[torchvision.transforms]
         List of PyTorch transforms
     """
-    assert dataset_type in ["classification", "instance_segmentation", "semantic_sgmentation"]
     dataset_functions = {
         "classification": ClassificationDataset,
         "instance_segmentation": InstanceSegmentationDataset,
         "semantic_segmentation": SemanticSegmentationDataset,
     }
-    dataset_function = dataset_functions[dataset_type]
+    dataset_function = dataset_functions.get(dataset_type)
+    if not dataset_function:
+        list_of_types = ", ".join(dataset_functions.keys())
+        raise ValueError(f"dataset_type needs to be one of '{list_of_types}'")
 
     if isinstance(dataset_path, str):
         dataset_path = Path(dataset_path)
@@ -76,16 +78,16 @@ class Dataset(data.Dataset):
 
         Parameters
         ----------
-        dataset_path
+        dataset_path: Path, str
             Path to the location of the dataset on the file system
-        annotation_type
+        annotation_type: str
             The type of annotation classes [tag, box, polygon]
-        partition
+        partition: str
             Selects one of the partitions [train, val, test]
-        split
-            Selects the split that defines the percetages used (use 'split' to select the default split)
-        split_type
-            Heuristic used to do the split [random, stratified, None]
+        split: str
+            Selects the split that defines the percentages used (use 'default' to select the default split)
+        split_type: str
+            Heuristic used to do the split [random, stratified]
         release_name: str
             Version of the dataset
         transform : list[torchvision.transforms]
@@ -140,7 +142,7 @@ class Dataset(data.Dataset):
             else:
                 raise FileNotFoundError(
                     f"Could not find a dataset partition. ",
-                    f"To split the dataset you can use 'split_dataset' from darwin.dataset.utils"
+                    f"Split the dataset using `split_dataset()` from `darwin.dataset.utils`"
                 )
         else:
             # If the partition is not specified, get all the annotations

--- a/darwin/utils.py
+++ b/darwin/utils.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, List, Optional, Union
 
 from darwin.config import Config
 
-SUPPORTED_IMAGE_EXTENSIONS = [".png", ".jpeg", ".jpg", ".jfif"]
+SUPPORTED_IMAGE_EXTENSIONS = [".png", ".jpeg", ".jpg", ".jfif", ".tif"]
 SUPPORTED_VIDEO_EXTENSIONS = [".bpm", ".mov", ".mp4"]
 SUPPORTED_EXTENSIONS = SUPPORTED_IMAGE_EXTENSIONS + SUPPORTED_VIDEO_EXTENSIONS
 


### PR DESCRIPTION
Restores `get_dataset()` function in the `darwin.torch` toolbox.

```
from darwin.torch import get_dataset

get_dataset("/PATH/TO/YOUR/DATASET", DATASET_TYPE [, PARTITION, SPLIT_TYPE, RELEASE_NAME, TRANSFORMS])
```