### PR TITLE
Adding support for labelbox Point

### DIFF
--- a/darwin/importer/formats/labelbox.py
+++ b/darwin/importer/formats/labelbox.py
@@ -3,8 +3,6 @@ from functools import partial
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set, cast
 
-from jsonschema import ValidationError
-
 from darwin.datatypes import (
     Annotation,
     AnnotationClass,


### PR DESCRIPTION
What changed
-----

Added support for labelbox Point. 
The schema was already here, so I didnt have to add it.

How can I test it?
----

with `pytest`, as a new test was added !