### PR TITLE
Remove pycocotools dependency

### DIFF
--- a/darwin/torch/__init__.py
+++ b/darwin/torch/__init__.py
@@ -1,4 +1,4 @@
-# Requirements: pytorch, torchvision, pycocotools
+# Requirements: pytorch, torchvision
 try:
     import torch  # noqa
     import torchvision  # noqa

--- a/darwin/torch/__init__.py
+++ b/darwin/torch/__init__.py
@@ -7,11 +7,4 @@ except ImportError:
         f"darwin.torch requires pytorch and torchvision. Install it using: pip install torch torchvision"
     ) from None
 
-try:
-    import pycocotools  # noqa
-except ImportError:
-    raise ImportError(
-        f"darwin.torch requires pycocotools. Install it using: pip install cython; pip install -U 'git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI'"
-    ) from None
-
 from .dataset import get_dataset  # noqa


### PR DESCRIPTION
Removing `pycocotools` dependency since we don't use it anymore to generate masks.