### PR TITLE
Added default values to optional types

### DIFF
--- a/darwin/datatypes.py
+++ b/darwin/datatypes.py
@@ -131,7 +131,10 @@ def make_tag(class_name: str, subs: Optional[List[SubAnnotation]] = None) -> Ann
 
 
 def make_polygon(
-    class_name: str, point_path: List[Point], bounding_box: Optional[Dict], subs: Optional[List[SubAnnotation]] = None
+    class_name: str,
+    point_path: List[Point],
+    bounding_box: Optional[Dict] = None,
+    subs: Optional[List[SubAnnotation]] = None,
 ) -> Annotation:
     return Annotation(
         AnnotationClass(class_name, "polygon"),
@@ -143,7 +146,7 @@ def make_polygon(
 def make_complex_polygon(
     class_name: str,
     point_paths: List[List[Point]],
-    bounding_box: Optional[Dict],
+    bounding_box: Optional[Dict] = None,
     subs: Optional[List[SubAnnotation]] = None,
 ) -> Annotation:
     return Annotation(

--- a/tests/darwin/datatypes_test.py
+++ b/tests/darwin/datatypes_test.py
@@ -1,0 +1,67 @@
+from typing import Dict, List
+
+from darwin.datatypes import Point, make_complex_polygon, make_polygon
+
+
+def describe_make_polygon():
+    def test_it_returns_annotation_with_default_params():
+        class_name: str = "class_name"
+        points: List[Point] = [{"x": 1, "y": 2}, {"x": 3, "y": 4}, {"x": 1, "y": 2}]
+        annotation = make_polygon(class_name, points)
+
+        assert_annoation_class(annotation, class_name, "polygon")
+
+        path = annotation.data.get("path")
+        assert path == points
+
+    def test_it_returns_annotation_with_bounding_box():
+        class_name: str = "class_name"
+        points: List[Point] = [{"x": 1, "y": 2}, {"x": 3, "y": 4}, {"x": 1, "y": 2}]
+        bbox: Dict[str, float] = {"x": 1, "y": 2, "w": 2, "h": 2}
+        annotation = make_polygon(class_name, points, bbox)
+
+        assert_annoation_class(annotation, class_name, "polygon")
+
+        path = annotation.data.get("path")
+        assert path == points
+
+        class_bbox = annotation.data.get("bounding_box")
+        assert class_bbox == bbox
+
+
+def describe_make_complex_polygon():
+    def test_it_returns_annotation_with_default_params():
+        class_name: str = "class_name"
+        points: List[List[Point]] = [
+            [{"x": 1, "y": 2}, {"x": 3, "y": 4}, {"x": 1, "y": 2}],
+            [{"x": 4, "y": 5}, {"x": 6, "y": 7}, {"x": 4, "y": 5}],
+        ]
+        annotation = make_complex_polygon(class_name, points)
+
+        assert_annoation_class(annotation, class_name, "complex_polygon", "polygon")
+
+        paths = annotation.data.get("paths")
+        assert paths == points
+
+    def test_it_returns_annotation_with_bounding_box():
+        class_name: str = "class_name"
+        points: List[List[Point]] = [
+            [{"x": 1, "y": 2}, {"x": 3, "y": 4}, {"x": 1, "y": 2}],
+            [{"x": 4, "y": 5}, {"x": 6, "y": 7}, {"x": 4, "y": 5}],
+        ]
+        bbox: Dict[str, float] = {"x": 1, "y": 2, "w": 2, "h": 2}
+        annotation = make_complex_polygon(class_name, points, bbox)
+
+        assert_annoation_class(annotation, class_name, "complex_polygon", "polygon")
+
+        paths = annotation.data.get("paths")
+        assert paths == points
+
+        class_bbox = annotation.data.get("bounding_box")
+        assert class_bbox == bbox
+
+
+def assert_annoation_class(annotation, name, type, internal_type=None):
+    assert annotation.annotation_class.name == name
+    assert annotation.annotation_class.annotation_type == type
+    assert annotation.annotation_class.annotation_internal_type == internal_type


### PR DESCRIPTION
Background
----

Coco imports were failing for one of our customers. 
The fix was to add default types to `make_polygon` and `make_complex_polygon`.

How can I test
-----

Tested locally with script and command line. 

Coco file used:
[21-11-03_15-24-02_coco.zip](https://github.com/v7labs/darwin-py/files/7562979/21-11-03_15-24-02_coco.zip)

You can use something simillar:

```
darwin dataset import andreas-team/cars coco 21-11-03_15-24-02_coco.json
Fetching remote class list...
Retrieving local annotations ...
Fetching remote file list...
1 annotation file(s) found.
1 classes needs to be created.
0 classes needs to be added to andreas-team/cars
About to create the following classes
        plants, type: polygon
Do you want to continue? [y/N] y
Working... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
```

Also test with client's script. 

You can use this, just change the name of the dataset and image to your liking.