### PR TITLE
COCO attributes are parsed as SubAnnotations

### DIFF
--- a/darwin/importer/formats/coco.py
+++ b/darwin/importer/formats/coco.py
@@ -158,11 +158,12 @@ def _build_sub_annotations(annotation: dict):
         available.
     """
     extra_info = annotation.get("extra")
+    if not extra_info:
+        return None
     attributes = extra_info.get("attributes")
-    sub_ann = None
-    if extra_info and attributes:
-        sub_ann = [dt.make_attributes(attributes)]
-    return sub_ann
+    if not attributes:
+        return None
+    return [dt.make_attributes(attributes)]
 
 
 @deprecation.deprecated(


### PR DESCRIPTION
This Pull Request refers to the following issue: [https://github.com/v7labs/darwin-py/issues/412](https://github.com/v7labs/darwin-py/issues/412)

The idea is that the COCO importer appends the attributes defined for each annotation. The attributes should be defined inside the `"extra"` key i.e.
```python
"annotations": [
    {
         "id": 1,
         "image_id": 1,
         "category_id": 18,
         "segmentation": [[ ... ]],
         "area": 11624.0,
         "bbox": [ ... ],
         "iscrowd": 0,
         "extra": {"attributes": ["some-attr", "some-other-attr"]}
    },
...]
```
The importer now should be able to parse the attributes and send them to the platform correctly.

