### PR TITLE
Adding support for polygons

### DIFF
--- a/darwin/importer/formats/labelbox.py
+++ b/darwin/importer/formats/labelbox.py
@@ -16,7 +16,7 @@ from darwin.datatypes import (
 def parse_file(path: Path) -> Optional[List[AnnotationFile]]:
     """
     Parses the given LabelBox file and maybe returns the corresponding annotations.
-    The file must have the following structure:
+    The file must have a structure simillar to the following:
     
     ```json
     [
@@ -24,6 +24,7 @@ def parse_file(path: Path) -> Optional[List[AnnotationFile]]:
             "Label":{
                 "objects":[
                     {
+                        "title": "SomeTitle",
                         "bbox":{"top":3558, "left":145, "height":623, "width":449}
                     },
                     {...}
@@ -37,6 +38,7 @@ def parse_file(path: Path) -> Optional[List[AnnotationFile]]:
 
     Currently we support the following annotations:
     - bounding-box `Image`: https://docs.labelbox.com/docs/bounding-box-json
+    - polygon `Image`: https://docs.labelbox.com/docs/polygon-json
 
     Parameters
     --------
@@ -106,24 +108,45 @@ def _convert_label_objects(obj: Dict[str, Any]) -> Annotation:
 def _to_bbox_annotation(bbox: Dict[str, Any], title: str) -> Annotation:
     x: Optional[float] = bbox.get("left")
     if x is None:
-        raise ValueError(f"bbox objects must have a 'left' value: {bbox}")
+        raise ValueError(
+            f"bbox objects must have a 'left' value: {bbox}\nPlease refer to: https://docs.labelbox.com/docs/bounding-box-json#export"
+        )
 
     y: Optional[float] = bbox.get("top")
     if y is None:
-        raise ValueError(f"bbox objects must have a 'top' value: {bbox}")
+        raise ValueError(
+            f"bbox objects must have a 'top' value: {bbox}\nPlease refer to: https://docs.labelbox.com/docs/bounding-box-json#export"
+        )
 
     width: Optional[float] = bbox.get("width")
     if width is None:
-        raise ValueError(f"bbox objects must have a 'width' value: {bbox}")
+        raise ValueError(
+            f"bbox objects must have a 'width' value: {bbox}\nPlease refer to: https://docs.labelbox.com/docs/bounding-box-json#export"
+        )
 
     height: Optional[float] = bbox.get("height")
     if height is None:
-        raise ValueError(f"bbox objects must have a 'height' value: {bbox}")
+        raise ValueError(
+            f"bbox objects must have a 'height' value: {bbox}\nPlease refer to: https://docs.labelbox.com/docs/bounding-box-json#export"
+        )
 
     return make_bounding_box(title, x, y, width, height)
 
 
 def _to_polygon_annotation(polygon: List[Point], title: str) -> Annotation:
+    for point in polygon:
+        x: Optional[float] = point.get("x")
+        if x is None:
+            raise ValueError(
+                f"LabelBox Polygon Points must have an 'x' value: {point}\nPlease refer to: https://docs.labelbox.com/docs/polygon-json#export"
+            )
+
+        y: Optional[float] = point.get("y")
+        if y is None:
+            raise ValueError(
+                f"LabelBox Polygon Points must have an 'y' value: {point}\nPlease refer to: https://docs.labelbox.com/docs/polygon-json#export"
+            )
+
     return make_polygon(title, polygon, None)
 
 

--- a/darwin/importer/formats/labelbox.py
+++ b/darwin/importer/formats/labelbox.py
@@ -7,7 +7,9 @@ from darwin.datatypes import (
     Annotation,
     AnnotationClass,
     AnnotationFile,
+    Point,
     make_bounding_box,
+    make_polygon,
 )
 
 
@@ -94,6 +96,10 @@ def _convert_label_objects(obj: Dict[str, Any]) -> Annotation:
     if bbox:
         return _to_bbox_annotation(bbox, title)
 
+    polygon: Optional[List[Point]] = obj.get("polygon")
+    if polygon:
+        return _to_polygon_annotation(polygon, title)
+
     raise ValueError(f"Unsupported object type {obj}")
 
 
@@ -115,6 +121,10 @@ def _to_bbox_annotation(bbox: Dict[str, Any], title: str) -> Annotation:
         raise ValueError(f"bbox objects must have a 'height' value: {bbox}")
 
     return make_bounding_box(title, x, y, width, height)
+
+
+def _to_polygon_annotation(polygon: List[Point], title: str) -> Annotation:
+    return make_polygon(title, polygon, None)
 
 
 def _get_class(annotation: Annotation) -> AnnotationClass:

--- a/tests/darwin/importer/formats/import_labelbox_test.py
+++ b/tests/darwin/importer/formats/import_labelbox_test.py
@@ -226,7 +226,7 @@ def describe_parse_file():
 
         assert f"bbox objects must have a 'height' value" in str(error.value)
 
-    def test_it_imports_bboxes(file_path: Path):
+    def test_it_imports_bbox_images(file_path: Path):
         json: str = """
          [
             {
@@ -265,6 +265,48 @@ def describe_parse_file():
 
         annotation_class = bbox_annotation.annotation_class
         assert_annotation_class(annotation_class, "Fruit", "bounding_box")
+
+    def test_it_imports_polygon_images(file_path: Path):
+        json: str = """
+            [
+               {
+                  "Label":{
+                     "objects":[
+                        {
+                           "title":"Fish",
+                           "polygon": [
+                              {"x": 3665.814, "y": 351.628},
+                              {"x": 3762.93, "y": 810.419},
+                              {"x": 3042.93, "y": 914.233},
+                              {"x": 2996.047, "y": 864},
+                              {"x": 3036.233, "y": 753.488}
+                           ]
+                        }
+                     ]
+                  },
+                  "External ID": "demo-image-7.jpg"
+               }
+            ]
+        """
+
+        file_path.write_text(json)
+
+        annotation_files: Optional[List[AnnotationFile]] = parse_file(file_path)
+        assert annotation_files is not None
+
+        annotation_file: AnnotationFile = annotation_files.pop()
+        assert annotation_file.path == file_path
+        assert annotation_file.filename == "demo-image-7.jpg"
+        assert annotation_file.annotation_classes
+        assert annotation_file.remote_path == "/"
+
+        assert annotation_file.annotations
+
+    #   bbox_annotation = annotation_file.annotations.pop()
+    #   assert_bbox(bbox_annotation, 145, 3558, 623, 449)
+
+    #   annotation_class = bbox_annotation.annotation_class
+    #   assert_annotation_class(annotation_class, "Fruit", "bounding_box")
 
 
 def assert_bbox(annotation: Annotation, x: float, y: float, h: float, w: float) -> None:


### PR DESCRIPTION
Background
-----

Added LabelBox Polygon Image support for importations.
- https://docs.labelbox.com/docs/polygon-json

- Improved error messages
- Updated docs for public API
- Added more tests

Note
----

I am not generating the polygon's bounding box out of the Polygon data. If this is required, let me know!

How can I test this?
-----------

Use the following `test.json` as a guide.
If you have a dataset, pick an image (any image) and replace the `External ID` field with your image's name:

```
[
    {
        "Label": {
            "objects": [
                {
                    "title": "UglyCar",
                    "polygon": [
                              {"x": 3665.814, "y": 351.628},
                              {"x": 3762.93, "y": 810.419},
                              {"x": 3665.814, "y": 351.628}
                        ]
                }
            ]
        },
        "External ID": "serge-kutuzov-1K9-TbJWs2U-unsplash.jpg"
    }
]
```

Then you can import this dummy annotation into your dataset with the following command:

```
darwin dataset import team-slug/dataset-slug labelbox test.json
```