### PR TITLE
added JSONschema validation to labelbox

### DIFF
--- a/darwin/importer/formats/__init__.py
+++ b/darwin/importer/formats/__init__.py
@@ -1,17 +1,17 @@
 from functools import partial
 from typing import List
 
-from jsonschema_rs import JSONSchema
+from jsonschema import validate
 
 from darwin.datatypes import ImporterFormat
 from darwin.importer.formats.labelbox_schemas import labelbox_export
 
 from . import coco, csvtags, csvtagsvideo, darwin, dataloop, labelbox, pascalvoc
 
-labelbox_validator = JSONSchema(labelbox_export)
+validate_with_schema = partial(validate, schema=labelbox_export)
 
 supported_formats: List[ImporterFormat] = [
-    ("labelbox", partial(labelbox.parse_file, validator=labelbox_validator)),
+    ("labelbox", partial(labelbox.parse_file, validate=validate_with_schema)),
     ("pascal_voc", pascalvoc.parse_file),
     ("dataloop", dataloop.parse_file),
     ("csv_tags", csvtags.parse_file),

--- a/darwin/importer/formats/__init__.py
+++ b/darwin/importer/formats/__init__.py
@@ -1,11 +1,13 @@
+from functools import partial
 from typing import List
 
 from darwin.datatypes import ImporterFormat
+from darwin.importer.formats.labelbox_schemas import labelbox_export
 
 from . import coco, csvtags, csvtagsvideo, darwin, dataloop, labelbox, pascalvoc
 
 supported_formats: List[ImporterFormat] = [
-    ("labelbox", labelbox.parse_file),
+    ("labelbox", partial(labelbox.parse_file, schema=labelbox_export)),
     ("pascal_voc", pascalvoc.parse_file),
     ("dataloop", dataloop.parse_file),
     ("csv_tags", csvtags.parse_file),

--- a/darwin/importer/formats/__init__.py
+++ b/darwin/importer/formats/__init__.py
@@ -1,13 +1,17 @@
 from functools import partial
 from typing import List
 
+from jsonschema_rs import JSONSchema
+
 from darwin.datatypes import ImporterFormat
 from darwin.importer.formats.labelbox_schemas import labelbox_export
 
 from . import coco, csvtags, csvtagsvideo, darwin, dataloop, labelbox, pascalvoc
 
+labelbox_validator = JSONSchema(labelbox_export)
+
 supported_formats: List[ImporterFormat] = [
-    ("labelbox", partial(labelbox.parse_file, schema=labelbox_export)),
+    ("labelbox", partial(labelbox.parse_file, validator=labelbox_validator)),
     ("pascal_voc", pascalvoc.parse_file),
     ("dataloop", dataloop.parse_file),
     ("csv_tags", csvtags.parse_file),

--- a/darwin/importer/formats/labelbox.py
+++ b/darwin/importer/formats/labelbox.py
@@ -3,6 +3,8 @@ from functools import partial
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 
+from jsonschema import validate
+
 from darwin.datatypes import (
     Annotation,
     AnnotationClass,
@@ -13,7 +15,7 @@ from darwin.datatypes import (
 )
 
 
-def parse_file(path: Path) -> Optional[List[AnnotationFile]]:
+def parse_file(path: Path, schema: Dict[str, Any]) -> Optional[List[AnnotationFile]]:
     """
     Parses the given LabelBox file and maybe returns the corresponding annotations.
     The file must have a structure simillar to the following:
@@ -64,23 +66,18 @@ def parse_file(path: Path) -> Optional[List[AnnotationFile]]:
 
     with path.open() as f:
         data = json.load(f)
+        validate(instance=data, schema=schema)
         convert_with_path = partial(_convert, path=path)
 
         return list(map(convert_with_path, data))
 
 
+# We ignore the Any | None warning here because the schema has been validated and we know
+# we have the values with the correct types
 def _convert(file_data: Dict[str, Any], path) -> AnnotationFile:
-    filename: Optional[str] = file_data.get("External ID")
-    if not filename:
-        raise ValueError(f"LabelBox Object must have an 'External ID' key: {file_data}")
-
-    label: Optional[Dict[str, Any]] = file_data.get("Label")
-    if label is None:
-        raise ValueError(f"LabelBox Object must have a 'Label' key: {file_data}")
-
-    label_objects: Optional[List[Dict[str, Any]]] = label.get("objects")
-    if label_objects is None:
-        raise ValueError(f"LabelBox Label must have an 'objects' key: {file_data}")
+    filename: str = file_data.get("External ID")  # type: ignore
+    label: Dict[str, Any] = file_data.get("Label")  # type: ignore
+    label_objects: List[Dict[str, Any]] = label.get("objects")  # type: ignore
 
     annotations: List[Annotation] = list(map(_convert_label_objects, label_objects))
     classes: Set[AnnotationClass] = set(map(_get_class, annotations))
@@ -89,10 +86,10 @@ def _convert(file_data: Dict[str, Any], path) -> AnnotationFile:
     )
 
 
+# We ignore the Any | None warning here because the schema has been validated and we know
+# we have the values with the correct types
 def _convert_label_objects(obj: Dict[str, Any]) -> Annotation:
-    title: Optional[str] = obj.get("title")
-    if not title:
-        raise ValueError(f"LabelBox objects must have a title: {obj}")
+    title: str = obj.get("title")  # type: ignore
 
     bbox: Optional[Dict[str, Any]] = obj.get("bbox")
     if bbox:
@@ -105,48 +102,18 @@ def _convert_label_objects(obj: Dict[str, Any]) -> Annotation:
     raise ValueError(f"Unsupported object type {obj}")
 
 
+# We ignore the Any | None warning here because the schema has been validated and we know
+# we have the values with the correct types
 def _to_bbox_annotation(bbox: Dict[str, Any], title: str) -> Annotation:
-    x: Optional[float] = bbox.get("left")
-    if x is None:
-        raise ValueError(
-            f"bbox objects must have a 'left' value: {bbox}\nPlease refer to: https://docs.labelbox.com/docs/bounding-box-json#export"
-        )
-
-    y: Optional[float] = bbox.get("top")
-    if y is None:
-        raise ValueError(
-            f"bbox objects must have a 'top' value: {bbox}\nPlease refer to: https://docs.labelbox.com/docs/bounding-box-json#export"
-        )
-
-    width: Optional[float] = bbox.get("width")
-    if width is None:
-        raise ValueError(
-            f"bbox objects must have a 'width' value: {bbox}\nPlease refer to: https://docs.labelbox.com/docs/bounding-box-json#export"
-        )
-
-    height: Optional[float] = bbox.get("height")
-    if height is None:
-        raise ValueError(
-            f"bbox objects must have a 'height' value: {bbox}\nPlease refer to: https://docs.labelbox.com/docs/bounding-box-json#export"
-        )
+    x: float = bbox.get("left")  # type: ignore
+    y: float = bbox.get("top")  # type: ignore
+    width: float = bbox.get("width")  # type: ignore
+    height: float = bbox.get("height")  # type: ignore
 
     return make_bounding_box(title, x, y, width, height)
 
 
 def _to_polygon_annotation(polygon: List[Point], title: str) -> Annotation:
-    for point in polygon:
-        x: Optional[float] = point.get("x")
-        if x is None:
-            raise ValueError(
-                f"LabelBox Polygon Points must have an 'x' value: {point}\nPlease refer to: https://docs.labelbox.com/docs/polygon-json#export"
-            )
-
-        y: Optional[float] = point.get("y")
-        if y is None:
-            raise ValueError(
-                f"LabelBox Polygon Points must have an 'y' value: {point}\nPlease refer to: https://docs.labelbox.com/docs/polygon-json#export"
-            )
-
     return make_polygon(title, polygon, None)
 
 

--- a/darwin/importer/formats/labelbox_schemas.py
+++ b/darwin/importer/formats/labelbox_schemas.py
@@ -1,5 +1,4 @@
 bounding_box = {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://darwin.v7labs.com/schemas/bounding_box",
     "description": "Schema of a Bounding Box",
     "title": "Bounding Box",
@@ -16,7 +15,6 @@ bounding_box = {
 }
 
 point = {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://darwin.v7labs.com/schemas/point",
     "description": "Schema of a Point",
     "title": "Point",
@@ -28,7 +26,6 @@ point = {
 }
 
 polygon = {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://darwin.v7labs.com/schemas/polygon",
     "description": "Schema of a Polygon",
     "title": "Polygon",
@@ -40,7 +37,15 @@ polygon = {
 
 
 label_object = {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://darwin.v7labs.com/schemas/label_object",
+    "description": "An object belonging to the objects array from a Label",
+    "title": "Label Object",
+    "default": {"title": "Banana", "point": {"x": 3665.814, "y": 351.628}},
+    "examples": [
+        {"title": "Banana", "point": {"x": 3665.814, "y": 351.628}},
+        {"title": "Orange", "bbox": {"top": 1.2, "left": 2.5, "height": 10, "width": 20}},
+        {"title": "Apple", "polygon": [{"x": 1.2, "y": 2.5}, {"x": 2.5, "y": 3.6}, {"x": 1.2, "y": 2.5}]},
+    ],
     "type": "object",
     "required": ["title"],
     "properties": {"title": {"type": "string"}},
@@ -51,8 +56,20 @@ label_object = {
     ],
 }
 
-label = {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
+labelbox_file = {
+    "$id": "https://darwin.v7labs.com/schemas/label_file",
+    "description": "A Labelbox file, equivalent to a Darwin AnnotationFile",
+    "title": "Labelbox File",
+    "default": {
+        "Label": {"objects": [{"title": "Banana", "point": {"x": 3665.814, "y": 351.628},}]},
+        "External ID": "demo-image-7.jpg",
+    },
+    "examples": [
+        {
+            "Label": {"objects": [{"title": "Banana", "point": {"x": 3665.814, "y": 351.628},}]},
+            "External ID": "demo-image-7.jpg",
+        }
+    ],
     "type": "object",
     "properties": {
         "Label": {
@@ -66,13 +83,28 @@ label = {
 }
 
 labelbox_export = {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://darwin.v7labs.com/schemas/export",
     "description": "A Labelbox export",
     "title": "Export",
-    "default": {"x": 1.2, "y": 2.5},
-    "examples": [{"x": 1.2, "y": 2.5}, {"x": 0, "y": 1}],
+    "default": [
+        {
+            "Label": {"objects": [{"title": "Banana", "point": {"x": 3665.814, "y": 351.628},}]},
+            "External ID": "demo-image-7.jpg",
+        }
+    ],
+    "examples": [
+        [
+            {
+                "Label": {"objects": [{"title": "Banana", "point": {"x": 3665.814, "y": 351.628},}]},
+                "External ID": "demo-image-7.jpg",
+            },
+            {
+                "Label": {"objects": [{"title": "Orange", "point": {"x": 0.814, "y": 0.628},}]},
+                "External ID": "demo-image-8.jpg",
+            },
+        ]
+    ],
     "type": "array",
-    "items": label,
+    "items": labelbox_file,
 }
 

--- a/darwin/importer/formats/labelbox_schemas.py
+++ b/darwin/importer/formats/labelbox_schemas.py
@@ -1,0 +1,78 @@
+bounding_box = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://darwin.v7labs.com/schemas/bounding_box",
+    "description": "Schema of a Bounding Box",
+    "title": "Bounding Box",
+    "default": {"top": 1.2, "left": 2.5, "height": 10, "width": 20},
+    "examples": [{"top": 0, "left": 0, "height": 10, "width": 20}],
+    "type": "object",
+    "properties": {
+        "top": {"type": "number"},
+        "left": {"type": "number"},
+        "height": {"type": "number"},
+        "width": {"type": "number"},
+    },
+    "required": ["top", "left", "height", "width"],
+}
+
+point = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://darwin.v7labs.com/schemas/point",
+    "description": "Schema of a Point",
+    "title": "Point",
+    "default": {"x": 1.2, "y": 2.5},
+    "examples": [{"x": 1.2, "y": 2.5}, {"x": 0, "y": 1}],
+    "type": "object",
+    "properties": {"x": {"type": "number"}, "y": {"type": "number"}},
+    "required": ["x", "y"],
+}
+
+polygon = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://darwin.v7labs.com/schemas/polygon",
+    "description": "Schema of a Polygon",
+    "title": "Polygon",
+    "default": [{"x": 1.2, "y": 2.5}, {"x": 2.5, "y": 3.6}, {"x": 1.2, "y": 2.5}],
+    "examples": [[{"x": 1.2, "y": 2.5}, {"x": 2.5, "y": 3.6}, {"x": 1.2, "y": 2.5}], []],
+    "type": "array",
+    "items": point,
+}
+
+
+label_object = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "required": ["title"],
+    "properties": {"title": {"type": "string"}},
+    "oneOf": [
+        {"type": "object", "required": ["point"], "properties": {"point": point}},
+        {"type": "object", "required": ["bbox"], "properties": {"bbox": bounding_box}},
+        {"type": "object", "required": ["polygon"], "properties": {"polygon": polygon}},
+    ],
+}
+
+label = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "Label": {
+            "type": "object",
+            "properties": {"objects": {"type": "array", "items": label_object}},
+            "required": ["objects"],
+        },
+        "External ID": {"type": "string"},
+    },
+    "required": ["Label", "External ID"],
+}
+
+labelbox_export = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://darwin.v7labs.com/schemas/export",
+    "description": "A Labelbox export",
+    "title": "Export",
+    "default": {"x": 1.2, "y": 2.5},
+    "examples": [{"x": 1.2, "y": 2.5}, {"x": 0, "y": 1}],
+    "type": "array",
+    "items": label,
+}
+

--- a/darwin/importer/formats/labelbox_schemas.py
+++ b/darwin/importer/formats/labelbox_schemas.py
@@ -9,8 +9,8 @@ bounding_box = {
     "properties": {
         "top": {"type": "number"},
         "left": {"type": "number"},
-        "height": {"type": "number"},
-        "width": {"type": "number"},
+        "height": {"type": "number", "minimum": 0},
+        "width": {"type": "number", "minimum": 0},
     },
     "required": ["top", "left", "height", "width"],
 }
@@ -45,9 +45,9 @@ label_object = {
     "required": ["title"],
     "properties": {"title": {"type": "string"}},
     "oneOf": [
-        {"type": "object", "required": ["point"], "properties": {"point": point}},
-        {"type": "object", "required": ["bbox"], "properties": {"bbox": bounding_box}},
-        {"type": "object", "required": ["polygon"], "properties": {"polygon": polygon}},
+        {"required": ["point"], "properties": {"point": point}},
+        {"required": ["bbox"], "properties": {"bbox": bounding_box}},
+        {"required": ["polygon"], "properties": {"polygon": polygon}},
     ],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setuptools.setup(
         "requests_toolbelt",
         "rich",
         "upolygon==0.1.6",
+        "jsonschema-rs",
     ],
     extras_require={"test": ["responses", "pytest", "pytest-describe"], "ml": ["sklearn", "torch", "torchvision"]},
     packages=[

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setuptools.setup(
         "requests_toolbelt",
         "rich",
         "upolygon==0.1.6",
-        "jsonschema-rs",
+        "jsonschema",
     ],
     extras_require={"test": ["responses", "pytest", "pytest-describe"], "ml": ["sklearn", "torch", "torchvision"]},
     packages=[

--- a/tests/darwin/importer/formats/import_labelbox_test.py
+++ b/tests/darwin/importer/formats/import_labelbox_test.py
@@ -4,6 +4,8 @@ from typing import List, Optional
 import pytest
 from darwin.datatypes import Annotation, AnnotationClass, AnnotationFile, Point
 from darwin.importer.formats.labelbox import parse_file
+from darwin.importer.formats.labelbox_schemas import labelbox_export
+from jsonschema import ValidationError
 
 
 def describe_parse_file():
@@ -15,7 +17,7 @@ def describe_parse_file():
 
     def test_it_returns_none_if_there_are_no_annotations():
         path = Path("path/to/file.xml")
-        assert parse_file(path) is None
+        assert parse_file(path, labelbox_export) is None
 
     def test_it_raises_if_external_id_is_missing(file_path: Path):
         json: str = """
@@ -40,10 +42,10 @@ def describe_parse_file():
 
         file_path.write_text(json)
 
-        with pytest.raises(ValueError) as error:
-            parse_file(file_path)
+        with pytest.raises(ValidationError) as error:
+            parse_file(file_path, labelbox_export)
 
-        assert f"LabelBox Object must have an 'External ID' key" in str(error.value)
+        assert "'External ID' is a required property" in str(error.value)
 
     def test_it_raises_if_label_is_missing(file_path: Path):
         json: str = """
@@ -52,10 +54,10 @@ def describe_parse_file():
 
         file_path.write_text(json)
 
-        with pytest.raises(ValueError) as error:
-            parse_file(file_path)
+        with pytest.raises(ValidationError) as error:
+            parse_file(file_path, labelbox_export)
 
-        assert f"LabelBox Object must have a 'Label' key" in str(error.value)
+        assert "'Label' is a required property" in str(error.value)
 
     def test_it_raises_if_label_objects_is_missing(file_path: Path):
         json: str = """
@@ -64,10 +66,10 @@ def describe_parse_file():
 
         file_path.write_text(json)
 
-        with pytest.raises(ValueError) as error:
-            parse_file(file_path)
+        with pytest.raises(ValidationError) as error:
+            parse_file(file_path, labelbox_export)
 
-        assert f"LabelBox Label must have an 'objects' key" in str(error.value)
+        assert "'objects' is a required property" in str(error.value)
 
     def test_it_raises_if_label_object_has_unknown_format(file_path: Path):
         json: str = """
@@ -81,10 +83,10 @@ def describe_parse_file():
 
         file_path.write_text(json)
 
-        with pytest.raises(ValueError) as error:
-            parse_file(file_path)
+        with pytest.raises(ValidationError) as error:
+            parse_file(file_path, labelbox_export)
 
-        assert f"Unsupported object type" in str(error.value)
+        assert "'point' is a required property" in str(error.value)
 
     def test_it_raises_if_annotation_has_no_title(file_path: Path):
         json: str = """
@@ -109,10 +111,10 @@ def describe_parse_file():
 
         file_path.write_text(json)
 
-        with pytest.raises(ValueError) as error:
-            parse_file(file_path)
+        with pytest.raises(ValidationError) as error:
+            parse_file(file_path, labelbox_export)
 
-        assert f"LabelBox objects must have a title" in str(error.value)
+        assert "'title' is a required property" in str(error.value)
 
     def test_it_raises_if_bbox_has_missing_top(file_path: Path):
         json: str = """
@@ -137,10 +139,10 @@ def describe_parse_file():
 
         file_path.write_text(json)
 
-        with pytest.raises(ValueError) as error:
-            parse_file(file_path)
+        with pytest.raises(ValidationError) as error:
+            parse_file(file_path, labelbox_export)
 
-        assert f"bbox objects must have a 'top' value" in str(error.value)
+        assert "'top' is a required property" in str(error.value)
 
     def test_it_raises_if_bbox_has_missing_left(file_path: Path):
         json: str = """
@@ -165,10 +167,10 @@ def describe_parse_file():
 
         file_path.write_text(json)
 
-        with pytest.raises(ValueError) as error:
-            parse_file(file_path)
+        with pytest.raises(ValidationError) as error:
+            parse_file(file_path, labelbox_export)
 
-        assert f"bbox objects must have a 'left' value" in str(error.value)
+        assert "'left' is a required property" in str(error.value)
 
     def test_it_raises_if_bbox_has_missing_width(file_path: Path):
         json: str = """
@@ -193,10 +195,10 @@ def describe_parse_file():
 
         file_path.write_text(json)
 
-        with pytest.raises(ValueError) as error:
-            parse_file(file_path)
+        with pytest.raises(ValidationError) as error:
+            parse_file(file_path, labelbox_export)
 
-        assert f"bbox objects must have a 'width' value" in str(error.value)
+        assert "'width' is a required property" in str(error.value)
 
     def test_it_raises_if_bbox_has_missing_height(file_path: Path):
         json: str = """
@@ -221,10 +223,10 @@ def describe_parse_file():
 
         file_path.write_text(json)
 
-        with pytest.raises(ValueError) as error:
-            parse_file(file_path)
+        with pytest.raises(ValidationError) as error:
+            parse_file(file_path, labelbox_export)
 
-        assert f"bbox objects must have a 'height' value" in str(error.value)
+        assert "'height' is a required property" in str(error.value)
 
     def test_it_imports_bbox_images(file_path: Path):
         json: str = """
@@ -250,7 +252,7 @@ def describe_parse_file():
 
         file_path.write_text(json)
 
-        annotation_files: Optional[List[AnnotationFile]] = parse_file(file_path)
+        annotation_files: Optional[List[AnnotationFile]] = parse_file(file_path, labelbox_export)
         assert annotation_files is not None
 
         annotation_file: AnnotationFile = annotation_files.pop()
@@ -289,10 +291,10 @@ def describe_parse_file():
 
         file_path.write_text(json)
 
-        with pytest.raises(ValueError) as error:
-            parse_file(file_path)
+        with pytest.raises(ValidationError) as error:
+            parse_file(file_path, labelbox_export)
 
-        assert f"LabelBox Polygon Points must have an 'x' value" in str(error.value)
+        assert "'x' is a required property" in str(error.value)
 
     def test_it_raises_if_polygon_point_has_missing_y(file_path: Path):
         json: str = """
@@ -317,10 +319,10 @@ def describe_parse_file():
 
         file_path.write_text(json)
 
-        with pytest.raises(ValueError) as error:
-            parse_file(file_path)
+        with pytest.raises(ValidationError) as error:
+            parse_file(file_path, labelbox_export)
 
-        assert f"LabelBox Polygon Points must have an 'y' value" in str(error.value)
+        assert "'y' is a required property" in str(error.value)
 
     def test_it_imports_polygon_images(file_path: Path):
         json: str = """
@@ -345,7 +347,7 @@ def describe_parse_file():
 
         file_path.write_text(json)
 
-        annotation_files: Optional[List[AnnotationFile]] = parse_file(file_path)
+        annotation_files: Optional[List[AnnotationFile]] = parse_file(file_path, labelbox_export)
         assert annotation_files is not None
 
         annotation_file: AnnotationFile = annotation_files.pop()


### PR DESCRIPTION
Background
----

I have, for the first time in darwin-py's life, added JSON schema validation, this time to Labelbox. 
However, there are a couple of things I am not a big fan of:
- The error message for `oneOf` is simply wrong. It says `"point" is required` which is not true, `point` is only one of the possible valued (bbox and polygon being the others).
- After double checking, I have realized `jsonschema` is only compatible with Python 3.7 and onwards. I have to use an alternative. 

In the meantime I would like a review of the code. What do you guys think?

How can I test this?
----

Simply run `pytest`.

EDIT
----

Replaced `jsonschema` with `jsonschmea_rs` because the second one is the only one compatible with all the versions of Python `darwin-py` official supports. 

Although the issue with `oneOf` is now fixed (it does not exist in this library`, we have however another, perhaps more important issue:
- None of the missing required properties for internal objects belonging to `oneOf` are shown as missing. Instead we just get a general error "Could not match any of the schemas".

This is not really any better, one might even say the loss of granularity is so severe it can be even worst. However, it is literally the only one compatible with Python version 3.6 - 3.9.

We should probably discuss this.