### PR TITLE
Fix issue with cyrillic text in csv report

### DIFF
--- a/darwin/dataset/remote_dataset.py
+++ b/darwin/dataset/remote_dataset.py
@@ -692,7 +692,10 @@ class RemoteDataset:
             A CSV report.
         """
         response: Response = self.client.get_report(self.dataset_id, granularity, self.team)
-        return response.text
+        try:
+            return response.content.decode(response.apparent_encoding)
+        except (UnicodeDecodeError, LookupError, TypeError):
+            return response.text
 
     def get_releases(self) -> List["Release"]:
         """


### PR DESCRIPTION
Command `darwin dataset report ${dataset}` generate wrong csv data when `first_name` or `last_name` contains cyrillic text.

![image](https://user-images.githubusercontent.com/3104366/170786970-0de6d8eb-c9e2-40b0-ac10-97add407b212.png)

After current fix
![image](https://user-images.githubusercontent.com/3104366/170787418-ba9b6f7a-8e34-4abd-ab12-c05986c3f2ed.png)
