### PR TITLE
Pass number of max workers for upload

### DIFF
--- a/darwin/dataset/remote_dataset.py
+++ b/darwin/dataset/remote_dataset.py
@@ -124,6 +124,7 @@ class RemoteDataset(ABC):
         *,
         blocking: bool = True,
         multi_threaded: bool = True,
+        max_workers: Optional[int] = None,
         fps: int = 0,
         as_frames: bool = False,
         files_to_exclude: Optional[List[PathLike]] = None,

--- a/darwin/dataset/remote_dataset_v1.py
+++ b/darwin/dataset/remote_dataset_v1.py
@@ -111,6 +111,7 @@ class RemoteDatasetV1(RemoteDataset):
         *,
         blocking: bool = True,
         multi_threaded: bool = True,
+        max_workers: Optional[int] = None,
         fps: int = 0,
         as_frames: bool = False,
         files_to_exclude: Optional[List[PathLike]] = None,
@@ -131,6 +132,8 @@ class RemoteDatasetV1(RemoteDataset):
         multi_threaded : bool, default: True
             Uses multiprocessing to upload the dataset in parallel.
             If blocking is False this has no effect.
+        max_workers : int, default: None
+            Maximum number of workers to use for parallel upload.
         fps : int, default: 0
             When the uploading file is a video, specify its framerate.
         as_frames: bool, default: False
@@ -186,6 +189,7 @@ class RemoteDatasetV1(RemoteDataset):
         handler = UploadHandlerV1(self, uploading_files)
         if blocking:
             handler.upload(
+                max_workers=max_workers,
                 multi_threaded=multi_threaded,
                 progress_callback=progress_callback,
                 file_upload_callback=file_upload_callback,

--- a/darwin/dataset/remote_dataset_v2.py
+++ b/darwin/dataset/remote_dataset_v2.py
@@ -111,7 +111,7 @@ class RemoteDatasetV2(RemoteDataset):
         *,
         blocking: bool = True,
         multi_threaded: bool = True,
-        max_workers: int = None,
+        max_workers: Optional[int] = None,
         fps: int = 0,
         as_frames: bool = False,
         files_to_exclude: Optional[List[PathLike]] = None,

--- a/darwin/dataset/remote_dataset_v2.py
+++ b/darwin/dataset/remote_dataset_v2.py
@@ -111,6 +111,7 @@ class RemoteDatasetV2(RemoteDataset):
         *,
         blocking: bool = True,
         multi_threaded: bool = True,
+        max_workers: int = None,
         fps: int = 0,
         as_frames: bool = False,
         files_to_exclude: Optional[List[PathLike]] = None,
@@ -131,6 +132,8 @@ class RemoteDatasetV2(RemoteDataset):
         multi_threaded : bool, default: True
             Uses multiprocessing to upload the dataset in parallel.
             If blocking is False this has no effect.
+        max_workers : int, default: None
+            Maximum number of workers to use for parallel upload.
         fps : int, default: 0
             When the uploading file is a video, specify its framerate.
         as_frames: bool, default: False
@@ -158,7 +161,6 @@ class RemoteDatasetV2(RemoteDataset):
             - If a path is specified when uploading a LocalFile object.
             - If there are no files to upload (because path is wrong or the exclude filter excludes everything).
         """
-
         if files_to_exclude is None:
             files_to_exclude = []
 
@@ -186,6 +188,7 @@ class RemoteDatasetV2(RemoteDataset):
         handler = UploadHandlerV2(self, uploading_files)
         if blocking:
             handler.upload(
+                max_workers=max_workers,
                 multi_threaded=multi_threaded,
                 progress_callback=progress_callback,
                 file_upload_callback=file_upload_callback,

--- a/darwin/dataset/upload_manager.py
+++ b/darwin/dataset/upload_manager.py
@@ -338,6 +338,14 @@ class UploadHandler(ABC):
                     file_complete.add(file_name)
                     progress_callback(self.pending_count, 1)
 
+        if max_workers:
+            if max_workers < 1:
+                raise ValueError("max_workers must be greater than 0")
+            elif max_workers > concurrent.futures.ThreadPoolExecutor()._max_workers:
+                raise ValueError(
+                    f"max_workers must be less than or equal to {concurrent.futures.ThreadPoolExecutor()._max_workers}"
+                )
+
         if multi_threaded and self.progress:
             with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
                 future_to_progress = {executor.submit(f, callback) for f in self.progress}

--- a/darwin/dataset/upload_manager.py
+++ b/darwin/dataset/upload_manager.py
@@ -447,7 +447,7 @@ class UploadHandlerV1(UploadHandler):
                     if upload_response.status_code != 503:
                         break
 
-                    time.sleep(2 ** retries)
+                    time.sleep(2**retries)
                     retries += 1
 
             upload_response.raise_for_status()
@@ -540,7 +540,7 @@ class UploadHandlerV2(UploadHandler):
                     if upload_response.status_code != 503:
                         break
 
-                    time.sleep(2 ** retries)
+                    time.sleep(2**retries)
                     retries += 1
 
             upload_response.raise_for_status()

--- a/darwin/dataset/upload_manager.py
+++ b/darwin/dataset/upload_manager.py
@@ -447,7 +447,7 @@ class UploadHandlerV1(UploadHandler):
                     if upload_response.status_code != 503:
                         break
 
-                    time.sleep(2**retries)
+                    time.sleep(2 ** retries)
                     retries += 1
 
             upload_response.raise_for_status()
@@ -540,7 +540,7 @@ class UploadHandlerV2(UploadHandler):
                     if upload_response.status_code != 503:
                         break
 
-                    time.sleep(2**retries)
+                    time.sleep(2 ** retries)
                     retries += 1
 
             upload_response.raise_for_status()


### PR DESCRIPTION
Hello,

This is for [issue #427 ](https://github.com/v7labs/darwin-py/issues/427).

Now, the value of `max_workers`, can be passed from `RemoteDataset` objects directly into `UploadHandler`. Additionally, there are some validation that is done on `max_workers` in `UploadHandler`.