### PR TITLE
added hack to expand left menu sidebar

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,10 +7,20 @@
       "source.organizeImports": true,
     }
   },
+  "[javascript]": {
+    "editor.formatOnSave": true,
+    "editor.insertSpaces": true,
+    "editor.tabSize": 2
+  },
   "python.formatting.blackPath": "black",
   "python.formatting.provider": "black",
-  "python.formatting.blackArgs": ["-l 120"],
+  "python.formatting.blackArgs": [
+    "-l 120"
+  ],
   "python.linting.mypyEnabled": true,
-  "python.sortImports.args": ["--profile", "black"],
+  "python.sortImports.args": [
+    "--profile",
+    "black"
+  ],
   "python.testing.pytestEnabled": true
 }

--- a/source/_static/js/custom.js
+++ b/source/_static/js/custom.js
@@ -1,42 +1,40 @@
-window.addEventListener('load', (_event) => {
-    var menu = document.querySelector(".wy-menu ul li:first-child")
-    recurse(menu)
+window.addEventListener("load", (_event) => {
+  const menu = document.querySelector(".wy-menu ul li:first-child")
+  recurse(menu)
 });
 
 /**
  * Given a Node, it recursively goes through every child and checks if the child is expandable, it
  * expands it unless it is already expanded.
- * 
- * @param {Node} node 
+ *
+ * @param {Node} node   The node to evaluate.
  */
-function recurse(node) {
-    if (is_expandable(node) && !is_expanded(node)) {
-        node.classList.add("current")
-    }
+const recurse = (node) => {
+  if (isExpandable(node) && !isExpanded(node)) {
+    node.classList.add("current")
+  }
 
-    // By default, children are not arrays, so we need to convert them
-    children = Array.prototype.slice.call(node.children)
+  // By default, children are not arrays, so we need to convert them
+  children = Array.prototype.slice.call(node.children)
 
-    children.forEach(recurse)
+  children.forEach(recurse)
 }
 
 /**
  * Returns whether or not the given node is an expandable list.
- * 
- * @param {Node} node 
+ *
+ * @param {Node} node   The node to evaluate.
+ *
  * @returns {boolean} true if the node is a toctree that can be expanded, false otherwise.
  */
-function is_expandable(node) {
-    return node.className.includes("toctree-l")
-}
+const isExpandable = (node) => node.className.includes("toctree-l")
 
 /**
  * Returns whether or not the given expandable node is already expanded.
  * Nodes are considered expandaded if they are 'current'ly selected, so we take advantage of this.
- * 
- * @param {Node} node 
+ *
+ * @param {Node} node   The node to evaluate.
+ *
  * @returns {boolean} true if the node is already expanded, false otherwise.
  */
-function is_expanded(node) {
-    return node.classList.contains("current")
-}
+const isExpanded = (node) => node.classList.contains("current")

--- a/source/_static/js/custom.js
+++ b/source/_static/js/custom.js
@@ -1,0 +1,42 @@
+window.addEventListener('load', (_event) => {
+    var menu = document.querySelector(".wy-menu ul li:first-child")
+    recurse(menu)
+});
+
+/**
+ * Given a Node, it recursively goes through every child and checks if the child is expandable, it
+ * expands it unless it is already expanded.
+ * 
+ * @param {Node} node 
+ */
+function recurse(node) {
+    if (is_expandable(node) && !is_expanded(node)) {
+        node.classList.add("current")
+    }
+
+    // By default, children are not arrays, so we need to convert them
+    children = Array.prototype.slice.call(node.children)
+
+    children.forEach(recurse)
+}
+
+/**
+ * Returns whether or not the given node is an expandable list.
+ * 
+ * @param {Node} node 
+ * @returns {boolean} true if the node is a toctree that can be expanded, false otherwise.
+ */
+function is_expandable(node) {
+    return node.className.includes("toctree-l")
+}
+
+/**
+ * Returns whether or not the given expandable node is already expanded.
+ * Nodes are considered expandaded if they are 'current'ly selected, so we take advantage of this.
+ * 
+ * @param {Node} node 
+ * @returns {boolean} true if the node is already expanded, false otherwise.
+ */
+function is_expanded(node) {
+    return node.classList.contains("current")
+}

--- a/source/conf.py
+++ b/source/conf.py
@@ -14,7 +14,7 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import List, Match, Optional
+from typing import Any, Dict, List, Match, Optional
 
 sys.path.insert(0, os.path.abspath("../darwin/"))
 
@@ -40,10 +40,7 @@ with open(Path(__file__).parent.parent / "darwin" / "__init__.py", "r") as f:
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions: List[str] = [
-    "sphinx.ext.viewcode",
-    "sphinx.ext.napoleon",
-]
+extensions: List[str] = ["sphinx.ext.viewcode", "sphinx.ext.napoleon"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path: List[str] = ["_templates"]
@@ -64,4 +61,15 @@ html_theme: str = "sphinx_rtd_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path: List[str] = []
+html_static_path: List[str] = ["_static"]
+
+# This is a hack so we can have the left menu bar expand automatically upon opening a page.
+# This hack is needed because of a bug in Sphinx:
+# https://github.com/readthedocs/sphinx_rtd_theme/issues/455
+#
+# If one day the bug gets fixed, then `html_js_files` and `html_theme_options` can be removed
+# as well as the files/directories they rely on.
+html_js_files: List[str] = ["js/custom.js"]
+html_theme_options: Dict[str, Any] = {
+    "collapse_navigation": False,
+}

--- a/source/index.rst
+++ b/source/index.rst
@@ -3,14 +3,6 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
-
-
 .. toctree::
    :hidden:
    :maxdepth: 3


### PR DESCRIPTION
What
----

Added hack to automatically expand left menu Packages list when opening a page.

Why
----

We agreed on a meeting that it would be more convenient and explicit for our users to have the list of package and subpackages expanded automatically upon opening the page. 
 
How
----

In a rather surprising twist, the option to have the left menu bar expanded is bugged and DOES NOT WORK. 
I had to resort to hacking the crap out of the DOM to make it happen. I tried making the code readable. Sorry for the suffering caused to any reviewers/victims.

How can I test this?
----

1. Download branch
2. Install dependencies
3. Run `rm -f README.rst && m2r README.md && mv README.rst source/ && rm -rf docs/*  && sphinx-apidoc -f -o source darwin && sphinx-build -b html source/ docs/`
4. Go to `docs/index.html` and open it in your browser


Additional Info
-----

Linear ticket: https://linear.app/v7labs/issue/V7-1718/prevent-left-menu-items-from-being-collapsed
