### PR TITLE
cvat export includes timezone

### DIFF
--- a/darwin/exporter/formats/cvat.py
+++ b/darwin/exporter/formats/cvat.py
@@ -1,5 +1,5 @@
 import xml.etree.ElementTree as ET
-from datetime import datetime
+import datetime
 from pathlib import Path
 from typing import Generator
 
@@ -57,7 +57,7 @@ def build_annotation(image, annotation):
 
 def build_meta(root, annotation_files, label_lookup):
     meta = ET.SubElement(root, "meta")
-    add_subelement_text(meta, "dumped", str(datetime.now()))
+    add_subelement_text(meta, "dumped", str(datetime.datetime.now(tz=datetime.timezone.utc)))
 
     task = ET.SubElement(meta, "task")
     add_subelement_text(task, "id", 1)
@@ -67,8 +67,8 @@ def build_meta(root, annotation_files, label_lookup):
     add_subelement_text(task, "overlapp", 0)
     add_subelement_text(task, "bugtracker", None)
     add_subelement_text(task, "flipped", False)
-    add_subelement_text(task, "created", str(datetime.now()))
-    add_subelement_text(task, "updated", str(datetime.now()))
+    add_subelement_text(task, "created", str(datetime.datetime.now(tz=datetime.timezone.utc)))
+    add_subelement_text(task, "updated", str(datetime.datetime.now(tz=datetime.timezone.utc)))
 
     labels = ET.SubElement(task, "labels")
     build_labels(labels, label_lookup)


### PR DESCRIPTION
cvat export timestamps should include the timezone. See [XML 1.1 Annotation](https://github.com/opencv/cvat/blob/develop/cvat/apps/documentation/xml_format.md) format