### PR TITLE
fixed check on filename not existing

### DIFF
--- a/darwin/importer/formats/pascalvoc.py
+++ b/darwin/importer/formats/pascalvoc.py
@@ -1,11 +1,11 @@
 import xml.etree.ElementTree as ET
 from pathlib import Path
-from typing import List, NoReturn, Union
+from typing import List, Union
 
 import darwin.datatypes as dt
 
 
-def parse_file(path: Path) -> Union[dt.AnnotationFile, None, NoReturn]:
+def parse_file(path: Path) -> Union[dt.AnnotationFile, None]:
     if path.suffix != ".xml":
         return None
 
@@ -21,7 +21,7 @@ def parse_file(path: Path) -> Union[dt.AnnotationFile, None, NoReturn]:
 
 
 # Private
-def _parse_annotation(annotation_object: ET.Element) -> Union[dt.Annotation, NoReturn]:
+def _parse_annotation(annotation_object: ET.Element) -> dt.Annotation:
     class_name = _find_text_value(annotation_object, "name")
 
     bndbox = _find_element(annotation_object, "bndbox")
@@ -34,7 +34,7 @@ def _parse_annotation(annotation_object: ET.Element) -> Union[dt.Annotation, NoR
 
 
 # Private
-def _find_element(source: ET.Element, name: str) -> Union[ET.Element, NoReturn]:
+def _find_element(source: ET.Element, name: str) -> ET.Element:
     element = source.find(name)
     if element is None:
         raise ValueError(f"Could not find {name} element in annotation file")
@@ -42,8 +42,8 @@ def _find_element(source: ET.Element, name: str) -> Union[ET.Element, NoReturn]:
 
 
 # Private
-def _find_text_value(source: ET.Element, name: str) -> Union[str, NoReturn]:
+def _find_text_value(source: ET.Element, name: str) -> str:
     element = _find_element(source, name)
-    if not element.text.strip():
+    if element.text is None or not element.text.strip():
         raise ValueError(f"{name} element does not have a text value")
     return element.text

--- a/darwin/importer/formats/pascalvoc.py
+++ b/darwin/importer/formats/pascalvoc.py
@@ -44,6 +44,6 @@ def _find_element(source: ET.Element, name: str) -> Union[ET.Element, NoReturn]:
 # Private
 def _find_text_value(source: ET.Element, name: str) -> Union[str, NoReturn]:
     element = _find_element(source, name)
-    if element is None or element.text is None:
+    if not element.text.strip():
         raise ValueError(f"{name} element does not have a text value")
     return element.text

--- a/darwin/importer/formats/pascalvoc.py
+++ b/darwin/importer/formats/pascalvoc.py
@@ -1,11 +1,32 @@
 import xml.etree.ElementTree as ET
 from pathlib import Path
-from typing import List, Union
+from typing import List, Optional
 
 import darwin.datatypes as dt
 
 
-def parse_file(path: Path) -> Union[dt.AnnotationFile, None]:
+def parse_file(path: Path) -> Optional[dt.AnnotationFile]:
+    """
+    Parses the given pascalvoc file and maybe returns the corresponding annotation.
+
+    Parameters
+    --------
+    path: Path
+        The path of the file to parse.
+
+    Returns
+    -------
+    Optional[darwin.datatypes.AnnotationFile]
+        An AnnotationFile with the parsed information from the file or None, if the file is not a 
+        `XML` file.
+
+    Raises
+    ------
+    ValueError
+        If a mandatory chield element is missing or is empty. Mandatory child elements are: 
+        filename, name, bndbox, xmin, xmax, ymin and ymax.
+
+    """
     if path.suffix != ".xml":
         return None
 
@@ -20,8 +41,26 @@ def parse_file(path: Path) -> Union[dt.AnnotationFile, None]:
     return dt.AnnotationFile(path, filename, annotation_classes, annotations, remote_path="/")
 
 
-# Private
 def _parse_annotation(annotation_object: ET.Element) -> dt.Annotation:
+    """
+    Parses the given XML element and returns the corresponding annotation.
+
+    Parameters
+    --------
+    annotation_object: xml.etree.ElementTree.Element
+        The element to convert into an annotation.
+
+    Returns
+    -------
+    darwin.datatypes.AnnotationFile
+        An AnnotationFile with the parsed information from the XML element.
+
+    Raises
+    ------
+    ValueError
+        If a mandatory chield element is missing or is empty. Mandatory child elements are: 
+        name, bndbox, xmin, xmax, ymin and ymax.
+    """
     class_name = _find_text_value(annotation_object, "name")
 
     bndbox = _find_element(annotation_object, "bndbox")
@@ -33,16 +72,54 @@ def _parse_annotation(annotation_object: ET.Element) -> dt.Annotation:
     return dt.make_bounding_box(class_name, xmin, ymin, xmax - xmin, ymax - ymin)
 
 
-# Private
 def _find_element(source: ET.Element, name: str) -> ET.Element:
+    """
+    Finds a child element inside the source element with the given name and returns it.
+
+    Parameters
+    --------
+    source: xml.etree.ElementTree.Element
+        Parent element that contains childs elements to be searched.
+    name: str
+        Name of the child element we wish to find.
+
+    Returns
+    -------
+    xml.etree.ElementTree.Element
+        Child element with the given name.
+
+    Raises
+    ------
+    ValueError
+        If a child element with the given name could not be found.
+    """
     element = source.find(name)
     if element is None:
         raise ValueError(f"Could not find {name} element in annotation file")
     return element
 
 
-# Private
 def _find_text_value(source: ET.Element, name: str) -> str:
+    """
+    Finds a child element inside the source element with the given name and returns its text value.
+
+    Parameters
+    --------
+    source: xml.etree.ElementTree.Element
+        Parent element that contains childs elements to be searched.
+    name: str
+        Name of the child element we wish to find.
+
+    Returns
+    -------
+    str
+        Text value of the found child element.
+
+    Raises
+    ------
+    ValueError
+        If the found child element has no text value or its text value is empty.
+    """
     element = _find_element(source, name)
     if element.text is None or not element.text.strip():
         raise ValueError(f"{name} element does not have a text value")

--- a/tests/darwin/importer/formats/pascalvoc_test.py
+++ b/tests/darwin/importer/formats/pascalvoc_test.py
@@ -37,6 +37,14 @@ def describe_parse_file():
 
         assert str(info.value) == "filename element does not have a text value"
 
+    def it_raises_value_error_if_filename_is_empty(annotation_path: Path):
+        annotation_path.write_text("<root><filename></filename></root>")
+
+        with pytest.raises(ValueError) as info:
+            parse_file(annotation_path)
+
+        assert str(info.value) == "filename element does not have a text value"
+
     def it_returns_annotation_file_with_empty_annotations_otherwise(annotation_path: Path):
         annotation_path.write_text("<root><filename>image.jpg</filename></root>")
 

--- a/tests/darwin/importer/formats/pascalvoc_test.py
+++ b/tests/darwin/importer/formats/pascalvoc_test.py
@@ -1,4 +1,3 @@
-import xml.etree.ElementTree as ET
 from pathlib import Path
 
 import pytest
@@ -29,6 +28,14 @@ def describe_parse_file():
             parse_file(annotation_path)
 
         assert str(info.value) == "Could not find filename element in annotation file"
+
+    def it_raises_value_error_if_filename_tag_has_empty_text(annotation_path: Path):
+        annotation_path.write_text("<root><filename> </filename></root>")
+
+        with pytest.raises(ValueError) as info:
+            parse_file(annotation_path)
+
+        assert str(info.value) == "filename element does not have a text value"
 
     def it_returns_annotation_file_with_empty_annotations_otherwise(annotation_path: Path):
         annotation_path.write_text("<root><filename>image.jpg</filename></root>")


### PR DESCRIPTION
Why
----

Upon reviewing the code for `pascal_voc` files I realized that the `<filename></filename>` child element could be empty or simply contain a `' '` space. 

I fixed this issue to avoid future problems. 

How can I test this?
-----------------------------
Since I added a test, running `pytest` should do it. 
