### PR TITLE
Fix dataclasses dependency for Python>=3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
     setup_requires=["wheel"],
     install_requires=[
         "argcomplete",
-        "dataclasses",
+        "dataclasses;python_version<'3.7'",
         "humanize",
         "numpy",
         "pillow",


### PR DESCRIPTION
According to https://pypi.org/project/dataclasses/ in Python>=3.7 the built-in module should be used instead.
This was causing issues for us on Python3.8 where the darwin dataclasses dependency was causing issues by using the PyPi module not the built-in one which is incompatible.