### PR TITLE
added superannotate types to class name

### DIFF
--- a/darwin/importer/formats/superannotate.py
+++ b/darwin/importer/formats/superannotate.py
@@ -159,7 +159,7 @@ def _to_keypoint_annotation(point: Dict[str, Any], classes: List[Dict[str, Any]]
     class_id: int = cast(int, point.get("classId"))
 
     name = _find_class_name(class_id, classes)
-    return make_keypoint(name + "-point", x, y)
+    return make_keypoint(f"{name}-point", x, y)
 
 
 def _to_bbox_annotation(bbox: Dict[str, Any], classes: List[Dict[str, Any]]) -> Annotation:
@@ -171,7 +171,7 @@ def _to_bbox_annotation(bbox: Dict[str, Any], classes: List[Dict[str, Any]]) -> 
     class_id: int = cast(int, bbox.get("classId"))
 
     name = _find_class_name(class_id, classes)
-    return make_bounding_box(name + "-bbox", x, y, w, h)
+    return make_bounding_box(f"{name}-bbox", x, y, w, h)
 
 
 def _to_ellipse_annotation(ellipse: Dict[str, Any], classes: List[Dict[str, Any]]) -> Annotation:
@@ -182,7 +182,7 @@ def _to_ellipse_annotation(ellipse: Dict[str, Any], classes: List[Dict[str, Any]
     class_id: int = cast(int, ellipse.get("classId"))
 
     name = _find_class_name(class_id, classes)
-    return make_ellipse(name + "-ellipse", ellipse_data)
+    return make_ellipse(f"{name}-ellipse", ellipse_data)
 
 
 def _to_cuboid_annotation(cuboid: Dict[str, Any], classes: List[Dict[str, Any]]) -> Annotation:
@@ -209,7 +209,7 @@ def _to_cuboid_annotation(cuboid: Dict[str, Any], classes: List[Dict[str, Any]])
     class_id: int = cast(int, cuboid.get("classId"))
 
     name = _find_class_name(class_id, classes)
-    return make_cuboid(name + "-cuboid", cuboid_data)
+    return make_cuboid(f"{name}-cuboid", cuboid_data)
 
 
 def _to_polygon_annotation(polygon: Dict[str, Any], classes: List[Dict[str, Any]]) -> Annotation:
@@ -218,7 +218,7 @@ def _to_polygon_annotation(polygon: Dict[str, Any], classes: List[Dict[str, Any]
     name: str = _find_class_name(class_id, classes)
     points: List[Point] = _map_to_list(_tuple_to_point, _group_to_list(data, 2, 0))
 
-    return make_polygon(name + "-polygon", points)
+    return make_polygon(f"{name}-polygon", points)
 
 
 def _to_line_annotation(line: Dict[str, Any], classes: List[Dict[str, Any]]) -> Annotation:
@@ -227,7 +227,7 @@ def _to_line_annotation(line: Dict[str, Any], classes: List[Dict[str, Any]]) -> 
     name: str = _find_class_name(class_id, classes)
     points: List[Point] = _map_to_list(_tuple_to_point, _group_to_list(data, 2, 0))
 
-    return make_line(name + "-polyline", points)
+    return make_line(f"{name}-polyline", points)
 
 
 def _find_class_name(class_id: int, classes: List[Dict[str, Any]]) -> str:

--- a/darwin/importer/formats/superannotate.py
+++ b/darwin/importer/formats/superannotate.py
@@ -159,7 +159,7 @@ def _to_keypoint_annotation(point: Dict[str, Any], classes: List[Dict[str, Any]]
     class_id: int = cast(int, point.get("classId"))
 
     name = _find_class_name(class_id, classes)
-    return make_keypoint(name, x, y)
+    return make_keypoint(name + "-point", x, y)
 
 
 def _to_bbox_annotation(bbox: Dict[str, Any], classes: List[Dict[str, Any]]) -> Annotation:
@@ -171,7 +171,7 @@ def _to_bbox_annotation(bbox: Dict[str, Any], classes: List[Dict[str, Any]]) -> 
     class_id: int = cast(int, bbox.get("classId"))
 
     name = _find_class_name(class_id, classes)
-    return make_bounding_box(name, x, y, w, h)
+    return make_bounding_box(name + "-bbox", x, y, w, h)
 
 
 def _to_ellipse_annotation(ellipse: Dict[str, Any], classes: List[Dict[str, Any]]) -> Annotation:
@@ -182,7 +182,7 @@ def _to_ellipse_annotation(ellipse: Dict[str, Any], classes: List[Dict[str, Any]
     class_id: int = cast(int, ellipse.get("classId"))
 
     name = _find_class_name(class_id, classes)
-    return make_ellipse(name, ellipse_data)
+    return make_ellipse(name + "-ellipse", ellipse_data)
 
 
 def _to_cuboid_annotation(cuboid: Dict[str, Any], classes: List[Dict[str, Any]]) -> Annotation:
@@ -209,7 +209,7 @@ def _to_cuboid_annotation(cuboid: Dict[str, Any], classes: List[Dict[str, Any]])
     class_id: int = cast(int, cuboid.get("classId"))
 
     name = _find_class_name(class_id, classes)
-    return make_cuboid(name, cuboid_data)
+    return make_cuboid(name + "-cuboid", cuboid_data)
 
 
 def _to_polygon_annotation(polygon: Dict[str, Any], classes: List[Dict[str, Any]]) -> Annotation:
@@ -218,7 +218,7 @@ def _to_polygon_annotation(polygon: Dict[str, Any], classes: List[Dict[str, Any]
     name: str = _find_class_name(class_id, classes)
     points: List[Point] = _map_to_list(_tuple_to_point, _group_to_list(data, 2, 0))
 
-    return make_polygon(name, points)
+    return make_polygon(name + "-polygon", points)
 
 
 def _to_line_annotation(line: Dict[str, Any], classes: List[Dict[str, Any]]) -> Annotation:
@@ -227,7 +227,7 @@ def _to_line_annotation(line: Dict[str, Any], classes: List[Dict[str, Any]]) -> 
     name: str = _find_class_name(class_id, classes)
     points: List[Point] = _map_to_list(_tuple_to_point, _group_to_list(data, 2, 0))
 
-    return make_line(name, points)
+    return make_line(name + "-polyline", points)
 
 
 def _find_class_name(class_id: int, classes: List[Dict[str, Any]]) -> str:

--- a/tests/darwin/importer/formats/import_superannotate_test.py
+++ b/tests/darwin/importer/formats/import_superannotate_test.py
@@ -229,7 +229,7 @@ def describe_parse_path():
         assert_point(point_annotation, {"x": 1.93, "y": 0.233})
 
         annotation_class = point_annotation.annotation_class
-        assert_annotation_class(annotation_class, "Person", "keypoint")
+        assert_annotation_class(annotation_class, "Person-point", "keypoint")
 
     def it_raises_if_ellipse_has_missing_coordinate(annotations_file_path: Path, classes_file_path: Path):
         annotations_json: str = """
@@ -301,7 +301,7 @@ def describe_parse_path():
         )
 
         annotation_class = ellipse_annotation.annotation_class
-        assert_annotation_class(annotation_class, "Person", "ellipse")
+        assert_annotation_class(annotation_class, "Person-ellipse", "ellipse")
 
     def it_raises_if_cuboid_has_missing_point(annotations_file_path: Path, classes_file_path: Path):
         annotations_json: str = """
@@ -401,7 +401,7 @@ def describe_parse_path():
         )
 
         annotation_class = cuboid_annotation.annotation_class
-        assert_annotation_class(annotation_class, "Person", "cuboid")
+        assert_annotation_class(annotation_class, "Person-cuboid", "cuboid")
 
     def it_raises_if_polygon_has_missing_points(annotations_file_path: Path, classes_file_path: Path):
         annotations_json: str = """
@@ -473,7 +473,7 @@ def describe_parse_path():
         )
 
         annotation_class = polygon_annotation.annotation_class
-        assert_annotation_class(annotation_class, "Person", "polygon")
+        assert_annotation_class(annotation_class, "Person-polygon", "polygon")
 
     def it_raises_if_polyline_has_missing_points(annotations_file_path: Path, classes_file_path: Path):
         annotations_json: str = """
@@ -545,7 +545,7 @@ def describe_parse_path():
         )
 
         annotation_class = line_annotation.annotation_class
-        assert_annotation_class(annotation_class, "Person", "line")
+        assert_annotation_class(annotation_class, "Person-polyline", "line")
 
     def it_raises_if_bbox_has_missing_points(annotations_file_path: Path, classes_file_path: Path):
         annotations_json: str = """
@@ -618,7 +618,7 @@ def describe_parse_path():
         assert_bbox(bbox_annotation, 1642.9, 516.5, 217.5, 277.1)
 
         annotation_class = bbox_annotation.annotation_class
-        assert_annotation_class(annotation_class, "Person", "bounding_box")
+        assert_annotation_class(annotation_class, "Person-bbox", "bounding_box")
 
 
 def assert_cuboid(annotation: Annotation, cuboid: CuboidData) -> None:


### PR DESCRIPTION
Background
--------

With  SuperAnnotate you can have a class name being used for multiple types. 
Example: you have a cat class, and you can create polygon , bounding_box or ellipse annotations with it

This PR adds the SuperAnnotate type to the end of the class name, this way we will be able to support this feature because for Darwin these will be different Annotations: `cat-polygon, cat-bounding_box and cat-ellipse`