### PR TITLE
fixed dataset export not working with class ids

### DIFF
--- a/darwin/cli_functions.py
+++ b/darwin/cli_functions.py
@@ -257,7 +257,7 @@ def dataset_report(dataset_slug: str, granularity: str) -> None:
     dataset_slug: str
         The dataset's slug.
     granularity: str
-        Granualarity of the report, can be 'day', 'week' or 'month'.
+        Granularity of the report, can be 'day', 'week' or 'month'.
     """
     client: Client = _load_client(offline=True)
     try:
@@ -269,7 +269,7 @@ def dataset_report(dataset_slug: str, granularity: str) -> None:
 
 
 def export_dataset(
-    dataset_slug: str, include_url_token: bool, name: str, annotation_class_ids: Optional[List[str]] = None
+    dataset_slug: str, include_url_token: bool, name: str, annotation_class_ids: Optional[str] = None
 ) -> None:
     """
     Create a new release for the dataset.
@@ -282,13 +282,18 @@ def export_dataset(
         If True includes the url token, if False does not.
     name: str
         Name of the release.
-    annotation_class_ids: Optional[List[str]]
-        List of the classes to filter. Defautls to None.
+    annotation_class_ids: Optional[str], default: None
+        Annotation class ids to filter by, separated by spaces.
     """
     client: Client = _load_client(offline=False)
     identifier: DatasetIdentifier = DatasetIdentifier.parse(dataset_slug)
     ds: RemoteDataset = client.get_remote_dataset(identifier)
-    ds.export(annotation_class_ids=annotation_class_ids, name=name, include_url_token=include_url_token)
+
+    class_ids: List[str] = []
+    if annotation_class_ids:
+        class_ids = annotation_class_ids.split()
+
+    ds.export(annotation_class_ids=class_ids, name=name, include_url_token=include_url_token)
     identifier.version = name
     print(f"Dataset {dataset_slug} successfully exported to {identifier}")
     print_new_version_info(client)

--- a/darwin/dataset/remote_dataset.py
+++ b/darwin/dataset/remote_dataset.py
@@ -643,9 +643,7 @@ class RemoteDataset:
         """
         return self.client.fetch_remote_attributes(self.dataset_id)
 
-    def export(
-        self, name: str, annotation_class_ids: Optional[List[str]] = None, include_url_token: bool = False
-    ) -> None:
+    def export(self, name: str, annotation_class_ids: List[str], include_url_token: bool = False) -> None:
         """
         Create a new release for this ``RemoteDataset``.
 
@@ -653,14 +651,13 @@ class RemoteDataset:
         ----------
         name : str
             Name of the release.
-        annotation_class_ids : Optional[List[str]], default: None
+        annotation_class_ids : List[str]
             List of the classes to filter.
         include_url_token : bool, default: False
             Should the image url in the export include a token enabling access without team
             membership or not?
         """
-        if annotation_class_ids is None:
-            annotation_class_ids = []
+
         payload = {
             "annotation_class_ids": annotation_class_ids,
             "name": name,

--- a/darwin/dataset/remote_dataset.py
+++ b/darwin/dataset/remote_dataset.py
@@ -668,7 +668,7 @@ class RemoteDataset:
         """
         if annotation_class_ids is None:
             annotation_class_ids = []
-            
+
         payload = {
             "annotation_class_ids": annotation_class_ids,
             "name": name,

--- a/darwin/dataset/remote_dataset.py
+++ b/darwin/dataset/remote_dataset.py
@@ -666,7 +666,9 @@ class RemoteDataset:
             If set, include annotator and reviewer metadata for each annotation.
 
         """
-
+        if annotation_class_ids is None:
+            annotation_class_ids = []
+            
         payload = {
             "annotation_class_ids": annotation_class_ids,
             "name": name,

--- a/darwin/options.py
+++ b/darwin/options.py
@@ -113,7 +113,7 @@ class Options(object):
         parser_export.add_argument(
             "annotation_class",
             type=str,
-            nargs="?",
+            nargs="+",
             help=(
                 "List of annotation class ids. If present, it will only include items that have"
                 " annotations with a class whose id matches."


### PR DESCRIPTION
The command `darwin dataset export cars lights_v3 "1439 1438"` was not working. 

Basically the function expected a list of strings, and we were always passing a string no matter what. The resulted in bad requests to the backend. 

This PR fixes that. Now before making the HTTP call, I split the string into a list. 
I also updated the docs accordingly.
