### PR TITLE
Added try except for symlink creation.

### DIFF
--- a/darwin/dataset/remote_dataset.py
+++ b/darwin/dataset/remote_dataset.py
@@ -282,12 +282,15 @@ class RemoteDataset:
         make_class_lists(release_dir)
 
         if release.latest and is_unix_like_os():
-            latest_dir: Path = self.local_releases_path / "latest"
-            if latest_dir.is_symlink():
-                latest_dir.unlink()
+            try:
+                latest_dir: Path = self.local_releases_path / "latest"
+                if latest_dir.is_symlink():
+                    latest_dir.unlink()
 
-            target_link: Path = self.local_releases_path / release_dir.name
-            latest_dir.symlink_to(target_link)
+                target_link: Path = self.local_releases_path / release_dir.name
+                latest_dir.symlink_to(target_link)
+            except OSError:
+                print("WARNING: Tried to create Symlink and failed. Continuing ...")
 
         if only_annotations:
             # No images will be downloaded


### PR DESCRIPTION
Why?
---

When creating a symlink in an Unix system in Azure, the creation of the symlink fails because Azure machines do not have the necessary permissions to do it. Thus code the raises and everything dies.

We previously thought this issue was only in Windows machines, but now we realize it can happen in any environment and that being a Unix machine is only bu a small factor.

What
----

We want to make it so that symlink creation does not raise under any circumstances. TO achieve this I added a try/except block.

I am not really that happy with this solution for 2 reasons:

 - I cannot test it in an _easy_ way. If you see the test and think there are too many nesting levels... You are right!
 - I am using a print instead of a Logger. Python does have a logger: https://docs.python.org/3/howto/logging.html . I defend we give it a look.

How can I test this?
----

Just simple `pytest` should do it. The test should cover this use case.