### PR TITLE
Update to upolygon 0.1.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
         "pyyaml>=5.1",
         "requests",
         "rich",
-        "upolygon==0.1.6",
+        "upolygon==0.1.8",
         "jsonschema==3.2.0",
         "deprecation",
         "pydantic",


### PR DESCRIPTION
From what I can tell, `darwin` isn't importable on Ubuntu 18 with Python 3.10. However, the issue is in upolygon 0.1.6 and not in darwin-py.

Partial stacktrace:
```
  File "/home/jolae/miniconda3/envs/downloader_3_10/lib/python3.10/site-packages/darwin/utils.py", line 24, in <module>
    from upolygon import draw_polygon
  File "/home/jolae/miniconda3/envs/downloader_3_10/lib/python3.10/site-packages/upolygon/__init__.py", line 1, in <module>
    from draw_polygon import draw_polygon  # noqa
ImportError: /home/jolae/miniconda3/envs/downloader_3_10/lib/python3.10/site-packages/draw_polygon.cpython-310-x86_64-linux-gnu.so: undefined symbol: _PyGen_Send
```

Indeed, `upolygon` version 0.1.6 isn't importable. I upgraded to `upolygon==0.1.8` locally, and then I see no issues with either darwin nor upolygon.

The problem for me now is that `upolygon` is pinned to 0.1.6 in this project, so I can't create a correct requirements.txt/environment.yml in my own project. Is there a specific reason for having a pinned version? To me it would be acceptable with "upolygon>=0.1.6".