### PR TITLE
[V7-2192] Allow for item deletion in CLI

### DIFF
--- a/darwin/cli.py
+++ b/darwin/cli.py
@@ -102,7 +102,7 @@ def _run(args: Namespace, parser: ArgumentParser) -> None:
         elif args.action == "set-file-status":
             f.set_file_status(args.dataset, args.status, args.files)
         elif args.action == "delete-files":
-            f.delete_files(args.dataset, args.files)
+            f.delete_files(args.dataset, args.files, args.yes)
         elif args.action == "split":
             f.split(args.dataset, args.val_percentage, args.test_percentage, args.seed)
         elif args.action == "help" or args.action is None:

--- a/darwin/cli.py
+++ b/darwin/cli.py
@@ -101,6 +101,8 @@ def _run(args: Namespace, parser: ArgumentParser) -> None:
             f.dataset_convert(args.dataset, args.format, args.output_dir)
         elif args.action == "set-file-status":
             f.set_file_status(args.dataset, args.status, args.files)
+        elif args.action == "delete-files":
+            f.delete_files(args.dataset, args.files)
         elif args.action == "split":
             f.split(args.dataset, args.val_percentage, args.test_percentage, args.seed)
         elif args.action == "help" or args.action is None:

--- a/darwin/cli_functions.py
+++ b/darwin/cli_functions.py
@@ -654,13 +654,13 @@ def set_file_status(dataset_slug: str, status: str, files: List[str]) -> None:
         _error(f"No dataset with name '{e.name}'")
 
 
-def delete_files(dataset_slug: str, files: List[str], yes: bool = False) -> None:
+def delete_files(dataset_slug: str, files: List[str], skip_user_confirmation: bool = False) -> None:
     client: Client = _load_client(dataset_identifier=dataset_slug)
     try:
         console = Console()
         dataset: RemoteDataset = client.get_remote_dataset(dataset_identifier=dataset_slug)
         items: Iterator[DatasetItem] = dataset.fetch_remote_files({"filenames": ",".join(files)})
-        if not yes and not secure_continue_request():
+        if not skip_user_confirmation and not secure_continue_request():
             console.print("Cancelled.")
             return
 

--- a/darwin/cli_functions.py
+++ b/darwin/cli_functions.py
@@ -657,6 +657,10 @@ def delete_files(dataset_slug: str, files: List[str]) -> None:
     try:
         dataset: RemoteDataset = client.get_remote_dataset(dataset_identifier=dataset_slug)
         items: Iterator[DatasetItem] = dataset.fetch_remote_files({"filenames": ",".join(files)})
+        if not secure_continue_request():
+            print("Cancelled.")
+            return
+
         dataset.delete_items(items)
     except NotFound as e:
         _error(f"No dataset with name '{e.name}'")

--- a/darwin/cli_functions.py
+++ b/darwin/cli_functions.py
@@ -270,6 +270,7 @@ def pull_dataset(
         )
     except Unauthenticated:
         _error(f"please re-authenticate")
+
     try:
         release: Release = dataset.get_release(version)
         dataset.pull(release=release, only_annotations=only_annotations, use_folders=folders, video_frames=video_frames)
@@ -284,6 +285,7 @@ def pull_dataset(
             f"Version '{dataset.identifier}:{version}' is of format '{uef.format}', "
             f"only the darwin format ('json') is supported for `darwin dataset pull`"
         )
+
     print(f"Dataset {release.identifier} downloaded at {dataset.local_path}. ")
 
 
@@ -652,18 +654,24 @@ def set_file_status(dataset_slug: str, status: str, files: List[str]) -> None:
         _error(f"No dataset with name '{e.name}'")
 
 
-def delete_files(dataset_slug: str, files: List[str]) -> None:
+def delete_files(dataset_slug: str, files: List[str], yes: bool = False) -> None:
     client: Client = _load_client(dataset_identifier=dataset_slug)
     try:
+        console = Console()
         dataset: RemoteDataset = client.get_remote_dataset(dataset_identifier=dataset_slug)
         items: Iterator[DatasetItem] = dataset.fetch_remote_files({"filenames": ",".join(files)})
-        if not secure_continue_request():
-            print("Cancelled.")
+        if not yes and not secure_continue_request():
+            console.print("Cancelled.")
             return
 
-        dataset.delete_items(items)
+        with console.status("[bold red]Deleting files..."):
+            dataset.delete_items(items)
+            console.print("[bold green]Files successfully deleted!")
+
     except NotFound as e:
         _error(f"No dataset with name '{e.name}'")
+    except:
+        _error(f"An error has occurred, please try again later.")
 
 
 def find_import_supported_format(query: str, supported_formats: List[ImporterFormat],) -> ImportParser:

--- a/darwin/client.py
+++ b/darwin/client.py
@@ -61,20 +61,24 @@ class Client:
 
         response: requests.Response = requests.get(urljoin(self.url, endpoint), headers=self._get_headers(team))
 
+        if debug:
+            print(
+                f"Client get request response ({response.json()}) with unexpected status "
+                f"({response.status_code}). "
+                f"Client: ({self})"
+                f"Request: (endpoint={endpoint})"
+            )
+
         if response.status_code == 401:
             raise Unauthorized()
+
         if response.status_code == 404:
             raise NotFound(urljoin(self.url, endpoint))
+
         if response.status_code != 200 and retry:
-            if debug:
-                print(
-                    f"Client get request response ({response.json()}) with unexpected status "
-                    f"({response.status_code}). "
-                    f"Client: ({self})"
-                    f"Request: (endpoint={endpoint})"
-                )
             time.sleep(10)
             return self.get(endpoint=endpoint, retry=False)
+
         if raw:
             return response
         else:
@@ -114,6 +118,14 @@ class Client:
             urljoin(self.url, endpoint), json=payload, headers=self._get_headers(team)
         )
 
+        if debug:
+            print(
+                f"Client GET request got response ({response.json()}) with unexpected status "
+                f"({response.status_code}). "
+                f"Client: ({self})"
+                f"Request: (endpoint={endpoint}, payload={payload})"
+            )
+
         if response.status_code == 401:
             raise Unauthorized()
 
@@ -123,14 +135,6 @@ class Client:
                 raise InsufficientStorage()
 
         if response.status_code != 200 and retry:
-            if debug:
-                print(
-                    f"Client GET request got response ({response.json()}) with unexpected status "
-                    f"({response.status_code}). "
-                    f"Client: ({self})"
-                    f"Request: (endpoint={endpoint}, payload={payload})"
-                )
-
             time.sleep(10)
             return self.put(endpoint, payload=payload, retry=False)
 
@@ -177,20 +181,24 @@ class Client:
             urljoin(self.url, endpoint), json=payload, headers=self._get_headers(team)
         )
 
+        if debug:
+            print(
+                f"Client get request response ({response.json()}) with unexpected status "
+                f"({response.status_code}). "
+                f"Client: ({self})"
+                f"Request: (endpoint={endpoint}, payload={payload})"
+            )
+
         if response.status_code == 401:
             raise Unauthorized()
+
+        if not error_handlers and not retry:
+            response.raise_for_status()
 
         if response.status_code != 200:
             for error_handler in error_handlers:
                 error_handler(response.status_code, response.json())
 
-            if debug:
-                print(
-                    f"Client get request response ({response.json()}) with unexpected status "
-                    f"({response.status_code}). "
-                    f"Client: ({self})"
-                    f"Request: (endpoint={endpoint}, payload={payload})"
-                )
             if retry:
                 time.sleep(10)
                 return self.post(endpoint, payload=payload, retry=False)
@@ -237,20 +245,24 @@ class Client:
             urljoin(self.url, endpoint), json=payload, headers=self._get_headers(team)
         )
 
+        if debug:
+            print(
+                f"Client get request response ({response.json()}) with unexpected status "
+                f"({response.status_code}). "
+                f"Client: ({self})"
+                f"Request: (endpoint={endpoint})"
+            )
+
         if response.status_code == 401:
             raise Unauthorized()
+
+        if not error_handlers and not retry:
+            response.raise_for_status()
 
         if response.status_code != 200:
             for error_handler in error_handlers:
                 error_handler(response.status_code, response.json())
 
-            if debug:
-                print(
-                    f"Client get request response ({response.json()}) with unexpected status "
-                    f"({response.status_code}). "
-                    f"Client: ({self})"
-                    f"Request: (endpoint={endpoint})"
-                )
             if retry:
                 time.sleep(10)
                 return self.delete(endpoint, payload=payload, retry=False)

--- a/darwin/client.py
+++ b/darwin/client.py
@@ -200,6 +200,7 @@ class Client:
     def delete(
         self,
         endpoint: str,
+        payload: Optional[Dict[Any, Any]] = None,
         team: Optional[str] = None,
         retry: bool = False,
         error_handlers: Optional[List[ErrorHandler]] = None,
@@ -210,11 +211,15 @@ class Client:
         Parameters
         ----------
         endpoint : str
-            Recipient of the HTTP operation
+            Recipient of the HTTP operation.
+        payload : Optional[Dict[Any, Any]]
+            JSON-encoded extra information that might be necessary to perform the deletion.
+        team : Optional[str]
+            Optional team slug, used to build the request headers.
         retry : bool
             Retry to perform the operation. Set to False on recursive calls.
-        refresh : bool
-            Flag for use the refresh token instead
+        error_handlers : Optional[List[ErrorHandler]]
+            List of functions to be called should the requests be unsuccessful.
         debug : bool
             Debugging flag. In this case failed requests get printed
 
@@ -223,10 +228,14 @@ class Client:
         dict
         Dictionary which contains the server response
         """
+        if payload is None:
+            payload = {}
         if error_handlers is None:
             error_handlers = []
 
-        response: requests.Response = requests.delete(urljoin(self.url, endpoint), headers=self._get_headers(team))
+        response: requests.Response = requests.delete(
+            urljoin(self.url, endpoint), json=payload, headers=self._get_headers(team)
+        )
 
         if response.status_code == 401:
             raise Unauthorized()
@@ -244,7 +253,7 @@ class Client:
                 )
             if retry:
                 time.sleep(10)
-                return self.delete(endpoint, retry=False)
+                return self.delete(endpoint, payload=payload, retry=False)
 
         return self._decode_response(response, debug)
 

--- a/darwin/dataset/remote_dataset.py
+++ b/darwin/dataset/remote_dataset.py
@@ -395,6 +395,11 @@ class RemoteDataset:
         payload: Dict[str, Any] = {"filter": {"dataset_item_ids": [item.id for item in items]}}
         self.client.put(endpoint, payload)
 
+    def delete_items(self, items: Iterator[DatasetItem]) -> None:
+        endpoint: str = f"teams/{self.team}/datasets/{self.slug}/items"
+        payload: Dict[str, Any] = {"filter": {"dataset_item_ids": [item.id for item in items]}}
+        self.client.delete(endpoint, payload)
+
     def fetch_annotation_type_id_for_name(self, name: str) -> Optional[int]:
         """
         Fetches annotation type id for a annotation type name, such as bounding_box

--- a/darwin/options.py
+++ b/darwin/options.py
@@ -1,11 +1,9 @@
 import argparse
 import sys
-
+from argparse import ArgumentParser, Namespace
 from typing import Tuple
 
 import argcomplete
-
-from argparse import Namespace, ArgumentParser
 
 
 class Options(object):
@@ -193,6 +191,16 @@ class Options(object):
         )
         parser_file_status.add_argument("status", type=str, help="Status to change to.")
         parser_file_status.add_argument("files", type=str, nargs="+", help="Files to change status.")
+
+        # Delete files
+        parser_delete_files = dataset_action.add_parser("delete-files", help="Delete one or more files remotely.")
+        parser_delete_files.add_argument(
+            "dataset",
+            type=str,
+            help="[Remote] Dataset name: to list all the existing dataset, run 'darwin dataset remote'.",
+        )
+        parser_delete_files.add_argument("files", type=str, nargs="+", help="Files to delete.")
+
         # Help
         dataset_action.add_parser("help", help="Show this help message and exit.")
 

--- a/darwin/options.py
+++ b/darwin/options.py
@@ -200,6 +200,14 @@ class Options(object):
             help="[Remote] Dataset name: to list all the existing dataset, run 'darwin dataset remote'.",
         )
         parser_delete_files.add_argument("files", type=str, nargs="+", help="Files to delete.")
+        parser_delete_files.add_argument(
+            "-y",
+            "--yes",
+            default=False,
+            action="store_true",
+            required=False,
+            help="Confirmation flag to delete the file without prompting for manual input.",
+        )
 
         # Help
         dataset_action.add_parser("help", help="Show this help message and exit.")

--- a/tests/darwin/cli_functions_test.py
+++ b/tests/darwin/cli_functions_test.py
@@ -1,4 +1,5 @@
 import builtins
+import sys
 from unittest.mock import call, patch
 
 import pytest
@@ -148,7 +149,16 @@ def describe_delete_files():
     def dataset_identifier(team_slug: str, dataset_slug: str):
         return f"{team_slug}/{dataset_slug}"
 
-    def test_deletes_items_if_user_accepts(dataset_identifier: str, remote_dataset: RemoteDataset):
+    def test_bypasses_user_prompt_if_yes_flag_is_true(dataset_identifier: str, remote_dataset: RemoteDataset):
+        with patch.object(Client, "get_remote_dataset", return_value=remote_dataset) as get_remote_dataset_mock:
+            with patch.object(RemoteDataset, "fetch_remote_files") as fetch_remote_files_mock:
+                with patch.object(RemoteDataset, "delete_items") as mock:
+                    delete_files(dataset_identifier, ["one.jpg", "two.jpg"], True)
+                    get_remote_dataset_mock.assert_called_once_with(dataset_identifier=dataset_identifier)
+                    fetch_remote_files_mock.assert_called_once_with({"filenames": "one.jpg,two.jpg"})
+                    mock.assert_called_once_with(fetch_remote_files_mock.return_value)
+
+    def test_deletes_items_if_user_accepts_prompt(dataset_identifier: str, remote_dataset: RemoteDataset):
         with patch.object(Client, "get_remote_dataset", return_value=remote_dataset) as get_remote_dataset_mock:
             with patch.object(RemoteDataset, "fetch_remote_files") as fetch_remote_files_mock:
                 with patch.object(builtins, "input", lambda _: "y"):
@@ -158,7 +168,7 @@ def describe_delete_files():
                         fetch_remote_files_mock.assert_called_once_with({"filenames": "one.jpg,two.jpg"})
                         mock.assert_called_once_with(fetch_remote_files_mock.return_value)
 
-    def test_does_not_deletes_items_if_user_refuses(dataset_identifier: str, remote_dataset: RemoteDataset):
+    def test_does_not_delete_items_if_user_refuses_prompt(dataset_identifier: str, remote_dataset: RemoteDataset):
         with patch.object(Client, "get_remote_dataset", return_value=remote_dataset) as get_remote_dataset_mock:
             with patch.object(RemoteDataset, "fetch_remote_files") as fetch_remote_files_mock:
                 with patch.object(builtins, "input", lambda _: "n"):
@@ -167,3 +177,20 @@ def describe_delete_files():
                         get_remote_dataset_mock.assert_called_once_with(dataset_identifier=dataset_identifier)
                         fetch_remote_files_mock.assert_called_once_with({"filenames": "one.jpg,two.jpg"})
                         mock.assert_not_called()
+
+    def test_exits_if_error_occurs(dataset_identifier: str, remote_dataset: RemoteDataset):
+        def error_mock():
+            raise ValueError("Something went Wrong")
+
+        with patch.object(sys, "exit") as exception:
+            with patch.object(Client, "get_remote_dataset", return_value=remote_dataset) as get_remote_dataset_mock:
+                with patch.object(RemoteDataset, "fetch_remote_files") as fetch_remote_files_mock:
+                    with patch.object(RemoteDataset, "delete_items", side_effect=error_mock) as mock:
+
+                        delete_files(dataset_identifier, ["one.jpg", "two.jpg"], True)
+
+                        get_remote_dataset_mock.assert_called_once_with(dataset_identifier=dataset_identifier)
+                        fetch_remote_files_mock.assert_called_once_with({"filenames": "one.jpg,two.jpg"})
+                        mock.assert_called_once_with(fetch_remote_files_mock.return_value)
+                        exception.assert_called_once_with(1)
+

--- a/tests/darwin/cli_functions_test.py
+++ b/tests/darwin/cli_functions_test.py
@@ -5,7 +5,7 @@ import responses
 from rich.console import Console
 from tests.fixtures import *
 
-from darwin.cli_functions import set_file_status, upload_data
+from darwin.cli_functions import delete_files, set_file_status, upload_data
 from darwin.client import Client
 from darwin.config import Config
 from darwin.dataset import RemoteDataset
@@ -137,6 +137,15 @@ def describe_set_file_status():
             with patch.object(RemoteDataset, "fetch_remote_files") as fetch_remote_files_mock:
                 with patch.object(RemoteDataset, "restore_archived") as mock:
                     set_file_status(dataset_identifier, "restore-archived", ["one.jpg", "two.jpg"])
+                    get_remote_dataset_mock.assert_called_once_with(dataset_identifier=dataset_identifier)
+                    fetch_remote_files_mock.assert_called_once_with({"filenames": "one.jpg,two.jpg"})
+                    mock.assert_called_once_with(fetch_remote_files_mock.return_value)
+
+    def calls_dataset_delete_items(dataset_identifier: str, remote_dataset: RemoteDataset):
+        with patch.object(Client, "get_remote_dataset", return_value=remote_dataset) as get_remote_dataset_mock:
+            with patch.object(RemoteDataset, "fetch_remote_files") as fetch_remote_files_mock:
+                with patch.object(RemoteDataset, "delete_items") as mock:
+                    delete_files(dataset_identifier, ["one.jpg", "two.jpg"])
                     get_remote_dataset_mock.assert_called_once_with(dataset_identifier=dataset_identifier)
                     fetch_remote_files_mock.assert_called_once_with({"filenames": "one.jpg,two.jpg"})
                     mock.assert_called_once_with(fetch_remote_files_mock.return_value)

--- a/tests/darwin/dataset/remote_dataset_test.py
+++ b/tests/darwin/dataset/remote_dataset_test.py
@@ -361,10 +361,7 @@ def describe_fetch_remote_files():
         )
         url = "http://localhost/api/datasets/1/items?page%5Bsize%5D=500"
         responses.add(
-            responses.POST,
-            url,
-            json=files_content,
-            status=200,
+            responses.POST, url, json=files_content, status=200,
         )
 
         actual = remote_dataset.fetch_remote_files()
@@ -595,6 +592,18 @@ def describe_restore_archived():
             remote_dataset.restore_archived([dataset_item])
             stub.assert_called_once_with(
                 f"teams/{team_slug}/datasets/{dataset_slug}/items/restore", {"filter": {"dataset_item_ids": [1]}}
+            )
+
+
+@pytest.mark.usefixtures("file_read_write_test")
+def describe_delete_items():
+    def calls_client_delete(
+        remote_dataset: RemoteDataset, dataset_item: DatasetItem, team_slug: str, dataset_slug: str
+    ):
+        with patch.object(Client, "delete", return_value={}) as stub:
+            remote_dataset.delete_items([dataset_item])
+            stub.assert_called_once_with(
+                f"teams/{team_slug}/datasets/{dataset_slug}/items", {"filter": {"dataset_item_ids": [1]}}
             )
 
 


### PR DESCRIPTION
# Why

We don't support file deletion from the CLI

# How

Add argument parser option and functions, which are pretty similar to the ones for setting an item status.
Note: this PR is changing `delete` APIs, and is not retro-compatible. With that said, the new API is aligned to `post` and `put`, which I think is important.

Because of the aforementioned reasons, I would release a new minor version: `0.7.0`