### PR TITLE
Fix docs GitHub flow

### DIFF
--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -23,6 +23,8 @@ jobs:
           pip install --editable ".[test]"
           pip install torch torchvision
           pip install -U sphinx
+          # Locking mistune version so m2r works. More info on issue:
+          # https://github.com/miyakogi/m2r/issues/66
           pip install mistune==0.8.4
           pip install m2r
           pip install sphinx_rtd_theme

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -23,6 +23,7 @@ jobs:
           pip install --editable ".[test]"
           pip install torch torchvision
           pip install -U sphinx
+          pip install mistune==0.8.4
           pip install m2r
           pip install sphinx_rtd_theme
       - name: Parse README


### PR DESCRIPTION
What is happening?
------

Document generation is currently failing. This is happening because one of the dependencies used to generate the docs ( m2r ) is crashing due to a dependency management conflict (in this case mistune did a backwards incompatible release and m2r is using it because their creator doesn't believe in locked versions ... ). 

To fix this (somewhat temporarily) I have added mistune manually to the pipeline with a locked version. This fixes the issue, until the creator of m2r does a full refactoring of m2r to be compatible with mistune, or until he accepts the value of locking versions in dependency trees.

Not the easiest issue to find. 