### PR TITLE
Adding support for superannotate bbox import

### DIFF
--- a/darwin/importer/formats/superannotate.py
+++ b/darwin/importer/formats/superannotate.py
@@ -11,6 +11,7 @@ from darwin.datatypes import (
     AnnotationFile,
     CuboidData,
     Point,
+    make_bounding_box,
     make_cuboid,
     make_ellipse,
     make_keypoint,
@@ -135,6 +136,9 @@ def _convert_objects(obj: Dict[str, Any], superannotate_classes: List[Dict[str, 
     if type == "cuboid":
         return _to_cuboid_annotation(obj, superannotate_classes)
 
+    if type == "bbox":
+        return _to_bbox_annotation(obj, superannotate_classes)
+
     raise ValueError(f"Unknown label object {obj}")
 
 
@@ -145,6 +149,18 @@ def _to_keypoint_annotation(point: Dict[str, Any], classes: List[Dict[str, Any]]
 
     name = _find_class_name(class_id, classes)
     return make_keypoint(name, x, y)
+
+
+def _to_bbox_annotation(bbox: Dict[str, Any], classes: List[Dict[str, Any]]) -> Annotation:
+    points: Dict[str, float] = cast(Dict[str, float], bbox.get("points"))
+    x: float = cast(float, points.get("x1"))
+    y: float = cast(float, points.get("y1"))
+    w: float = abs(cast(float, points.get("x2")) - cast(float, points.get("x1")))
+    h: float = abs(cast(float, points.get("y1")) - cast(float, points.get("y2")))
+    class_id: int = cast(int, bbox.get("classId"))
+
+    name = _find_class_name(class_id, classes)
+    return make_bounding_box(name, x, y, w, h)
 
 
 def _to_ellipse_annotation(ellipse: Dict[str, Any], classes: List[Dict[str, Any]]) -> Annotation:

--- a/darwin/importer/formats/superannotate_schemas.py
+++ b/darwin/importer/formats/superannotate_schemas.py
@@ -1,3 +1,27 @@
+bbox = {
+    "$id": "https://darwin.v7labs.com/schemas/supperannotate/bounding_box",
+    "description": "Schema of a Bounding Box",
+    "title": "Bounding Box",
+    "default": {"type": "bbox", "points": {"x1": 1223.1, "x2": 1420.2, "y1": 607.3, "y2": 1440,}, "classId": 1,},
+    "examples": [{"type": "bbox", "points": {"x1": 587.5, "x2": 1420.2, "y1": 607.3, "y2": 1440,}, "classId": 1,}],
+    "type": "object",
+    "properties": {
+        "classId": {"type": "integer"},
+        "type": {"enum": ["bbox"]},
+        "points": {
+            "type": "object",
+            "properties": {
+                "x1": {"type": "number",},
+                "x2": {"type": "number",},
+                "y1": {"type": "number",},
+                "y2": {"type": "number",},
+            },
+            "required": ["x1", "x2", "y1", "y2"],
+        },
+    },
+    "required": ["points", "type", "classId"],
+}
+
 cuboid = {
     "$id": "https://darwin.v7labs.com/schemas/supperannotate/cuboid",
     "description": "Schema of a Cuboid",
@@ -90,7 +114,7 @@ point = {
         "classId": {"type": "integer"},
         "x": {"type": "number"},
         "y": {"type": "number"},
-        "ẗype": {"enum": ["point"]},
+        "type": {"enum": ["point"]},
     },
     "required": ["x", "y", "type", "classId"],
 }
@@ -99,7 +123,7 @@ point = {
 superannotate_export = {
     "type": "object",
     "properties": {
-        "instances": {"type": "array", "items": {"oneOf": [point, ellipse, cuboid]},},
+        "instances": {"type": "array", "items": {"oneOf": [point, ellipse, cuboid, bbox]},},
         "metadata": {"type": "object", "required": ["name"], "properties": {"name": {"type": "string"}}},
     },
     "required": ["instances", "metadata"],

--- a/tests/darwin/importer/formats/import_superannotate_test.py
+++ b/tests/darwin/importer/formats/import_superannotate_test.py
@@ -475,6 +475,34 @@ def describe_parse_path():
         annotation_class = polygon_annotation.annotation_class
         assert_annotation_class(annotation_class, "Person", "polygon")
 
+    def it_raises_if_bbox_has_missing_points(annotations_file_path: Path, classes_file_path: Path):
+        annotations_json: str = """
+          {
+            "instances": [
+               {
+                  "type": "bbox",
+                  "classId": 1,
+                  "points": {
+                     "x2": 1920,
+                     "y1": 516.5,
+                     "y2": 734
+                  }
+               }
+            ],
+            "metadata": {
+               "name": "demo-image-0.jpg"
+            }
+         }
+         """
+        classes_json: str = """[]"""
+        annotations_file_path.write_text(annotations_json)
+        classes_file_path.write_text(classes_json)
+
+        with pytest.raises(ValidationError) as error:
+            parse_path(annotations_file_path)
+
+        assert "'bbox' is not one of ['point']" in str(error.value)
+
     def it_imports_bbox_vectors(annotations_file_path: Path, classes_file_path: Path):
 
         annotations_json: str = """

--- a/tests/darwin/importer/formats/import_superannotate_test.py
+++ b/tests/darwin/importer/formats/import_superannotate_test.py
@@ -255,7 +255,7 @@ def describe_parse_path():
         with pytest.raises(ValidationError) as error:
             parse_path(annotations_file_path)
 
-        assert "'ellipse' is not one of ['cuboid']" in str(error.value)
+        assert "'ellipse' is not one of ['point']" in str(error.value)
 
     def it_imports_ellipse_vectors(annotations_file_path: Path, classes_file_path: Path):
 
@@ -338,7 +338,7 @@ def describe_parse_path():
         with pytest.raises(ValidationError) as error:
             parse_path(annotations_file_path)
 
-        assert "'cuboid' is not one of ['ellipse']" in str(error.value)
+        assert "'cuboid' is not one of ['point']" in str(error.value)
 
     def it_imports_cuboid_vectors(annotations_file_path: Path, classes_file_path: Path):
 
@@ -402,6 +402,51 @@ def describe_parse_path():
 
         annotation_class = cuboid_annotation.annotation_class
         assert_annotation_class(annotation_class, "Person", "cuboid")
+
+    def it_imports_bbox_vectors(annotations_file_path: Path, classes_file_path: Path):
+
+        annotations_json: str = """
+         {
+            "instances": [
+               {
+                  "type": "bbox",
+                  "classId": 1,
+                  "points": {
+                     "x1": 1642.9,
+                     "x2": 1920,
+                     "y1": 516.5,
+                     "y2": 734
+                  }
+               }
+            ],
+            "metadata": {
+               "name": "demo-image-0.jpg"
+            }
+         }
+      """
+        classes_json: str = """
+       [
+          {"name": "Person", "id": 1}
+       ]
+       """
+
+        annotations_file_path.write_text(annotations_json)
+        classes_file_path.write_text(classes_json)
+
+        annotation_file: Optional[AnnotationFile] = parse_path(annotations_file_path)
+        assert annotation_file is not None
+        assert annotation_file.path == annotations_file_path
+        assert annotation_file.filename == "demo-image-0.jpg"
+        assert annotation_file.annotation_classes
+        assert annotation_file.remote_path == "/"
+
+        assert annotation_file.annotations
+
+        bbox_annotation: Annotation = cast(Annotation, annotation_file.annotations.pop())
+        assert_bbox(bbox_annotation, 1642.9, 516.5, 217.5, 277.1)
+
+        annotation_class = bbox_annotation.annotation_class
+        assert_annotation_class(annotation_class, "Person", "bounding_box")
 
 
 def assert_cuboid(annotation: Annotation, cuboid: CuboidData) -> None:


### PR DESCRIPTION
How to test
----------

JSON test file:
```
{
    "instances": [
        {
            "type": "bbox",
            "classId": 2,
            "probability": 100,
            "points": {
                "x1": 1727.06,
                "x2": 3057.62,
                "y1": 1723.25,
                "y2": 2295.13
            },
            "groupId": 1,
            "pointLabels": {},
            "locked": false,
            "visible": true,
            "attributes": [
                {
                    "id": 11,
                    "groupId": 4
                }
            ]
        }
    ],
    "tags": [],
    "metadata": {
        "version": "1.0.0",
        "name": "sonnie-hiles-PUBt7UPbJFY-unsplash.jpg",
        "status": "Completed"
    }
}
```

classes.json file:
```
[
    {
        "attribute_groups": [
            {
                "id": 1,
                "name": "Sex",
                "is_multiselect": false,
                "attributes": [
                    {
                        "id": 1,
                        "name": "Male"
                    },
                    {
                        "id": 2,
                        "name": "Female"
                    }
                ],
                "opened": true,
                "hasChanges": false
            },
            {
                "id": 2,
                "name": "Emotion",
                "is_multiselect": false,
                "attributes": [
                    {
                        "id": 3,
                        "name": "Smiling"
                    },
                    {
                        "id": 4,
                        "name": "Sadness"
                    },
                    {
                        "id": 5,
                        "name": "Crying"
                    }
                ],
                "opened": true,
                "hasChanges": false
            },
            {
                "id": 3,
                "name": "Action",
                "is_multiselect": false,
                "attributes": [
                    {
                        "id": 6,
                        "name": "Skateboarding"
                    },
                    {
                        "id": 7,
                        "name": "Skating"
                    },
                    {
                        "id": 8,
                        "name": "Riding"
                    },
                    {
                        "id": 9,
                        "name": "Running"
                    },
                    {
                        "id": 10,
                        "name": "Swimming"
                    }
                ],
                "opened": true,
                "hasChanges": false
            }
        ],
        "color": "#fd7007",
        "id": 2,
        "name": "Pedestrian",
        "opened": true
    }
]
```

command used to test:

```
darwin dataset import cars superannotate /home/pedro/Downloads/mysupertest/
```

Issues
--------

Cannot rotate bbox in my machine:
https://doc.superannotate.com/changelog/whats-new-february-3-2021

There also seems to be no differentiation between a normal bbox and a rotated one:
https://doc.superannotate.com/docs/vector-json#bounding-box-and-rotated-bounding-box

I am not sure how to address these issues.