### PR TITLE
added support for polygon and complex_polygon bboxes

### DIFF
--- a/darwin/exporter/formats/pascalvoc.py
+++ b/darwin/exporter/formats/pascalvoc.py
@@ -36,8 +36,9 @@ def build_xml(annotation_file: dt.AnnotationFile) -> Element:
 
     for annotation in annotation_file.annotations:
         annotation_type = annotation.annotation_class.annotation_type
-        if annotation_type not in ["bounding_box", "polygon"]:
+        if annotation_type not in ["bounding_box", "polygon", "complex_polygon"]:
             continue
+
         data = annotation.data
         sub_annotation = SubElement(root, "object")
         add_subelement_text(sub_annotation, "name", annotation.annotation_class.name)
@@ -46,21 +47,17 @@ def build_xml(annotation_file: dt.AnnotationFile) -> Element:
         add_subelement_text(sub_annotation, "difficult", "0")
         bndbox = SubElement(sub_annotation, "bndbox")
 
-        if annotation_type == "bounding_box":
-            add_subelement_text(bndbox, "xmin", str(round(data["x"])))
-            add_subelement_text(bndbox, "ymin", str(round(data["y"])))
-            add_subelement_text(bndbox, "xmax", str(round(data["x"] + data["w"])))
-            add_subelement_text(bndbox, "ymax", str(round(data["y"] + data["h"])))
-        elif annotation_type == "polygon":
-            polygon_bbox = data.get("bounding_box")
-            xmin = polygon_bbox.get("x")
-            ymin = polygon_bbox.get("y")
-            xmax = xmin + polygon_bbox.get("w")
-            ymax = ymin + polygon_bbox.get("h")
-            add_subelement_text(bndbox, "xmin", str(round(xmin)))
-            add_subelement_text(bndbox, "ymin", str(round(ymin)))
-            add_subelement_text(bndbox, "xmax", str(round(xmax)))
-            add_subelement_text(bndbox, "ymax", str(round(ymax)))
+        if annotation_type == "polygon" or annotation_type == "complex_polygon":
+            data = data.get("bounding_box")
+
+        xmin = data.get("x")
+        ymin = data.get("y")
+        xmax = xmin + data.get("w")
+        ymax = ymin + data.get("h")
+        add_subelement_text(bndbox, "xmin", str(round(xmin)))
+        add_subelement_text(bndbox, "ymin", str(round(ymin)))
+        add_subelement_text(bndbox, "xmax", str(round(xmax)))
+        add_subelement_text(bndbox, "ymax", str(round(ymax)))
 
     return root
 

--- a/darwin/exporter/formats/pascalvoc.py
+++ b/darwin/exporter/formats/pascalvoc.py
@@ -35,7 +35,8 @@ def build_xml(annotation_file: dt.AnnotationFile) -> Element:
     add_subelement_text(root, "segmented", "0")
 
     for annotation in annotation_file.annotations:
-        if annotation.annotation_class.annotation_type != "bounding_box":
+        annotation_type = annotation.annotation_class.annotation_type
+        if annotation_type not in ["bounding_box", "polygon"]:
             continue
         data = annotation.data
         sub_annotation = SubElement(root, "object")
@@ -44,10 +45,22 @@ def build_xml(annotation_file: dt.AnnotationFile) -> Element:
         add_subelement_text(sub_annotation, "truncated", "0")
         add_subelement_text(sub_annotation, "difficult", "0")
         bndbox = SubElement(sub_annotation, "bndbox")
-        add_subelement_text(bndbox, "xmin", str(round(data["x"])))
-        add_subelement_text(bndbox, "ymin", str(round(data["y"])))
-        add_subelement_text(bndbox, "xmax", str(round(data["x"] + data["w"])))
-        add_subelement_text(bndbox, "ymax", str(round(data["y"] + data["h"])))
+
+        if annotation_type == "bounding_box":
+            add_subelement_text(bndbox, "xmin", str(round(data["x"])))
+            add_subelement_text(bndbox, "ymin", str(round(data["y"])))
+            add_subelement_text(bndbox, "xmax", str(round(data["x"] + data["w"])))
+            add_subelement_text(bndbox, "ymax", str(round(data["y"] + data["h"])))
+        elif annotation_type == "polygon":
+            polygon_bbox = data.get("bounding_box")
+            xmin = polygon_bbox.get("x")
+            ymin = polygon_bbox.get("y")
+            xmax = xmin + polygon_bbox.get("w")
+            ymax = ymin + polygon_bbox.get("h")
+            add_subelement_text(bndbox, "xmin", str(round(xmin)))
+            add_subelement_text(bndbox, "ymin", str(round(ymin)))
+            add_subelement_text(bndbox, "xmax", str(round(xmax)))
+            add_subelement_text(bndbox, "ymax", str(round(ymax)))
 
     return root
 

--- a/tests/darwin/exporter/formats/export_pascalvoc_test.py
+++ b/tests/darwin/exporter/formats/export_pascalvoc_test.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+from xml.etree.ElementTree import Element, tostring
+
+from darwin.datatypes import Annotation, AnnotationClass, AnnotationFile
+from darwin.exporter.formats.pascalvoc import build_xml
+
+
+def describe_build_xml():
+    def test_returns_bounding_boxes_of_polygons():
+        car_class = AnnotationClass(name="car", annotation_type="polygon", annotation_internal_type=None)
+        car_annotation = Annotation(
+            annotation_class=car_class,
+            data={"path": [{...}], "bounding_box": {"x": 94.0, "y": 438.0, "w": 1709.0, "h": 545.0},},
+            subs=[],
+        )
+        annotation_file = AnnotationFile(
+            path=Path("/annotation_test.json"),
+            filename="annotation_test.jpg",
+            annotation_classes={car_class},
+            annotations=[car_annotation],
+            frame_urls=None,
+            image_height=1080,
+            image_width=1920,
+            is_video=False,
+        )
+
+        xml = build_xml(annotation_file)
+
+        assert isinstance(xml.find("object"), Element)

--- a/tests/darwin/exporter/formats/export_pascalvoc_test.py
+++ b/tests/darwin/exporter/formats/export_pascalvoc_test.py
@@ -1,23 +1,23 @@
 from pathlib import Path
-from xml.etree.ElementTree import Element, tostring
+from xml.etree.ElementTree import Element
 
 from darwin.datatypes import Annotation, AnnotationClass, AnnotationFile
 from darwin.exporter.formats.pascalvoc import build_xml
 
 
 def describe_build_xml():
-    def test_returns_bounding_boxes_of_polygons():
-        car_class = AnnotationClass(name="car", annotation_type="polygon", annotation_internal_type=None)
-        car_annotation = Annotation(
-            annotation_class=car_class,
+    def test_xml_has_bounding_boxes_of_polygons():
+        annotation_class = AnnotationClass(name="car", annotation_type="polygon", annotation_internal_type=None)
+        annotation = Annotation(
+            annotation_class=annotation_class,
             data={"path": [{...}], "bounding_box": {"x": 94.0, "y": 438.0, "w": 1709.0, "h": 545.0},},
             subs=[],
         )
         annotation_file = AnnotationFile(
             path=Path("/annotation_test.json"),
             filename="annotation_test.jpg",
-            annotation_classes={car_class},
-            annotations=[car_annotation],
+            annotation_classes={annotation_class},
+            annotations=[annotation],
             frame_urls=None,
             image_height=1080,
             image_width=1920,
@@ -26,4 +26,100 @@ def describe_build_xml():
 
         xml = build_xml(annotation_file)
 
-        assert isinstance(xml.find("object"), Element)
+        object = get_xml_element(xml, "object")
+        assert_xml_element_text(object, "name", "car")
+        assert_xml_element_text(object, "pose", "Unspecified")
+        assert_xml_element_text(object, "truncated", "0")
+        assert_xml_element_text(object, "difficult", "0")
+
+        bndbox = get_xml_element(object, "bndbox")
+        assert_xml_element_text(bndbox, "xmin", "94")
+        assert_xml_element_text(bndbox, "ymin", "438")
+        assert_xml_element_text(bndbox, "xmax", "1803")
+        assert_xml_element_text(bndbox, "ymax", "983")
+
+    def test_xml_has_bounding_boxes_of_complex_polygons():
+        annotation_class = AnnotationClass(
+            name="rubber", annotation_type="complex_polygon", annotation_internal_type="polygon"
+        )
+        annotation = Annotation(
+            annotation_class=annotation_class,
+            data={"paths": [{...}], "bounding_box": {"x": 1174.28, "y": 2379.17, "w": 824.9000000000001, "h": 843.52}},
+            subs=[],
+        )
+
+        annotation_file = AnnotationFile(
+            path=Path("/annotation_test.json"),
+            filename="annotation_test.jpg",
+            annotation_classes={annotation_class},
+            annotations=[annotation],
+            frame_urls=None,
+            image_height=4000,
+            image_width=6000,
+            is_video=False,
+        )
+
+        xml = build_xml(annotation_file)
+
+        object = get_xml_element(xml, "object")
+        assert_xml_element_text(object, "name", "rubber")
+        assert_xml_element_text(object, "pose", "Unspecified")
+        assert_xml_element_text(object, "truncated", "0")
+        assert_xml_element_text(object, "difficult", "0")
+
+        bndbox = get_xml_element(object, "bndbox")
+        assert_xml_element_text(bndbox, "xmin", "1174")
+        assert_xml_element_text(bndbox, "ymin", "2379")
+        assert_xml_element_text(bndbox, "xmax", "1999")
+        assert_xml_element_text(bndbox, "ymax", "3223")
+
+    def test_xml_has_bounding_boxes():
+        annotation_class = AnnotationClass(name="tire", annotation_type="bounding_box", annotation_internal_type=None)
+        annotation = Annotation(
+            annotation_class=annotation_class, data={"x": 574.88, "y": 427.0, "w": 137.04, "h": 190.66}, subs=[],
+        )
+        annotation_file = AnnotationFile(
+            path=Path("/annotation_test.json"),
+            filename="annotation_test.jpg",
+            annotation_classes={annotation_class},
+            annotations=[annotation],
+            frame_urls=None,
+            image_height=853,
+            image_width=1400,
+            is_video=False,
+        )
+
+        xml = build_xml(annotation_file)
+
+        object = get_xml_element(xml, "object")
+        assert_xml_element_text(object, "name", "tire")
+        assert_xml_element_text(object, "pose", "Unspecified")
+        assert_xml_element_text(object, "truncated", "0")
+        assert_xml_element_text(object, "difficult", "0")
+
+        bndbox = get_xml_element(object, "bndbox")
+        assert_xml_element_text(bndbox, "xmin", "575")
+        assert_xml_element_text(bndbox, "ymin", "427")
+        assert_xml_element_text(bndbox, "xmax", "712")
+        assert_xml_element_text(bndbox, "ymax", "618")
+
+
+def get_xml_element(parent: Element, key: str) -> Element:
+    """
+    Return the first child of the parent name whose name matches the given key.
+    If no children are found, it raises.
+    """
+    object = parent.find(key)
+    assert isinstance(object, Element)
+    return object
+
+
+def assert_xml_element_text(parent: Element, key: str, val: str) -> None:
+    """
+    Asserts if the first child with a name matching the key of the given parent element has the 
+    given text value.
+    Raises if no children are found or if the text value is not equal.
+    """
+    obj = parent.find(key)
+    assert isinstance(obj, Element)
+    assert obj.text == val


### PR DESCRIPTION
Slack link: https://vseven.slack.com/archives/CJUN8TRJA/p1636468559125000

When exporting to PascalVOC format, the bounding boxes of Polygons are being discarded. 

This PR fixes that.