### PR TITLE
fixed val-percentage and test-percentage being optional

### DIFF
--- a/darwin/options.py
+++ b/darwin/options.py
@@ -165,10 +165,8 @@ class Options(object):
             "split", help="Splits a local dataset following random and stratified split types."
         )
         parser_split.add_argument("dataset", type=str, help="Local dataset name to split.")
-        parser_split.add_argument("-v", "--val-percentage", type=float, required=True, help="Validation percentage.")
-        parser_split.add_argument(
-            "-t", "--test-percentage", type=float, required=False, default=0, help="Test percentage."
-        )
+        parser_split.add_argument("val-percentage", type=float, help="Validation percentage.")
+        parser_split.add_argument("test-percentage", type=float, help="Test percentage.")
         parser_split.add_argument("-s", "--seed", type=int, required=False, default=0, help="Split seed.")
 
         # File listing

--- a/darwin/options.py
+++ b/darwin/options.py
@@ -165,8 +165,8 @@ class Options(object):
             "split", help="Splits a local dataset following random and stratified split types."
         )
         parser_split.add_argument("dataset", type=str, help="Local dataset name to split.")
-        parser_split.add_argument("val-percentage", type=float, help="Validation percentage.")
-        parser_split.add_argument("test-percentage", type=float, help="Test percentage.")
+        parser_split.add_argument("-v", "--val-percentage", required=True, type=float, help="Validation percentage.")
+        parser_split.add_argument("-t", "--test-percentage", required=True, type=float, help="Test percentage.")
         parser_split.add_argument("-s", "--seed", type=int, required=False, default=0, help="Split seed.")
 
         # File listing


### PR DESCRIPTION
Right now if we run `-h` we see this:

```
 darwin dataset split -h
usage: darwin dataset split [-h] -v VAL_PERCENTAGE [-t TEST_PERCENTAGE] [-s SEED] dataset

positional arguments:
  dataset               Local dataset name to split.

optional arguments:
  -h, --help            show this help message and exit
  -v VAL_PERCENTAGE, --val-percentage VAL_PERCENTAGE
                        Validation percentage.
  -t TEST_PERCENTAGE, --test-percentage TEST_PERCENTAGE
                        Test percentage.
  -s SEED, --seed SEED  Split seed.
```

Which is incorrect, because if we try to run `darwin dataset split planes` the action will fail. Both `val-percentage` and `test-percentage` are actually mandatory. 

This PR fixes that:
```
$ darwin dataset split -h
usage: darwin dataset split [-h] [-s SEED] dataset val-percentage test-percentage

positional arguments:
  dataset               Local dataset name to split.
  val-percentage        Validation percentage.
  test-percentage       Test percentage.

optional arguments:
  -h, --help            show this help message and exit
  -s SEED, --seed SEED  Split seed.

``` 