### PR TITLE
Support yolo export for bounding boxes

### DIFF
--- a/darwin/datatypes.py
+++ b/darwin/datatypes.py
@@ -284,6 +284,53 @@ class AnnotationFile:
         return construct_full_path(self.remote_path, self.filename)
 
 
+@dataclass(frozen=True, eq=True)
+class ConversionError:
+    """
+    Represents a failed conversion to YOLO format.
+
+    Attributes
+    ----------
+    reason : str
+        The reason on why the conversion failed.
+    annotation : Union[Annotation, VideoAnnotation]
+        The annotation that failed to be converted.
+    filename : Path
+        The path of the ``AnnotationFile`` holding the failed ``Annotation``.
+    """
+
+    reason: str
+    annotation: Union[Annotation, VideoAnnotation]
+    filename: Path
+
+
+@dataclass(frozen=True, eq=True)
+class YoloAnnotation:
+    """
+    Represents a YOLO annotation ready to be persisted as a bounding box.
+    The XY coordinates represent the top left corner of said bounding box.
+
+    Attributes
+    ----------
+    annotation_class : str
+        The name of the ``AnnotationClass``.
+    x : float
+        Left X coordinate of the bounding box.
+    y : float
+        Top Y coordinate of the bounding box.
+    width : float
+        Width of the bounding box.
+    height : float
+        Height of the bounding box.
+    """
+
+    annotation_class: str
+    x: float
+    y: float
+    width: float
+    height: float
+
+
 def make_bounding_box(
     class_name: str, x: float, y: float, w: float, h: float, subs: Optional[List[SubAnnotation]] = None
 ) -> Annotation:
@@ -383,7 +430,7 @@ def make_complex_polygon(
     subs: Optional[List[SubAnnotation]] = None,
 ) -> Annotation:
     """
-    Creates and returns a conplex polygon annotation. Complex polygons are those who have holes 
+    Creates and returns a conplex polygon annotation. Complex polygons are those who have holes
     and/or disform shapes.
 
     Parameters
@@ -391,8 +438,8 @@ def make_complex_polygon(
     class_name: str
         The name of the class for this ``Annotation``.
     point_paths: List[List[Point]]
-        A list of lists points that comprises the complex polygon. This is needed as a complex 
-        polygon can be effectively seen as a sum of multiple simple polygons. The list should have 
+        A list of lists points that comprises the complex polygon. This is needed as a complex
+        polygon can be effectively seen as a sum of multiple simple polygons. The list should have
         a format simillar to:
 
         .. code-block:: python
@@ -515,7 +562,7 @@ def make_ellipse(class_name: str, parameters: EllipseData, subs: Optional[List[S
     class_name: str
         The name of the class for this ``Annotation``.
     parameters: EllipseData
-        The data needed to build an Ellipse. This data must be a dictionary with a format simillar 
+        The data needed to build an Ellipse. This data must be a dictionary with a format simillar
         to:
 
         .. code-block:: javascript
@@ -532,10 +579,10 @@ def make_ellipse(class_name: str, parameters: EllipseData, subs: Optional[List[S
             }
 
         Where:
-        
+
         - ``angle: float`` is the orientation angle of the ellipse.
         - ``center: Point`` is the center point of the ellipse.
-        - ``radius: Point`` is the width and height of the elipse, where ``x`` represents the width 
+        - ``radius: Point`` is the width and height of the elipse, where ``x`` represents the width
         and ``y`` represents height.
     subs: Optional[List[SubAnnotation]], default: None
         List of ``SubAnnotation``s for this ``Annotation``. Defaults to ``None``.
@@ -543,7 +590,7 @@ def make_ellipse(class_name: str, parameters: EllipseData, subs: Optional[List[S
     Returns
     -------
     Annotation
-        An ellipse ``Annotation``. 
+        An ellipse ``Annotation``.
     """
     return Annotation(AnnotationClass(class_name, "ellipse"), parameters, subs or [])
 
@@ -557,7 +604,7 @@ def make_cuboid(class_name: str, cuboid: CuboidData, subs: Optional[List[SubAnno
     class_name: str
         The name of the class for this ``Annotation``.
     parameters: CuboidData
-        The data needed to build a .Cuboid This data must be a dictionary with a format simillar 
+        The data needed to build a .Cuboid This data must be a dictionary with a format simillar
         to:
 
         .. code-block:: javascript
@@ -567,7 +614,7 @@ def make_cuboid(class_name: str, cuboid: CuboidData, subs: Optional[List[SubAnno
             }
 
         Where:
-        
+
         - ``back: Dict[str, float]`` is a dictionary containing the ``x`` and ``y`` of the top
         left corner Point, together with the width ``w`` and height ``h`` to form the back box.
         - ``front: Dict[str, float]`` is a dictionary containing the ``x`` and ``y`` of the top
@@ -578,7 +625,7 @@ def make_cuboid(class_name: str, cuboid: CuboidData, subs: Optional[List[SubAnno
     Returns
     -------
     Annotation
-        A cuboid ``Annotation``. 
+        A cuboid ``Annotation``.
     """
     return Annotation(AnnotationClass(class_name, "cuboid"), cuboid, subs or [])
 
@@ -591,12 +638,12 @@ def make_instance_id(value: int) -> SubAnnotation:
     ----------
     value: int
         The value of this instance's id.
-    
+
 
     Returns
     -------
     SubAnnotation
-        An instance id ``SubAnnotation``. 
+        An instance id ``SubAnnotation``.
     """
     return SubAnnotation("instance_id", value)
 
@@ -609,11 +656,11 @@ def make_attributes(attributes: List[str]) -> SubAnnotation:
     ----------
     value: List[str]
         A list of attributes. Example: ``["orange", "big"]``.
-    
+
     Returns
     -------
     SubAnnotation
-        An attributes ``SubAnnotation``. 
+        An attributes ``SubAnnotation``.
     """
     return SubAnnotation("attributes", attributes)
 
@@ -626,11 +673,11 @@ def make_text(text: str) -> SubAnnotation:
     ----------
     text: str
         The text for the sub-annotation.
-    
+
     Returns
     -------
     SubAnnotation
-        A text ``SubAnnotation``. 
+        A text ``SubAnnotation``.
     """
     return SubAnnotation("text", text)
 
@@ -648,11 +695,11 @@ def make_keyframe(annotation: Annotation, idx: int) -> KeyFrame:
         The annotation for the keyframe.
     idx: int
         The id of the keyframe.
-    
+
     Returns
     -------
     KeyFrame
-        The created ``Keyframe``. 
+        The created ``Keyframe``.
     """
     return {"idx": idx, "annotation": annotation}
 
@@ -673,11 +720,11 @@ def make_video_annotation(
         The list of segments for the video.
     interpolated: bool
         If this video annotation is interpolated or not.
-    
+
     Returns
     -------
     VideoAnnotation
-        The created ``VideoAnnotation``. 
+        The created ``VideoAnnotation``.
 
     Raises
     ------

--- a/darwin/datatypes.py
+++ b/darwin/datatypes.py
@@ -304,33 +304,6 @@ class ConversionError:
     filename: Path
 
 
-@dataclass(frozen=True, eq=True)
-class YoloAnnotation:
-    """
-    Represents a YOLO annotation ready to be persisted as a bounding box.
-    The XY coordinates represent the top left corner of said bounding box.
-
-    Attributes
-    ----------
-    annotation_class : str
-        The name of the ``AnnotationClass``.
-    x : float
-        Left X coordinate of the bounding box.
-    y : float
-        Top Y coordinate of the bounding box.
-    width : float
-        Width of the bounding box.
-    height : float
-        Height of the bounding box.
-    """
-
-    annotation_class: str
-    x: float
-    y: float
-    width: float
-    height: float
-
-
 def make_bounding_box(
     class_name: str, x: float, y: float, w: float, h: float, subs: Optional[List[SubAnnotation]] = None
 ) -> Annotation:

--- a/darwin/exporter/formats/__init__.py
+++ b/darwin/exporter/formats/__init__.py
@@ -9,4 +9,5 @@ supported_formats: List[str] = [
     "semantic_mask",
     "semantic_mask_grey",
     "semantic_mask_index",
+    "yolo",
 ]

--- a/darwin/exporter/formats/yolo.py
+++ b/darwin/exporter/formats/yolo.py
@@ -1,0 +1,90 @@
+from functools import partial
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Tuple, Union
+
+from rich.console import Console
+from rich.theme import Theme
+
+from darwin.datatypes import (
+    Annotation,
+    AnnotationFile,
+    ConversionError,
+    VideoAnnotation,
+    YoloAnnotation,
+)
+
+
+def export(annotation_files: Iterable[AnnotationFile], output_dir: Path) -> None:
+    """
+    Exports the given ``AnnotationFile``s into the yolo format inside of the given ``output_dir``.
+
+    Parameters
+    ----------
+    annotation_files : Iterator[dt.AnnotationFile]
+        The ``AnnotationFile``s to be exported.
+    output_dir : Path
+        The folder where the new coco file will be.
+    """
+    console = Console(theme=_console_theme())
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for annotation_file in annotation_files:
+        output_file_path = (output_dir / annotation_file.filename).with_suffix(".txt")
+        errors, yolo_annotations = _convert_file(annotation_file)
+
+        with open(output_file_path, "w") as f:
+            for yolo in yolo_annotations:
+                f.write(f"{yolo.annotation_class} {yolo.x} {yolo.y} {yolo.width} {yolo.height}")
+
+        for err in errors:
+            console.print(
+                f"Failed to convert: '{err.filename}'. Reason: {err.reason}. Annotation: {err.annotation}\n",
+                style="error",
+            )
+
+
+def _convert_file(file: AnnotationFile) -> Tuple[List[ConversionError], List[YoloAnnotation]]:
+    conversions: List[Union[ConversionError, YoloAnnotation]] = _to_yolo(file)
+    yolo_annotations: List[YoloAnnotation] = [x for x in conversions if isinstance(x, YoloAnnotation)]
+    errors: List[ConversionError] = [x for x in conversions if isinstance(x, ConversionError)]
+    return (errors, yolo_annotations)
+
+
+def _to_yolo(annotation_file: AnnotationFile) -> List[Union[ConversionError, YoloAnnotation]]:
+    create_yolo_annotation_with_file = partial(_create_yolo_annotation, annotation_file=annotation_file)
+    return _map_list(create_yolo_annotation_with_file, annotation_file.annotations)
+
+
+def _create_yolo_annotation(
+    annotation: Union[VideoAnnotation, Annotation], annotation_file: AnnotationFile
+) -> Union[ConversionError, YoloAnnotation]:
+    if isinstance(annotation, VideoAnnotation):
+        return ConversionError(
+            reason="Cannot convert video annotations to yolo",
+            annotation=annotation,
+            filename=annotation_file.path,
+        )
+
+    annotation_type: str = annotation.annotation_class.annotation_type
+    if annotation_type == "bounding_box":
+        return _from_bounding_box(annotation)
+
+    return ConversionError(
+        reason=f"Unsupported annotation type: {annotation_type}",
+        annotation=annotation,
+        filename=annotation_file.path,
+    )
+
+
+def _from_bounding_box(annotation: Annotation) -> YoloAnnotation:
+    name: str = annotation.annotation_class.name
+    bbox: Dict[str, float] = annotation.data.get("bounding_box", {})
+    return YoloAnnotation(annotation_class=name, x=bbox["x"], y=bbox["y"], width=bbox["w"], height=bbox["h"])
+
+
+def _map_list(fun: Callable[[Any], Any], the_list: List[Any]) -> List[Any]:
+    return list(map(fun, the_list))
+
+
+def _console_theme() -> Theme:
+    return Theme({"success": "bold green", "warning": "bold yellow", "error": "bold red"})

--- a/tests/darwin/exporter/formats/export_yolo_test.py
+++ b/tests/darwin/exporter/formats/export_yolo_test.py
@@ -1,0 +1,90 @@
+import shutil
+from pathlib import Path
+from typing import Dict, Optional
+
+import pytest
+from darwin.datatypes import Annotation, AnnotationClass, AnnotationFile
+from darwin.exporter.formats import yolo
+
+
+def describe_export():
+    @pytest.fixture
+    def folder_path(tmp_path: Path):
+        path: Path = tmp_path / "yolo_export_output_files"
+        yield path
+        shutil.rmtree(path)
+
+    def test_it_creates_missing_folders(folder_path: Path):
+        yolo.export([], folder_path)
+        assert folder_path.exists()
+
+    def it_creates_txt_files_for_each_image(folder_path: Path):
+        annotation_file_1 = _create_empty_annotation_file("annotation_test_1")
+        annotation_file_2 = _create_empty_annotation_file("annotation_test_2")
+
+        yolo.export([annotation_file_1, annotation_file_2], folder_path)
+
+        txt_file_1: Path = Path(f"{Path(annotation_file_1.filename).stem}.txt")
+        txt_file_2: Path = Path(f"{Path(annotation_file_2.filename).stem}.txt")
+
+        assert Path(folder_path, txt_file_1).exists()
+        assert Path(folder_path, txt_file_2).exists()
+
+    def it_converts_darwin_bounding_boxes(folder_path: Path):
+        bbox = {"x": 91.59, "y": 432.26, "w": 1716.06, "h": 556.88}
+        annotation_file = _create_bbox_annotation_file("car", bbox)
+
+        yolo.export([annotation_file], folder_path)
+
+        txt_file: Path = Path(folder_path, f"{Path(annotation_file.filename).stem}.txt")
+        with open(txt_file) as f:
+            lines = f.readlines()
+            assert lines[0] == "car 91.59 432.26 1716.06 556.88"
+
+
+# def it_converts_prints_error_if_given_video_annotation(folder_path: Path):
+
+#     def it_converts_darwin_polygons():
+
+#     def it_converts_darwin_complex_polygons():
+
+#     def it_converts_darwin_ellipses():
+
+
+def _create_empty_annotation_file(filename: str) -> AnnotationFile:
+    return AnnotationFile(
+        path=Path(f"/{filename}.json"),
+        filename=f"{filename}.jpg",
+        annotation_classes=set(),
+        annotations=[],
+        frame_urls=None,
+        image_height=1080,
+        image_width=1920,
+        is_video=False,
+    )
+
+
+def _create_bbox_annotation_file(
+    class_name: str, bbox: Dict[str, float], filename: Optional[str] = "annotation_test"
+) -> AnnotationFile:
+    annotation_class: AnnotationClass = AnnotationClass(
+        name=class_name, annotation_type="bounding_box", annotation_internal_type=None
+    )
+    annotation = Annotation(
+        annotation_class=annotation_class,
+        data={
+            "path": [{...}],
+            "bounding_box": bbox,
+        },
+        subs=[],
+    )
+    return AnnotationFile(
+        path=Path(f"/{filename}.json"),
+        filename=f"{filename}.jpg",
+        annotation_classes={annotation_class},
+        annotations=[annotation],
+        frame_urls=None,
+        image_height=1080,
+        image_width=1920,
+        is_video=False,
+    )


### PR DESCRIPTION
What?
-------

This is the first draft of the YOLO exporter. 
Right now I only support bounding boxes.

For more on the YOLO format please see:
https://towardsdatascience.com/image-data-labelling-and-annotation-everything-you-need-to-know-86ede6c684b1

Todo (after this PR)
------

- Support polygons
- Support Ellipses
- Support Complex polygons
- Support other shapes I am not remembering right now
- Test console error messages

I have taken the decision to **NOT** support `VideoAnnotation`s. I believe this to be reasonable, let me know if you think otherwise. 

What I am looking for if you review
-------------------------------

- Is the code easy to read? (are the functions too big?)
- What do you think of the new `datatypes` I added? I am trying to make feedback for users as friendly as possible. In my head, nothing beat a nice Rich message with good information.
- Am I missing any test cases here? (Failure to create folders or permissions denied on files comes to mind, but I am not sure this is a case I should consider covering to begin with).

Assumptions
-------------

This code is written understand the assumption that the `AnnotationFile`s I will be receiving have coherent, well formed data, since this data is being generated from within our app. Let me know if this assumption could be wrong.

Other things you may see relevant, please share. 
I will not move on with another PR until we are all happy and agree this PR is a solid base to built upon.