### PR TITLE
Add comments to items in datasets 

### DIFF
--- a/darwin/cli.py
+++ b/darwin/cli.py
@@ -14,12 +14,12 @@ from darwin.options import Options
 
 def main() -> None:
     """
-    Executes the main function of program. 
+    Executes the main function of program.
 
     Raises
     ------
     Unauthorized
-        If the API key with which the use is authenticated does not grant access for the given 
+        If the API key with which the use is authenticated does not grant access for the given
         action.
     Unauthenticated
         If a given action needs authentication and you are not authenticated.
@@ -123,6 +123,16 @@ def _run(args: Namespace, parser: ArgumentParser) -> None:
             f.split(args.dataset, args.val_percentage, args.test_percentage, args.seed)
         elif args.action == "help" or args.action is None:
             f.help(parser, "dataset")
+        elif args.action == "comment":
+            f.post_comment(
+                args.dataset,
+                args.file,
+                args.comment_text,
+                args.comment_x_position,
+                args.comment_y_position,
+                args.comment_width_px,
+                args.comment_height_px,
+            )
 
 
 if __name__ == "__main__":

--- a/darwin/cli.py
+++ b/darwin/cli.py
@@ -125,13 +125,7 @@ def _run(args: Namespace, parser: ArgumentParser) -> None:
             f.help(parser, "dataset")
         elif args.action == "comment":
             f.post_comment(
-                args.dataset,
-                args.file,
-                args.comment_text,
-                args.comment_x_position,
-                args.comment_y_position,
-                args.comment_width_px,
-                args.comment_height_px,
+                args.dataset, args.file, args.text, args.x, args.y, args.w, args.h,
             )
 
 

--- a/darwin/cli_functions.py
+++ b/darwin/cli_functions.py
@@ -885,7 +885,29 @@ def post_comment(
     dataset_slug: str, filename: str, text: str, x: float = 1, y: float = 1, w: float = 1, h: float = 1
 ) -> None:
     """
-    
+    Creates a comment box with a comment for the given file in the given dataset.
+
+    Parameters
+    ----------
+    dataset_slug: str
+        The slug of the dataset the item belongs to.
+    filename: str
+        The filename to receive the commment.
+    text: str
+        The comment.
+    x: float, default: 1
+        X value of the top left coordinate for the comment box.
+    y: float, default: 1
+        Y value of the top left coordinate for the comment box.
+    w: float, default: 1
+        Width of the comment box.
+    h: float, default: 1
+        Height of the comment box.
+
+    Raises
+    ------
+    NotFound
+        If the Dataset was not found.
     """
     client: Client = _load_client(dataset_identifier=dataset_slug)
     console = Console()
@@ -906,7 +928,7 @@ def post_comment(
             if maybe_workflow_id is None:
                 workflow_id: int = client.instantitate_item(item.id)
             else:
-                workflow_id: int = maybe_workflow_id
+                workflow_id = maybe_workflow_id
 
             client.post_workflow_comment(workflow_id, text, x, y, w, h)
             console.print("[bold green]Comment added successfully!")

--- a/darwin/client.py
+++ b/darwin/client.py
@@ -716,7 +716,7 @@ class Client:
 
     def post_workflow_comment(
         self, workflow_id: int, text: str, x: float = 1, y: float = 1, w: float = 1, h: float = 1
-    ) -> None:
+    ) -> int:
         """
         Creates a comment box with the given text for the given workflow.
 
@@ -734,11 +734,25 @@ class Client:
             The width of the comment box.
         h: float, default: 1
             The height of the comment box.
+
+        Returns
+        -------
+        int
+            The id of the created comment.
         """
-        self._post(
-            f"workflows/{workflow_id}/workflow_comment_threads",
-            {"bounding_box": {"x": x, "y": y, "w": w, "h": h}, "workflow_comments": [{"body": text}]},
+        response: Dict[str, Any] = cast(
+            Dict[str, Any],
+            self._post(
+                f"workflows/{workflow_id}/workflow_comment_threads",
+                {"bounding_box": {"x": x, "y": y, "w": w, "h": h}, "workflow_comments": [{"body": text}]},
+            ),
         )
+
+        comment_id: Optional[int] = response.get("id")
+        if comment_id is None:
+            raise ValueError(f"Unable to retrieve comment id for workflow: {workflow_id}.")
+
+        return comment_id
 
     def instantitate_item(self, item_id: int) -> int:
         """
@@ -760,7 +774,7 @@ class Client:
             If due to an error, no workflow was instantiated for this item an therefore no workflow id can be returned.
         """
         response: Dict[str, Any] = cast(Dict[str, Any], self._post(f"dataset_items/{item_id}/workflow"))
-        id: Optional[int] = response["current_workflow_id"]
+        id: Optional[int] = response.get("current_workflow_id")
 
         if id is None:
             raise ValueError(f"No Workflow Id found for item_id: {item_id}")

--- a/darwin/client.py
+++ b/darwin/client.py
@@ -714,6 +714,59 @@ class Client:
         """
         self._put_raw(f"teams/{team_slug}/datasets/{dataset_slug}/items/reset", payload, team_slug)
 
+    def post_workflow_comment(
+        self, workflow_id: int, text: str, x: float = 1, y: float = 1, w: float = 1, h: float = 1
+    ) -> None:
+        """
+        Creates a comment box with the given text for the given workflow.
+
+        Parameters
+        ----------
+        workflow_id: int
+            The id of the workflow that will receive the comment.
+        text: str
+            The comment itself. 
+        x: float, default: 1
+            The top left X coordinate value of the comment box.
+        y: float, default: 1
+            The top left Y coordinate value of the comment box.
+        w: float, default: 1
+            The width of the comment box.
+        h: float, default: 1
+            The height of the comment box.
+        """
+        self._post(
+            f"workflows/{workflow_id}/workflow_comment_threads",
+            {"bounding_box": {"x": x, "y": y, "w": w, "h": h}, "workflow_comments": [{"body": text}]},
+        )
+
+    def instantitate_item(self, item_id: int) -> int:
+        """
+        Instantiates the given item with a workflow.
+
+        Parameters
+        ----------
+        item_id: int
+            The id of the item to be instantiated.
+        
+        Returns
+        -------
+        int
+            The id of the workflow for the given item.
+        
+        Raises
+        ------
+        ValueError
+            If due to an error, no workflow was instantiated for this item an therefore no workflow id can be returned.
+        """
+        response: Dict[str, Any] = cast(Dict[str, Any], self._post(f"dataset_items/{item_id}/workflow"))
+        id: Optional[int] = response["current_workflow_id"]
+
+        if id is None:
+            raise ValueError(f"No Workflow Id found for item_id: {item_id}")
+
+        return id
+
     @classmethod
     def local(cls, team_slug: Optional[str] = None) -> "Client":
         """

--- a/darwin/options.py
+++ b/darwin/options.py
@@ -217,10 +217,10 @@ class Options(object):
         )
         parser_comment.add_argument("file", type=str, help="File to comment")
         parser_comment.add_argument("--comment-text", type=str, help="Comment: list of words")
-        parser_comment.add_argument("--comment-x-position", type=int, default=1, help="X coordinate for comment")
-        parser_comment.add_argument("--comment-y-position", type=int, default=1, help="Y coordinate for comment")
-        parser_comment.add_argument("--comment-width-px", type=int, default=1, help="Comment width in pixels")
-        parser_comment.add_argument("--comment-height-px", type=int, default=1, help="Comment height in pixels")
+        parser_comment.add_argument("--comment-x-position", type=float, default=1, help="X coordinate for comment")
+        parser_comment.add_argument("--comment-y-position", type=float, default=1, help="Y coordinate for comment")
+        parser_comment.add_argument("--comment-width-px", type=float, default=1, help="Comment width in pixels")
+        parser_comment.add_argument("--comment-height-px", type=float, default=1, help="Comment height in pixels")
 
         # Help
         dataset_action.add_parser("help", help="Show this help message and exit.")

--- a/darwin/options.py
+++ b/darwin/options.py
@@ -1,4 +1,3 @@
-import argparse
 import sys
 from argparse import ArgumentParser, Namespace
 from typing import Tuple

--- a/darwin/options.py
+++ b/darwin/options.py
@@ -217,10 +217,18 @@ class Options(object):
         )
         parser_comment.add_argument("file", type=str, help="File to comment")
         parser_comment.add_argument("--comment-text", type=str, help="Comment: list of words")
-        parser_comment.add_argument("--comment-x-position", type=float, default=1, help="X coordinate for comment")
-        parser_comment.add_argument("--comment-y-position", type=float, default=1, help="Y coordinate for comment")
-        parser_comment.add_argument("--comment-width-px", type=float, default=1, help="Comment width in pixels")
-        parser_comment.add_argument("--comment-height-px", type=float, default=1, help="Comment height in pixels")
+        parser_comment.add_argument(
+            "--comment-x-position", required=False, type=float, default=1, help="X coordinate for comment"
+        )
+        parser_comment.add_argument(
+            "--comment-y-position", required=False, type=float, default=1, help="Y coordinate for comment"
+        )
+        parser_comment.add_argument(
+            "--comment-width-px", required=False, type=float, default=1, help="Comment width in pixels"
+        )
+        parser_comment.add_argument(
+            "--comment-height-px", required=False, type=float, default=1, help="Comment height in pixels"
+        )
 
         # Help
         dataset_action.add_parser("help", help="Show this help message and exit.")

--- a/darwin/options.py
+++ b/darwin/options.py
@@ -216,18 +216,14 @@ class Options(object):
             help="[Remote] Dataset name: to list all the existing dataset, run 'darwin dataset remote'. ",
         )
         parser_comment.add_argument("file", type=str, help="File to comment")
-        parser_comment.add_argument("--comment-text", type=str, help="Comment: list of words")
+        parser_comment.add_argument("--text", type=str, help="Comment: list of words")
+        parser_comment.add_argument("--x", required=False, type=float, default=1, help="X coordinate for comment box")
+        parser_comment.add_argument("--y", required=False, type=float, default=1, help="Y coordinate for comment box")
         parser_comment.add_argument(
-            "--comment-x-position", required=False, type=float, default=1, help="X coordinate for comment"
+            "--w", "--width", required=False, type=float, default=1, help="Comment box width in pixels"
         )
         parser_comment.add_argument(
-            "--comment-y-position", required=False, type=float, default=1, help="Y coordinate for comment"
-        )
-        parser_comment.add_argument(
-            "--comment-width-px", required=False, type=float, default=1, help="Comment width in pixels"
-        )
-        parser_comment.add_argument(
-            "--comment-height-px", required=False, type=float, default=1, help="Comment height in pixels"
+            "--h", "--height", required=False, type=float, default=1, help="Comment box height in pixels"
         )
 
         # Help

--- a/darwin/options.py
+++ b/darwin/options.py
@@ -209,6 +209,20 @@ class Options(object):
             help="Confirmation flag to delete the file without prompting for manual input.",
         )
 
+        # Add comments
+        parser_comment = dataset_action.add_parser("comment", help="Comment image.")
+        parser_comment.add_argument(
+            "dataset",
+            type=str,
+            help="[Remote] Dataset name: to list all the existing dataset, run 'darwin dataset remote'. ",
+        )
+        parser_comment.add_argument("file", type=str, help="File to comment")
+        parser_comment.add_argument("--comment-text", type=str, help="Comment: list of words")
+        parser_comment.add_argument("--comment-x-position", type=int, default=1, help="X coordinate for comment")
+        parser_comment.add_argument("--comment-y-position", type=int, default=1, help="Y coordinate for comment")
+        parser_comment.add_argument("--comment-width-px", type=int, default=1, help="Comment width in pixels")
+        parser_comment.add_argument("--comment-height-px", type=int, default=1, help="Comment height in pixels")
+
         # Help
         dataset_action.add_parser("help", help="Show this help message and exit.")
 

--- a/tests/darwin/client_test.py
+++ b/tests/darwin/client_test.py
@@ -207,6 +207,58 @@ def describe_get_team_features():
         ]
 
 
+@pytest.mark.usefixtures("file_read_write_test")
+def describe_instantitate_item():
+    @responses.activate
+    def it_raises_if_workflow_id_is_not_found(darwin_client: Client):
+        item_id: int = 1234
+        endpoint: str = f"/dataset_items/{item_id}/workflow"
+        json_response: Dict[str, Any] = {}
+
+        responses.add(responses.POST, darwin_client.url + endpoint, json=json_response, status=200)
+
+        with pytest.raises(ValueError) as exception:
+            darwin_client.instantitate_item(item_id)
+
+        assert str(exception.value) == f"No Workflow Id found for item_id: {item_id}"
+
+    @responses.activate
+    def it_returns_workflow_id(darwin_client: Client):
+        item_id: int = 1234
+        workflow_id: int = 1
+        endpoint: str = f"/dataset_items/{item_id}/workflow"
+        json_response: Dict[str, Any] = {"current_workflow_id": workflow_id}
+
+        responses.add(responses.POST, darwin_client.url + endpoint, json=json_response, status=200)
+        assert darwin_client.instantitate_item(item_id) == workflow_id
+
+
+@pytest.mark.usefixtures("file_read_write_test")
+def describe_post_workflow_comment():
+    @responses.activate
+    def it_raises_if_comment_id_is_not_found(darwin_client: Client):
+        workflow_id = 1234
+        endpoint: str = f"/workflows/{workflow_id}/workflow_comment_threads"
+        json_response: Dict[str, Any] = {}
+
+        responses.add(responses.POST, darwin_client.url + endpoint, json=json_response, status=200)
+
+        with pytest.raises(ValueError) as exception:
+            darwin_client.post_workflow_comment(workflow_id, "My comment.")
+
+        assert str(exception.value) == f"Unable to retrieve comment id for workflow: {workflow_id}."
+
+    @responses.activate
+    def it_returns_comment_id(darwin_client: Client):
+        comment_id: int = 1234
+        workflow_id: int = 1
+        endpoint: str = f"/workflows/{workflow_id}/workflow_comment_threads"
+        json_response: Dict[str, Any] = {"id": comment_id}
+
+        responses.add(responses.POST, darwin_client.url + endpoint, json=json_response, status=200)
+        assert darwin_client.post_workflow_comment(workflow_id, "My comment.") == comment_id
+
+
 def assert_dataset(dataset_1, dataset_2):
     assert dataset_1.name == dataset_2.name
     assert dataset_1.team == dataset_2.team


### PR DESCRIPTION
What ?
-------

A client of ours added this functionality a while ago to their version of darwin-py and then they got mad when they updated to the newest version and realized their changes to the cloned project were gone ( go figure ! )

This PR adds the functionality of adding a comment to a file via CLI and SDK.

How to test it?
----------

Pick a dataset and a file and use the following command:

(all the args passed with `--` are OPTIONAL, meaning you only have to pass the dataset slug, filename and the text_comment):

```
dataset comment {DATASET_SLUG} {FILENAME} --text {TEXT_COMMENT} --x {X} --y {Y} --w {WIDTH} --h {HEIGHT}
```

You should then see a comment box with your comment on the image.
