### PR TITLE
Addes --yes flag to skip prompts when importing

### DIFF
--- a/darwin/cli.py
+++ b/darwin/cli.py
@@ -112,7 +112,7 @@ def _run(args: Namespace, parser: ArgumentParser) -> None:
         elif args.action == "pull":
             f.pull_dataset(args.dataset, args.only_annotations, args.folders, args.video_frames)
         elif args.action == "import":
-            f.dataset_import(args.dataset, args.format, args.files, args.append)
+            f.dataset_import(args.dataset, args.format, args.files, args.append, args.yes)
         elif args.action == "convert":
             f.dataset_convert(args.dataset, args.format, args.output_dir)
         elif args.action == "set-file-status":
@@ -125,7 +125,13 @@ def _run(args: Namespace, parser: ArgumentParser) -> None:
             f.help(parser, "dataset")
         elif args.action == "comment":
             f.post_comment(
-                args.dataset, args.file, args.text, args.x, args.y, args.w, args.h,
+                args.dataset,
+                args.file,
+                args.text,
+                args.x,
+                args.y,
+                args.w,
+                args.h,
             )
 
 

--- a/darwin/cli.py
+++ b/darwin/cli.py
@@ -112,7 +112,7 @@ def _run(args: Namespace, parser: ArgumentParser) -> None:
         elif args.action == "pull":
             f.pull_dataset(args.dataset, args.only_annotations, args.folders, args.video_frames)
         elif args.action == "import":
-            f.dataset_import(args.dataset, args.format, args.files, args.append, args.yes)
+            f.dataset_import(args.dataset, args.format, args.files, args.append, not args.yes)
         elif args.action == "convert":
             f.dataset_convert(args.dataset, args.format, args.output_dir)
         elif args.action == "set-file-status":

--- a/darwin/cli_functions.py
+++ b/darwin/cli_functions.py
@@ -609,13 +609,15 @@ def upload_data(
 
         if already_existing_items:
             console.print(
-                f"Skipped {len(already_existing_items)} files already in the dataset.\n", style="warning",
+                f"Skipped {len(already_existing_items)} files already in the dataset.\n",
+                style="warning",
             )
 
         if upload_manager.error_count or other_skipped_items:
             error_count = upload_manager.error_count + len(other_skipped_items)
             console.print(
-                f"{error_count} files couldn't be uploaded because an error occurred.\n", style="error",
+                f"{error_count} files couldn't be uploaded because an error occurred.\n",
+                style="error",
             )
 
         if not verbose and upload_manager.error_count:
@@ -659,7 +661,9 @@ def upload_data(
         _error(f"No files found")
 
 
-def dataset_import(dataset_slug: str, format: str, files: List[PathLike], append: bool) -> None:
+def dataset_import(
+    dataset_slug: str, format: str, files: List[PathLike], append: bool, class_prompt: bool = True
+) -> None:
     """
     Imports annotation files to the given dataset.
     Exits the application if no dataset with the given slug is found.
@@ -682,7 +686,7 @@ def dataset_import(dataset_slug: str, format: str, files: List[PathLike], append
     try:
         parser: ImportParser = get_importer(format)
         dataset: RemoteDataset = client.get_remote_dataset(dataset_identifier=dataset_slug)
-        import_annotations(dataset, parser, files, append)
+        import_annotations(dataset, parser, files, append, class_prompt)
     except ImporterNotFoundError:
         _error(f"Unsupported import format: {format}, currently supported: {import_formats}")
     except AttributeError:

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -122,6 +122,7 @@ def import_annotations(
     importer: Callable[[Path], Union[List[dt.AnnotationFile], dt.AnnotationFile, None]],
     file_paths: List[PathLike],
     append: bool,
+    class_prompt: bool = True,
 ) -> None:
     """
     Imports the given given Annotations into the given Dataset.
@@ -137,6 +138,8 @@ def import_annotations(
         A list of `Path`'s or strings containing the Annotations we wish to import.
     append : bool
         If `True` appends the given annotations to the datasets. If `False` will override them.
+    class_prompt : bool
+        If `False` classes will be created and added to the datasets without require user prompt.
 
     Returns
     -------
@@ -190,7 +193,7 @@ def import_annotations(
         for local_file in local_files_missing_remotely:
             print(f"\t{local_file.path}: '{local_file.full_path}'")
 
-        if not secure_continue_request():
+        if class_prompt and not secure_continue_request():
             return
 
     local_classes_not_in_dataset, local_classes_not_in_team = _resolve_annotation_classes(
@@ -216,7 +219,7 @@ def import_annotations(
             print(
                 f"\t{missing_class.name}, type: {missing_class.annotation_internal_type or missing_class.annotation_type}"
             )
-        if not secure_continue_request():
+        if class_prompt and not secure_continue_request():
             return
         for missing_class in local_classes_not_in_team:
             dataset.create_annotation_class(

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -133,17 +133,17 @@ def import_annotations(
         Dataset where the Annotations will be imported to.
     importer : Callable[[Path], Union[List[dt.AnnotationFile], dt.AnnotationFile, None]]
         Parsing module containing the logic to parse the given Annotation files given in
-        `files_path`. See `importer/format` for a list of out of supported parsers.
+        ``files_path``. See ``importer/format`` for a list of out of supported parsers.
     file_paths : List[PathLike]
-        A list of `Path`'s or strings containing the Annotations we wish to import.
+        A list of ``Path``'s or strings containing the Annotations we wish to import.
     append : bool
-        If `True` appends the given annotations to the datasets. If `False` will override them.
+        If ``True`` appends the given annotations to the datasets. If ``False`` will override them.
     class_prompt : bool
-        If `False` classes will be created and added to the datasets without require user prompt.
+        If ``False`` classes will be created and added to the datasets without requiring a user's prompt.
 
     Returns
     -------
-        None
+    None
 
     Raises
     -------

--- a/darwin/options.py
+++ b/darwin/options.py
@@ -145,6 +145,9 @@ class Options(object):
 
         parser_import.add_argument("files", type=str, nargs="+", help="Annotation files (or folders) to import.")
         parser_import.add_argument("--append", action="store_true", help="Append annotations instead of overwriting.")
+        parser_import.add_argument(
+            "--yes", action="store_true", help="Skips prompts for creating and adding classes to dataset"
+        )
 
         # Convert
         parser_convert = dataset_action.add_parser("convert", help="Converts darwin json to other annotation formats.")

--- a/tests/darwin/cli_functions_test.py
+++ b/tests/darwin/cli_functions_test.py
@@ -1,5 +1,4 @@
 import builtins
-import logging
 import sys
 from unittest.mock import call, patch
 


### PR DESCRIPTION
Allows for 
```sh
darwin dataset import --yes my-dataset darwin.json
```

And 
```python
 import_annotations(dataset, parser, files, append, class_prompt=False)
```

to skip the `secure_continue_request` prompts.
