### PR TITLE
Replace tqdm with rich.progress

### DIFF
--- a/darwin/dataset/utils.py
+++ b/darwin/dataset/utils.py
@@ -10,7 +10,6 @@ from typing import Generator, Iterable, List, Optional, Union
 
 import numpy as np
 from PIL import Image
-from rich.progress import Progress
 
 from darwin.exceptions import NotFound
 from darwin.utils import SUPPORTED_IMAGE_EXTENSIONS, get_progress_bar
@@ -479,6 +478,7 @@ def exhaust_generator(progress: Generator, count: int, multi_threaded: bool):
     """
     responses = []
     if multi_threaded:
+        from rich.progress import Progress
         with Progress() as p:
             pbar = p.add_task("Progress", total=count)
 

--- a/darwin/exporter/formats/instance_mask.py
+++ b/darwin/exporter/formats/instance_mask.py
@@ -16,7 +16,7 @@ def export(annotation_files: Generator[dt.AnnotationFile, None, None], output_di
     masks_dir.mkdir(parents=True)
     with open(output_dir / "instance_mask_annotations.csv", "w") as f:
         f.write("image_id,mask_id,class_name\n")
-        for annotation_file in get_progress_bar(list(annotation_files), "Processing annotations"):
+        for annotation_file in get_progress_bar(list(annotation_files), "Processing annotations", color="cyan"):
             image_id = annotation_file.path.stem
             height = annotation_file.image_height
             width = annotation_file.image_width

--- a/darwin/exporter/formats/semantic_mask.py
+++ b/darwin/exporter/formats/semantic_mask.py
@@ -35,7 +35,7 @@ def export(annotation_files: Generator[dt.AnnotationFile, None, None], output_di
         palette_rgb = {c: rgb for c, rgb in zip(categories, RGB_colors)}
         RGB_colors = [c for e in RGB_colors for c in e]
 
-    for annotation_file in get_progress_bar(list(annotation_files), "Processing annotations"):
+    for annotation_file in get_progress_bar(list(annotation_files), "Processing annotations", color="cyan"):
         outfile = masks_dir / f"{annotation_file.path.stem}.png"
         height = annotation_file.image_height
         width = annotation_file.image_width

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Callable, List, Union
 
 import darwin.datatypes as dt
-from darwin.utils import secure_continue_request, get_progress_bar
+from darwin.utils import get_progress_bar, secure_continue_request
 
 
 def build_main_annotations_lookup_table(annotation_classes):

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -1,9 +1,8 @@
 from pathlib import Path
 from typing import Callable, List, Union
-from tqdm import tqdm
 
 import darwin.datatypes as dt
-from darwin.utils import secure_continue_request
+from darwin.utils import secure_continue_request, get_progress_bar
 
 
 def build_main_annotations_lookup_table(annotation_classes):
@@ -94,7 +93,7 @@ def import_annotations(
         parsed_files = importer(local_path)
         if type(parsed_files) is not list:
             parsed_files = [parsed_files]
-        for parsed_file in tqdm(parsed_files):
+        for parsed_file in get_progress_bar(parsed_files):
             image_id = remote_files[parsed_file.filename]
             _import_annotations(dataset.client, image_id, remote_classes, parsed_file.annotations, dataset)
 

--- a/darwin/utils.py
+++ b/darwin/utils.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional, Union
 
 import numpy as np
-from tqdm import tqdm
 from upolygon import draw_polygon
 
 import darwin.datatypes as dt
@@ -67,9 +66,14 @@ def is_deprecated_project_dir(project_path: Path) -> bool:
     return (project_path / "annotations").exists() and (project_path / "images").exists()
 
 
-def get_progress_bar(array: List, description: Optional[str] = None):
-    pbar = tqdm(array)
-    pbar.set_description(desc=description, refresh=True)
+def get_progress_bar(array: List, description: str = "Progress", total: int = None):
+    try:
+        from rich.progress import track
+        pbar = track(array, description=description, total=total)
+    except ImportError:
+        from tqdm import tqdm
+        pbar = tqdm(array)
+        pbar.set_description(desc=description, refresh=True, total=total)
     return pbar
 
 

--- a/darwin/utils.py
+++ b/darwin/utils.py
@@ -69,9 +69,11 @@ def is_deprecated_project_dir(project_path: Path) -> bool:
 def get_progress_bar(array: List, description: str = "Progress", total: int = None):
     try:
         from rich.progress import track
+
         pbar = track(array, description=description, total=total)
     except ImportError:
         from tqdm import tqdm
+
         pbar = tqdm(array)
         pbar.set_description(desc=description, refresh=True, total=total)
     return pbar

--- a/darwin/utils.py
+++ b/darwin/utils.py
@@ -67,17 +67,31 @@ def is_deprecated_project_dir(project_path: Path) -> bool:
 
 
 def get_progress_bar(array: List, description: str = "Progress", total: int = None, color: str = None):
+    """Creates a progress bar
+
+    Parameters
+    ----------
+    array : List
+        A sequence you wish to iterate over
+    description : str
+        Description of task show next to progress bar. Default is "Progress"
+    total : int
+        Total number of steps. Default is len(array)
+    color : str
+        Color of the description
+
+    Returns
+    -------
+        Progress bar
+    """
     try:
         from rich.progress import track
-
         if color:
             description = f"[{color}]{description}"
         pbar = track(array, description=description, total=total)
     except ImportError:
         from tqdm import tqdm
-
-        pbar = tqdm(array)
-        pbar.set_description(desc=description, refresh=True, total=total)
+        pbar = tqdm(array, desc=description, refresh=True, total=total)
     return pbar
 
 

--- a/darwin/utils.py
+++ b/darwin/utils.py
@@ -66,10 +66,12 @@ def is_deprecated_project_dir(project_path: Path) -> bool:
     return (project_path / "annotations").exists() and (project_path / "images").exists()
 
 
-def get_progress_bar(array: List, description: str = "Progress", total: int = None):
+def get_progress_bar(array: List, description: str = "Progress", total: int = None, color: str = None):
     try:
         from rich.progress import track
 
+        if color:
+            description = f"[{color}]{description}"
         pbar = track(array, description=description, total=total)
     except ImportError:
         from tqdm import tqdm

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setuptools.setup(
     name="darwin-py",
-    version="0.5.6",
+    version="0.5.7",
     author="V7",
     author_email="info@v7labs.com",
     description="Library and command line interface for darwin.v7labs.com",
@@ -24,7 +24,7 @@ setuptools.setup(
         "requests",
         "scikit-learn",
         "sh",
-        "tqdm",
+        "rich",
         "pillow",
         "upolygon==0.1",
     ],


### PR DESCRIPTION
This PR replaces `tqdm`'s with `rich.progress` progress bars. It also adds a new helper function in `darwin.utils` called `get_progress_bar` that abstracts the progress bar API.