### PR TITLE
Fix unicode decoding problems during package installation for python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 
-with open("README.md", "r") as f:
-    long_description = f.read()
+with open("README.md", "rb") as f:
+    long_description = f.read().decode('utf-8')
 
 setuptools.setup(
     name="darwin-py",


### PR DESCRIPTION
Using darwin-py with python 3.6 results in the following error during installation of requirements:

requirements.txt:
<snip>
darwin-py==0.5.14
<snip>

` Complete output (7 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-w562jode/darwin-py_19665130c7244b609fa181f78ad2f4ea/setup.py", line 4, in <module>
        long_description = f.read()
      File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 3193: ordinal not in range(128)`

The problem is some kind of UTF-8 symbol in the readme.
This pull request fixes the issue, by decoding as UTF-8.



