### PR TITLE
Make class IDs list optional when generating a new dataset export

### DIFF
--- a/darwin/cli.py
+++ b/darwin/cli.py
@@ -104,9 +104,7 @@ def _run(args: Namespace, parser: ArgumentParser) -> None:
         elif args.action == "report":
             f.dataset_report(args.dataset, args.granularity or "day", args.pretty)
         elif args.action == "export":
-            f.export_dataset(
-                args.dataset, args.include_url_token, args.name, args.annotation_class, args.include_authorship
-            )
+            f.export_dataset(args.dataset, args.include_url_token, args.name, args.class_ids, args.include_authorship)
         elif args.action == "files":
             f.list_files(args.dataset, args.status, args.path, args.only_filenames, args.sort_by)
         elif args.action == "releases":

--- a/darwin/cli_functions.py
+++ b/darwin/cli_functions.py
@@ -324,7 +324,7 @@ def export_dataset(
         Name of the release.
     annotation_class_ids : Optional[List[str]], default: None
         List of the classes to filter.
-    include_authorship : bool
+    include_authorship : bool, default: False
         If ``True`` include annotator and reviewer metadata for each annotation.
     """
     client: Client = _load_client(offline=False)

--- a/darwin/dataset/remote_dataset.py
+++ b/darwin/dataset/remote_dataset.py
@@ -657,7 +657,7 @@ class RemoteDataset:
         ----------
         name : str
             Name of the release.
-        annotation_class_ids : List[str]
+        annotation_class_ids : Optional[List[str]], default: None
             List of the classes to filter.
         include_url_token : bool, default: False
             Should the image url in the export include a token enabling access without team

--- a/darwin/options.py
+++ b/darwin/options.py
@@ -117,7 +117,7 @@ class Options(object):
         parser_export.add_argument("dataset", type=str, help="Remote dataset name to export.")
         parser_export.add_argument("name", type=str, help="Name with with the version gets tagged.")
         parser_export.add_argument(
-            "annotation_class",
+            "--class-ids",
             type=str,
             nargs="+",
             help=(


### PR DESCRIPTION
Fixing `annotation_class_ids` being mandatory an not optional. Now help menu shows:

```
$ darwin dataset export -h
usage: darwin dataset export [-h] [--class-ids CLASS_IDS] [--include-authorship] [--include-url-token] dataset name

positional arguments:
  dataset               Remote dataset name to export.
  name                  Name with with the version gets tagged.

optional arguments:
  -h, --help            show this help message and exit
  --class-ids CLASS_IDS
                        List of annotation class ids. If present, it will only include items that have annotations with a class whose id matches.
  --include-authorship  Each annotation contains annotator and reviewer authorship metadata.
  --include-url-token   Each annotation file includes a url with an access token.Warning, anyone with the url can access the images, even without being a team member.
```