### PR TITLE
Feature/preserve extra text on coco import

### DIFF
--- a/darwin/importer/formats/coco.py
+++ b/darwin/importer/formats/coco.py
@@ -27,7 +27,6 @@ def parse_json(path: Path, data: Dict[str, Any]) -> Iterator[dt.AnnotationFile]:
         image_id = annotation["image_id"]
         annotation["category_id"]
         annotation["segmentation"]
-
         if image_id not in image_annotations:
             image_annotations[image_id] = []
         image_annotations[image_id].append(parse_annotation(annotation, category_lookup_table))


### PR DESCRIPTION
We would like to add a feature to the COCO importing logic, to allow us to add a field to the import COCO that will be preserved in the output COCO.

Specifically, we were planning to use the `extra.text` field of an annotation to store an ID.

I would have liked to submit this in a working state, but have not been able to get the field to persist when exporting (from the web interface), so am hoping for a nudge in the right direction.