### PR TITLE
Hotfix/compute distributions

### DIFF
--- a/darwin/dataset/utils.py
+++ b/darwin/dataset/utils.py
@@ -496,6 +496,8 @@ def compute_distributions(
     for partition in partitions:
         for annotation_type in annotation_types:
             split_file: Path = split_path / f"stratified_{annotation_type}_{partition}.txt"
+            if not split_file.exists():
+                split_file = split_path / f"random_{partition}.txt"
             stems: List[str] = [e.rstrip("\n\r") for e in split_file.open()]
 
             for stem in stems:

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setuptools.setup(
         "darwin.exporter",
         "darwin.importer.formats",
         "darwin.exporter.formats",
+        "darwin.version",
     ],
     entry_points={"console_scripts": ["darwin=darwin.cli:main"]},
     classifiers=["Programming Language :: Python :: 3", "License :: OSI Approved :: MIT License"],


### PR DESCRIPTION
Hotfix for darwin-py within model integrations:

```
** fvcore version of PathManager will be deprecated soon. **
** Please migrate to the version in iopath repo. **
https://github.com/facebookresearch/iopath

** fvcore version of PathManager will be deprecated soon. **
** Please migrate to the version in iopath repo. **
https://github.com/facebookresearch/iopath

Traceback (most recent call last):
  File "/home/user/app/gust_entry.py", line 15, in <module>
    from darwin.utils import convert_sequences_to_polygons, convert_xyxy_to_bounding_box
  File "/opt/conda/lib/python3.9/site-packages/darwin/__init__.py", line 1, in <module>
    import darwin.dataset  # noqa
  File "/opt/conda/lib/python3.9/site-packages/darwin/dataset/__init__.py", line 1, in <module>
    from darwin.dataset.local_dataset import LocalDataset  # noqa
  File "/opt/conda/lib/python3.9/site-packages/darwin/dataset/local_dataset.py", line 7, in <module>
    from darwin.dataset.utils import get_classes, get_release_path, load_pil_image
  File "/opt/conda/lib/python3.9/site-packages/darwin/dataset/utils.py", line 12, in <module>
    from darwin.importer.formats.darwin import parse_path
  File "/opt/conda/lib/python3.9/site-packages/darwin/importer/__init__.py", line 5, in <module>
    from .importer import import_annotations  # noqa
  File "/opt/conda/lib/python3.9/site-packages/darwin/importer/importer.py", line 21, in <module>
    from darwin.utils import secure_continue_request
  File "/opt/conda/lib/python3.9/site-packages/darwin/utils.py", line 29, in <module>
    from darwin.version import __version__
ModuleNotFoundError: No module named 'darwin.version'
```
