### PR TITLE
fixing code blocks

### DIFF
--- a/darwin/importer/formats/labelbox.py
+++ b/darwin/importer/formats/labelbox.py
@@ -1,5 +1,4 @@
 import json
-from dataclasses import dataclass
 from functools import partial, reduce
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set, cast
@@ -23,30 +22,31 @@ def parse_file(path: Path, validate: Callable[[Any], None]) -> Optional[List[Ann
     Parses the given LabelBox file and maybe returns the corresponding annotations.
     The file must have a structure simillar to the following:
     
-    ```json
-    [
-        {
-            "Label":{
-                "objects":[
-                    {
-                        "title": "SomeTitle",
-                        "bbox":{"top":3558, "left":145, "height":623, "width":449}
-                    },
-                    {...}
-                ],
-                "classifications": [
-                    {
-                        "value": "a_question",
-                        "answer": {"value": "an_answer"}
-                    },
-                    ....
-                ]
+    '''
+    .. highlight:: javascript
+    .. code-block:: javascript
+        [
+            {
+                "Label":{
+                    "objects":[
+                        {
+                            "title": "SomeTitle",
+                            "bbox":{"top":3558, "left":145, "height":623, "width":449}
+                        },
+                        { }
+                    ],
+                    "classifications": [
+                        {
+                            "value": "a_question",
+                            "answer": {"value": "an_answer"}
+                        }
+                    ]
+                },
+                "External ID": "demo-image-7.jpg"
             },
-            "External ID": "demo-image-7.jpg"
-        },
-        {...}
-    ]
-    ```
+            { }
+        ]
+    '''
 
     You can check the Labelbox Schemas in `labelbox_schemas.py`.
 


### PR DESCRIPTION
We cannot display code blocks like in markdown.

The parser translates them to a sort of Italic:
https://darwin-py-sdk.v7labs.com/darwin.html#module-darwin.config

While it is clearly not code, it is passable. We could use double backtick and go for monospace.
I don't like it, but I could live with it if only it didn't create messes like this:
https://darwin-py-sdk.v7labs.com/darwin.importer.formats.html#module-darwin.importer.formats.labelbox

This PR tries to fix that.