### PR TITLE
Delete non existent files

### DIFF
--- a/darwin/cli_functions.py
+++ b/darwin/cli_functions.py
@@ -4,8 +4,9 @@ import datetime
 import os
 import sys
 import traceback
+from itertools import tee
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, NoReturn, Optional, Union, cast
+from typing import Any, Dict, Iterator, List, NoReturn, Optional, Set, Union
 
 import humanize
 from rich.console import Console
@@ -850,25 +851,30 @@ def delete_files(dataset_slug: str, files: List[str], skip_user_confirmation: bo
 
     Parameters
     ----------
-    dataset_slug: str
+    dataset_slug : str
         The dataset's slug.
-    files: List[str]
+    files : List[str]
         The list of filenames to delete.
-    skip_user_confirmation: bool
-        If True, skips user confirmation, if False it will prompt the user. Defaults to False.
+    skip_user_confirmation : bool, default: False
+        If ``True``, skips user confirmation, if False it will prompt the user.
     """
     client: Client = _load_client(dataset_identifier=dataset_slug)
     try:
-        console = Console()
+        console = Console(theme=_console_theme(), stderr=True)
         dataset: RemoteDataset = client.get_remote_dataset(dataset_identifier=dataset_slug)
-        items: Iterator[DatasetItem] = dataset.fetch_remote_files({"filenames": ",".join(files)})
+        items, items_2 = tee(dataset.fetch_remote_files({"filenames": ",".join(files)}))
         if not skip_user_confirmation and not secure_continue_request():
             console.print("Cancelled.")
             return
 
+        found_filenames: Set[str] = set([item.filename for item in items_2])
+        not_found_filenames: Set[str] = set(files) - found_filenames
+        for filename in not_found_filenames:
+            console.print(f"File not found: {filename}", style="warning")
+
         with console.status("[bold red]Deleting files..."):
             dataset.delete_items(items)
-            console.print("[bold green]Files successfully deleted!")
+            console.print("Operation successfully completed!", style="success")
 
     except NotFound as e:
         _error(f"No dataset with name '{e.name}'")
@@ -884,13 +890,13 @@ def dataset_convert(dataset_identifier: str, format: str, output_dir: Optional[P
 
     Parameters
     ----------
-    dataset_identifier: str
+    dataset_identifier : str
         The dataset identifier, normally in the "<team-slug>/<dataset-slug>:<version>" form.
-    format: str
+    format : str
         The format we want to convert to.
-    output_dir: Optional[PathLike]
+    output_dir : Optional[PathLike], default: None
         The folder where the exported annotation files will be. If None it will be the inside the
-        annotations folder of the dataset under 'other_formats/{format}'. The Defaults to None.
+        annotations folder of the dataset under 'other_formats/{format}'.
     """
     identifier: DatasetIdentifier = DatasetIdentifier.parse(dataset_identifier)
     client: Client = _load_client(team_slug=identifier.team_slug)

--- a/darwin/cli_functions.py
+++ b/darwin/cli_functions.py
@@ -862,7 +862,7 @@ def delete_files(dataset_slug: str, files: List[str], skip_user_confirmation: bo
     try:
         console = Console(theme=_console_theme(), stderr=True)
         dataset: RemoteDataset = client.get_remote_dataset(dataset_identifier=dataset_slug)
-        items, items_2 = tee(dataset.fetch_remote_files({"filenames": ",".join(files)}))
+        items, items_2 = tee(dataset.fetch_remote_files({"filenames": files}))
         if not skip_user_confirmation and not secure_continue_request():
             console.print("Cancelled.")
             return

--- a/darwin/client.py
+++ b/darwin/client.py
@@ -613,7 +613,7 @@ class Client:
         dataset_id: int
             The id of the dataset.
         granularity: str
-            Granualirity of the report, can be 'day', 'week' or 'month'.
+            Granularity of the report, can be 'day', 'week' or 'month'.
         team_slug: Optional[str]
             Team slug of the team the dataset will belong to. Defaults to None.
 
@@ -710,7 +710,7 @@ class Client:
         team_slug: str
             The slug of the team.
         payload: Dict[str, Any]
-            A filter Dictionary that defines the items to be reseted.
+            A filter Dictionary that defines the items to be reset.
         """
         self._put_raw(f"teams/{team_slug}/datasets/{dataset_slug}/items/reset", payload, team_slug)
 

--- a/darwin/datatypes.py
+++ b/darwin/datatypes.py
@@ -160,7 +160,7 @@ class VideoAnnotation:
     segments: List[Segment]
         A list of ``Segment``'s.
     interpolated: bool
-        Whehter this ``VideoAnnotation`` is interpolated or not.
+        Whether this ``VideoAnnotation`` is interpolated or not.
     """
 
     annotation_class: AnnotationClass
@@ -229,33 +229,32 @@ class AnnotationFile:
 
     Attributes
     ----------
-    path: Path
+    path : Path
         Path to the file.
-    filename: str
+    filename : str
         Name of the file containing the annotations.
-    annotation_classes: Set[AnnotationClass]
+    annotation_classes : Set[AnnotationClass]
         ``Set`` of all ``AnnotationClass``es this file contains. Used as a way to know in advance
         which ``AnnotationClass``es this file has without having to go through the list of
         annotations.
-    annotations: Union[List[VideoAnnotation], List[Annotation]]
+    annotations : Union[List[VideoAnnotation], List[Annotation]]
         List of ``VideoAnnotation``s or ``Annotation``s.
-    is_video: bool, default: False
+    is_video : bool, default: False
         Whether the annotations in the ``annotations`` attribute are ``VideoAnnotation`` or not.
-        Defaults to ``False``.
-    image_width: Optional[int], default:  None
-        Width of the image in this annotation. Defaults to ``None``.
-    image_height: Optional[int], default:  None
-        Height of the image in this annotation. Defaults to ``None``.
-    image_url: Optional[str], default:  None
-        URL of the image in this annotation. Defaults to ``None``.
-    workview_url: Optional[str], default:  None
-        URL of the workview for this annotation. Defaults to ``None``.
-    seq: Optional[int], default:  None
-        Sequence for this annotation. Defaults to ``None``.
-    frame_urls: Optional[List[str]], default:  None
-        URLs for the frames this ``AnnotationFile`` has. Defautls to ``None``.
-    remote_path: Optional[str], default:  None
-        Remote path for this Annoataion file in V7's darwin. Defaults to ``None``.
+    image_width : Optional[int], default: None
+        Width of the image in this annotation.
+    image_height : Optional[int], default: None
+        Height of the image in this annotation.
+    image_url : Optional[str], default: None
+        URL of the image in this annotation.
+    workview_url : Optional[str], default: None
+        URL of the workview for this annotation.
+    seq : Optional[int], default: None
+        Sequence for this annotation.
+    frame_urls : Optional[List[str]], default:  None
+        URLs for the frames this ``AnnotationFile`` has.
+    remote_path : Optional[str], default:  None
+        Remote path for this ``Annotation``'s file in V7's darwin.
     """
 
     path: Path
@@ -293,18 +292,18 @@ def make_bounding_box(
 
     Parameters
     ----------
-    class_name: str
+    class_name : str
         The name of the class for this ``Annotation``.
-    x: float
+    x : float
         The top left ``x`` value where the bounding box will start.
-    y: float
+    y : float
         The top left ``y`` value where the bounding box will start.
-    w: float
+    w : float
         The width of the bounding box.
-    h: float
+    h : float
         The height of the bounding box.
-    subs: Optional[List[SubAnnotation]], default: None
-        List of ``SubAnnotation``s for this ``Annotation``. Defaults to ``None``.
+    subs : Optional[List[SubAnnotation]], default: None
+        List of ``SubAnnotation``s for this ``Annotation``.
 
     Returns
     -------
@@ -324,10 +323,10 @@ def make_tag(class_name: str, subs: Optional[List[SubAnnotation]] = None) -> Ann
 
     Parameters
     ----------
-    class_name: str
+    class_name : str
         The name of the class for this ``Annotation``.
-    subs: Optional[List[SubAnnotation]], default: None
-        List of ``SubAnnotation``s for this ``Annotation``. Defaults to ``None``.
+    subs : Optional[List[SubAnnotation]], default: None
+        List of ``SubAnnotation``s for this ``Annotation``.
 
     Returns
     -------
@@ -348,10 +347,10 @@ def make_polygon(
 
     Parameters
     ----------
-    class_name: str
+    class_name : str
         The name of the class for this ``Annotation``.
-    point_path: List[Point]
-        A list of points that comprises the polygon. The list should have a format simillar to:
+    point_path : List[Point]
+        A list of points that comprises the polygon. The list should have a format similar to:
 
         .. code-block:: python
             [
@@ -359,10 +358,10 @@ def make_polygon(
                 {"x": 2, "y": 1}
             ]
 
-    bounding_box: Optional[Dict], default: None
-        The bounding box that encompasses the polyong. Defaults to ``None``.
-    subs: Optional[List[SubAnnotation]], default: None
-        List of ``SubAnnotation``s for this ``Annotation``. Defaults to ``None``.
+    bounding_box : Optional[Dict], default: None
+        The bounding box that encompasses the polyong.
+    subs : Optional[List[SubAnnotation]], default: None
+        List of ``SubAnnotation``s for this ``Annotation``.
 
     Returns
     -------
@@ -383,7 +382,7 @@ def make_complex_polygon(
     subs: Optional[List[SubAnnotation]] = None,
 ) -> Annotation:
     """
-    Creates and returns a conplex polygon annotation. Complex polygons are those who have holes 
+    Creates and returns a complex polygon annotation. Complex polygons are those who have holes
     and/or disform shapes.
 
     Parameters
@@ -391,9 +390,9 @@ def make_complex_polygon(
     class_name: str
         The name of the class for this ``Annotation``.
     point_paths: List[List[Point]]
-        A list of lists points that comprises the complex polygon. This is needed as a complex 
-        polygon can be effectively seen as a sum of multiple simple polygons. The list should have 
-        a format simillar to:
+        A list of lists points that comprises the complex polygon. This is needed as a complex
+        polygon can be effectively seen as a sum of multiple simple polygons. The list should have
+        a format similar to:
 
         .. code-block:: python
             [
@@ -408,10 +407,10 @@ def make_complex_polygon(
                 # ... and so on ...
             ]
 
-    bounding_box: Optional[Dict], default: None
-        The bounding box that encompasses the polyong. Defaults to ``None``.
-    subs: Optional[List[SubAnnotation]], default: None
-        List of ``SubAnnotation``s for this ``Annotation``. Defaults to ``None``.
+    bounding_box : Optional[Dict], default: None
+        The bounding box that encompasses the polyong.
+    subs : Optional[List[SubAnnotation]], default: None
+        List of ``SubAnnotation``s for this ``Annotation``.
 
     Returns
     -------
@@ -431,14 +430,14 @@ def make_keypoint(class_name: str, x: float, y: float, subs: Optional[List[SubAn
 
     Parameters
     ----------
-    class_name: str
+    class_name : str
         The name of the class for this ``Annotation``.
-    x: float
+    x : float
         The ``x`` value of the point.
-    y: float
+    y : float
         The ``y`` value of the point.
-    subs: Optional[List[SubAnnotation]], default: None
-        List of ``SubAnnotation``s for this ``Annotation``. Defaults to ``None``.
+    subs : Optional[List[SubAnnotation]], default: None
+        List of ``SubAnnotation``s for this ``Annotation``.
 
     Returns
     -------
@@ -454,10 +453,10 @@ def make_line(class_name: str, path: List[Point], subs: Optional[List[SubAnnotat
 
     Parameters
     ----------
-    class_name: str
+    class_name : str
         The name of the class for this ``Annotation``.
-    point_path: List[Point]
-        A list of points that comprises the polygon. The list should have a format simillar to:
+    point_path : List[Point]
+        A list of points that comprises the polygon. The list should have a format similar to:
 
         .. code-block:: python
             [
@@ -465,8 +464,8 @@ def make_line(class_name: str, path: List[Point], subs: Optional[List[SubAnnotat
                 {"x": 2, "y": 1}
             ]
 
-    subs: Optional[List[SubAnnotation]], default: None
-        List of ``SubAnnotation``s for this ``Annotation``. Defaults to ``None``.
+    subs : Optional[List[SubAnnotation]], default: None
+        List of ``SubAnnotation``s for this ``Annotation``.
 
     Returns
     -------
@@ -482,10 +481,10 @@ def make_skeleton(class_name: str, nodes: List[Node], subs: Optional[List[SubAnn
 
     Parameters
     ----------
-    class_name: str
+    class_name : str
         The name of the class for this ``Annotation``.
-    nodes: List[Node]
-        List of ``Node``s that comprise the skeleton. Each Node will have a format simillar to:
+    nodes : List[Node]
+        List of ``Node``s that comprise the skeleton. Each Node will have a format similar to:
 
         .. code-block:: python
             {
@@ -495,8 +494,8 @@ def make_skeleton(class_name: str, nodes: List[Node], subs: Optional[List[SubAnn
                 "y": 939.81
             }
 
-    subs: Optional[List[SubAnnotation]], default: None
-        List of ``SubAnnotation``s for this ``Annotation``. Defaults to ``None``.
+    subs : Optional[List[SubAnnotation]], default: None
+        List of ``SubAnnotation``s for this ``Annotation``.
 
     Returns
     -------
@@ -512,10 +511,10 @@ def make_ellipse(class_name: str, parameters: EllipseData, subs: Optional[List[S
 
     Parameters
     ----------
-    class_name: str
+    class_name : str
         The name of the class for this ``Annotation``.
-    parameters: EllipseData
-        The data needed to build an Ellipse. This data must be a dictionary with a format simillar 
+    parameters : EllipseData
+        The data needed to build an Ellipse. This data must be a dictionary with a format similar
         to:
 
         .. code-block:: javascript
@@ -532,18 +531,18 @@ def make_ellipse(class_name: str, parameters: EllipseData, subs: Optional[List[S
             }
 
         Where:
-        
+
         - ``angle: float`` is the orientation angle of the ellipse.
         - ``center: Point`` is the center point of the ellipse.
-        - ``radius: Point`` is the width and height of the elipse, where ``x`` represents the width 
+        - ``radius: Point`` is the width and height of the ellipse, where ``x`` represents the width
         and ``y`` represents height.
-    subs: Optional[List[SubAnnotation]], default: None
-        List of ``SubAnnotation``s for this ``Annotation``. Defaults to ``None``.
+    subs : Optional[List[SubAnnotation]], default: None
+        List of ``SubAnnotation``s for this ``Annotation``.
 
     Returns
     -------
     Annotation
-        An ellipse ``Annotation``. 
+        An ellipse ``Annotation``.
     """
     return Annotation(AnnotationClass(class_name, "ellipse"), parameters, subs or [])
 
@@ -554,10 +553,10 @@ def make_cuboid(class_name: str, cuboid: CuboidData, subs: Optional[List[SubAnno
 
     Parameters
     ----------
-    class_name: str
+    class_name : str
         The name of the class for this ``Annotation``.
-    parameters: CuboidData
-        The data needed to build a .Cuboid This data must be a dictionary with a format simillar 
+    parameters : CuboidData
+        The data needed to build a .Cuboid This data must be a dictionary with a format similar
         to:
 
         .. code-block:: javascript
@@ -567,18 +566,18 @@ def make_cuboid(class_name: str, cuboid: CuboidData, subs: Optional[List[SubAnno
             }
 
         Where:
-        
+
         - ``back: Dict[str, float]`` is a dictionary containing the ``x`` and ``y`` of the top
         left corner Point, together with the width ``w`` and height ``h`` to form the back box.
         - ``front: Dict[str, float]`` is a dictionary containing the ``x`` and ``y`` of the top
         left corner Point, together with the width ``w`` and height ``h`` to form the front box.
-    subs: Optional[List[SubAnnotation]], default: None
+    subs : Optional[List[SubAnnotation]], default: None
         List of ``SubAnnotation``s for this ``Annotation``. Defaults to ``None``.
 
     Returns
     -------
     Annotation
-        A cuboid ``Annotation``. 
+        A cuboid ``Annotation``.
     """
     return Annotation(AnnotationClass(class_name, "cuboid"), cuboid, subs or [])
 
@@ -589,14 +588,14 @@ def make_instance_id(value: int) -> SubAnnotation:
 
     Parameters
     ----------
-    value: int
+    value : int
         The value of this instance's id.
-    
+
 
     Returns
     -------
     SubAnnotation
-        An instance id ``SubAnnotation``. 
+        An instance id ``SubAnnotation``.
     """
     return SubAnnotation("instance_id", value)
 
@@ -607,13 +606,13 @@ def make_attributes(attributes: List[str]) -> SubAnnotation:
 
     Parameters
     ----------
-    value: List[str]
+    value : List[str]
         A list of attributes. Example: ``["orange", "big"]``.
-    
+
     Returns
     -------
     SubAnnotation
-        An attributes ``SubAnnotation``. 
+        An attributes ``SubAnnotation``.
     """
     return SubAnnotation("attributes", attributes)
 
@@ -624,13 +623,13 @@ def make_text(text: str) -> SubAnnotation:
 
     Parameters
     ----------
-    text: str
+    text : str
         The text for the sub-annotation.
-    
+
     Returns
     -------
     SubAnnotation
-        A text ``SubAnnotation``. 
+        A text ``SubAnnotation``.
     """
     return SubAnnotation("text", text)
 
@@ -644,15 +643,15 @@ def make_keyframe(annotation: Annotation, idx: int) -> KeyFrame:
 
     Parameters
     ----------
-    annotation: Annotation
+    annotation : Annotation
         The annotation for the keyframe.
-    idx: int
+    idx : int
         The id of the keyframe.
-    
+
     Returns
     -------
     KeyFrame
-        The created ``Keyframe``. 
+        The created ``Keyframe``.
     """
     return {"idx": idx, "annotation": annotation}
 
@@ -665,24 +664,24 @@ def make_video_annotation(
 
     Parameters
     ----------
-    frames: Dict[int, Any]
+    frames : Dict[int, Any]
         The frames for the video. All frames must have the same ``annotation_class.name`` value.
-    keyframes: Dict[int, bool]
+    keyframes : Dict[int, bool]
         Indicates which frames are keyframes.
-    segments: List[Segment]
+    segments : List[Segment]
         The list of segments for the video.
-    interpolated: bool
+    interpolated : bool
         If this video annotation is interpolated or not.
-    
+
     Returns
     -------
     VideoAnnotation
-        The created ``VideoAnnotation``. 
+        The created ``VideoAnnotation``.
 
     Raises
     ------
     ValueError
-        If some of the frames have different annotaion class names.
+        If some of the frames have different annotation class names.
     """
     first_annotation: Annotation = list(frames.values())[0]
     if not all(frame.annotation_class.name == first_annotation.annotation_class.name for frame in frames.values()):

--- a/tests/darwin/cli_functions_test.py
+++ b/tests/darwin/cli_functions_test.py
@@ -156,7 +156,7 @@ def describe_delete_files():
                     delete_files(dataset_identifier, ["one.jpg", "two.jpg"], True)
                     get_remote_dataset_mock.assert_called_once_with(dataset_identifier=dataset_identifier)
                     fetch_remote_files_mock.assert_called_once_with({"filenames": "one.jpg,two.jpg"})
-                    mock.assert_called_once_with(fetch_remote_files_mock.return_value)
+                    mock.assert_called_once()
 
     def test_deletes_items_if_user_accepts_prompt(dataset_identifier: str, remote_dataset: RemoteDataset):
         with patch.object(Client, "get_remote_dataset", return_value=remote_dataset) as get_remote_dataset_mock:
@@ -166,7 +166,7 @@ def describe_delete_files():
                         delete_files(dataset_identifier, ["one.jpg", "two.jpg"])
                         get_remote_dataset_mock.assert_called_once_with(dataset_identifier=dataset_identifier)
                         fetch_remote_files_mock.assert_called_once_with({"filenames": "one.jpg,two.jpg"})
-                        mock.assert_called_once_with(fetch_remote_files_mock.return_value)
+                        mock.assert_called_once()
 
     def test_does_not_delete_items_if_user_refuses_prompt(dataset_identifier: str, remote_dataset: RemoteDataset):
         with patch.object(Client, "get_remote_dataset", return_value=remote_dataset) as get_remote_dataset_mock:
@@ -191,5 +191,5 @@ def describe_delete_files():
 
                         get_remote_dataset_mock.assert_called_once_with(dataset_identifier=dataset_identifier)
                         fetch_remote_files_mock.assert_called_once_with({"filenames": "one.jpg,two.jpg"})
-                        mock.assert_called_once_with(fetch_remote_files_mock.return_value)
+                        mock.assert_called_once()
                         exception.assert_called_once_with(1)

--- a/tests/darwin/cli_functions_test.py
+++ b/tests/darwin/cli_functions_test.py
@@ -155,7 +155,7 @@ def describe_delete_files():
                 with patch.object(RemoteDataset, "delete_items") as mock:
                     delete_files(dataset_identifier, ["one.jpg", "two.jpg"], True)
                     get_remote_dataset_mock.assert_called_once_with(dataset_identifier=dataset_identifier)
-                    fetch_remote_files_mock.assert_called_once_with({"filenames": "one.jpg,two.jpg"})
+                    fetch_remote_files_mock.assert_called_once_with({"filenames": ["one.jpg", "two.jpg"]})
                     mock.assert_called_once()
 
     def test_deletes_items_if_user_accepts_prompt(dataset_identifier: str, remote_dataset: RemoteDataset):
@@ -165,7 +165,7 @@ def describe_delete_files():
                     with patch.object(RemoteDataset, "delete_items") as mock:
                         delete_files(dataset_identifier, ["one.jpg", "two.jpg"])
                         get_remote_dataset_mock.assert_called_once_with(dataset_identifier=dataset_identifier)
-                        fetch_remote_files_mock.assert_called_once_with({"filenames": "one.jpg,two.jpg"})
+                        fetch_remote_files_mock.assert_called_once_with({"filenames": ["one.jpg", "two.jpg"]})
                         mock.assert_called_once()
 
     def test_does_not_delete_items_if_user_refuses_prompt(dataset_identifier: str, remote_dataset: RemoteDataset):
@@ -175,7 +175,7 @@ def describe_delete_files():
                     with patch.object(RemoteDataset, "delete_items") as mock:
                         delete_files(dataset_identifier, ["one.jpg", "two.jpg"])
                         get_remote_dataset_mock.assert_called_once_with(dataset_identifier=dataset_identifier)
-                        fetch_remote_files_mock.assert_called_once_with({"filenames": "one.jpg,two.jpg"})
+                        fetch_remote_files_mock.assert_called_once_with({"filenames": ["one.jpg", "two.jpg"]})
                         mock.assert_not_called()
 
     def test_exits_if_error_occurs(dataset_identifier: str, remote_dataset: RemoteDataset):
@@ -190,6 +190,6 @@ def describe_delete_files():
                         delete_files(dataset_identifier, ["one.jpg", "two.jpg"], True)
 
                         get_remote_dataset_mock.assert_called_once_with(dataset_identifier=dataset_identifier)
-                        fetch_remote_files_mock.assert_called_once_with({"filenames": "one.jpg,two.jpg"})
+                        fetch_remote_files_mock.assert_called_once_with({"filenames": ["one.jpg", "two.jpg"]})
                         mock.assert_called_once()
                         exception.assert_called_once_with(1)


### PR DESCRIPTION
Now instead of always saying "Files deleted successfully!", it prints files that were not found and prints the result of the overall operation:

```
$ darwin dataset delete-files helis asdf dajsdnad asjdd
Do you want to continue? [y/N] y
File not found: asjdd
File not found: asdf
File not found: dajsdnad
Operation successfully completed!
```

Related to:
https://github.com/v7labs/darwin-py/issues/381