### PR TITLE
[SWAT-450][External] Skipping import of file if no annotations are present

### DIFF
--- a/darwin/cli.py
+++ b/darwin/cli.py
@@ -112,7 +112,7 @@ def _run(args: Namespace, parser: ArgumentParser) -> None:
         elif args.action == "pull":
             f.pull_dataset(args.dataset, args.only_annotations, args.folders, args.video_frames)
         elif args.action == "import":
-            f.dataset_import(args.dataset, args.format, args.files, args.append, not args.yes)
+            f.dataset_import(args.dataset, args.format, args.files, args.append, not args.yes, args.delete_for_empty)
         elif args.action == "convert":
             f.dataset_convert(args.dataset, args.format, args.output_dir)
         elif args.action == "set-file-status":

--- a/darwin/cli_functions.py
+++ b/darwin/cli_functions.py
@@ -735,7 +735,7 @@ def dataset_import(
     append : bool, default: True
         If ``True`` it appends the annotation from the files to the dataset, if ``False`` it will
         override the dataset's current annotations with the ones from the given files.
-        Incompatible with ``delete_for_empty``.
+        Incompatible with ``delete-for-empty``.
     delete_for_empty : bool, default: False
         If ``True`` will use empty annotation files to delete all annotations from the remote file.
         If ``False``, empty annotation files will simply be skipped.

--- a/darwin/cli_functions.py
+++ b/darwin/cli_functions.py
@@ -737,6 +737,7 @@ def dataset_import(
     delete_for_empty : bool, default: False
         If ``True`` will use empty annotation files to delete all annotations from the remote file.
         If ``False``, empty annotation files will simply be skipped.
+        Only works for V2 datasets.
     """
 
     client: Client = _load_client(dataset_identifier=dataset_slug)

--- a/darwin/cli_functions.py
+++ b/darwin/cli_functions.py
@@ -738,6 +738,7 @@ def dataset_import(
         If ``True`` will use empty annotation files to delete all annotations from the remote file.
         If ``False``, empty annotation files will simply be skipped.
         Only works for V2 datasets.
+        Takes precedence over the ``append`` flag.
     """
 
     client: Client = _load_client(dataset_identifier=dataset_slug)

--- a/darwin/cli_functions.py
+++ b/darwin/cli_functions.py
@@ -712,7 +712,12 @@ def upload_data(
 
 
 def dataset_import(
-    dataset_slug: str, format: str, files: List[PathLike], append: bool, class_prompt: bool = True
+    dataset_slug: str,
+    format: str,
+    files: List[PathLike],
+    append: bool,
+    class_prompt: bool = True,
+    delete_for_empty: bool = False,
 ) -> None:
     """
     Imports annotation files to the given dataset.
@@ -720,15 +725,18 @@ def dataset_import(
 
     Parameters
     ----------
-    dataset_slug: str
+    dataset_slug : str
         The dataset's slug.
-    format: str
+    format : str
         Format of the export files.
-    files: List[PathLike]
+    files : List[PathLike]
         List of where the files are.
-    append: bool
-        If True it appends the annotation from the files to the dataset, if False it will override
-        the dataset's current annotations with the ones from the given files.
+    append : bool, default: True
+        If ``True`` it appends the annotation from the files to the dataset, if ``False`` it will
+        override the dataset's current annotations with the ones from the given files.
+    delete_for_empty : bool, default: False
+        If ``True`` will use empty annotation files to delete all annotations from the remote file.
+        If ``False``, empty annotation files will simply be skipped.
     """
 
     client: Client = _load_client(dataset_identifier=dataset_slug)
@@ -736,7 +744,7 @@ def dataset_import(
     try:
         parser: ImportParser = get_importer(format)
         dataset: RemoteDataset = client.get_remote_dataset(dataset_identifier=dataset_slug)
-        import_annotations(dataset, parser, files, append, class_prompt)
+        import_annotations(dataset, parser, files, append, class_prompt, delete_for_empty)
     except ImporterNotFoundError:
         _error(f"Unsupported import format: {format}, currently supported: {import_formats}")
     except AttributeError:

--- a/darwin/cli_functions.py
+++ b/darwin/cli_functions.py
@@ -34,6 +34,7 @@ from darwin.dataset.upload_manager import LocalFile
 from darwin.dataset.utils import get_release_path
 from darwin.datatypes import ExportParser, ImportParser, PathLike, Team
 from darwin.exceptions import (
+    IncompatibleOptions,
     InvalidLogin,
     MissingConfig,
     NameTaken,
@@ -734,11 +735,12 @@ def dataset_import(
     append : bool, default: True
         If ``True`` it appends the annotation from the files to the dataset, if ``False`` it will
         override the dataset's current annotations with the ones from the given files.
+        Incompatible with ``delete_for_empty``.
     delete_for_empty : bool, default: False
         If ``True`` will use empty annotation files to delete all annotations from the remote file.
         If ``False``, empty annotation files will simply be skipped.
         Only works for V2 datasets.
-        Takes precedence over the ``append`` flag.
+        Incompatible with ``append``.
     """
 
     client: Client = _load_client(dataset_identifier=dataset_slug)
@@ -753,6 +755,8 @@ def dataset_import(
         _error(f"Unsupported import format: {format}, currently supported: {import_formats}")
     except NotFound as e:
         _error(f"No dataset with name '{e.name}'")
+    except IncompatibleOptions as e:
+        _error(str(e))
 
 
 def list_files(

--- a/darwin/exceptions.py
+++ b/darwin/exceptions.py
@@ -1,12 +1,19 @@
 from pathlib import Path
 
 
+class IncompatibleOptions(Exception):
+    """
+    Used when a combination of options has one or more options that are not compatible between them.
+    An option is not compatible with another if any combination from their set of possibilities
+    returns an unspecified result.
+    """
+
+
 class Unauthenticated(Exception):
     """
     Used when a user tries to perform an action that requires authentication without being
     authenticated.
     """
-
 
 
 class InvalidLogin(Exception):
@@ -15,19 +22,16 @@ class InvalidLogin(Exception):
     """
 
 
-
 class InvalidTeam(Exception):
     """
     Used when a team is not found or has no valid API key.
     """
 
 
-
 class MissingConfig(Exception):
     """
     Used when the configuration file was not found.
     """
-
 
 
 class UnsupportedExportFormat(Exception):
@@ -84,19 +88,16 @@ class InsufficientStorage(Exception):
     """
 
 
-
 class NameTaken(Exception):
     """
     Used when one tries to create an entity and the name of that entity is already taken.
     """
 
 
-
 class ValidationError(Exception):
     """
     Used when a validation fails.
     """
-
 
 
 class Unauthorized(Exception):
@@ -112,4 +113,3 @@ class OutdatedDarwinJSONFormat(Exception):
     """
     Used when one tries to parse a video with an old darwin format that is no longer compatible.
     """
-

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -180,6 +180,7 @@ def import_annotations(
     delete_for_empty : bool, default: False
         If ``True`` will use empty annotation files to delete all annotations from the remote file.
         If ``False``, empty annotation files will simply be skipped.
+        Only works for V2 datasets.
 
     Raises
     -------
@@ -284,10 +285,14 @@ def import_annotations(
     else:
         remote_classes = build_main_annotations_lookup_table(team_classes)
 
-    console.print(
-        "Importing annotations...\nEmpty annotations will be skipped, if you want to delete annotations rerun with '--delete-for-empty' ",
-        style="info",
-    )
+    if dataset.version == 1:
+        console.print("Importing annotations...\nEmpty annotations will be skipped.", style="info")
+    else:
+        console.print(
+            "Importing annotations...\nEmpty annotations will be skipped, if you want to delete annotations rerun with '--delete-for-empty' ",
+            style="info",
+        )
+
     # Need to re parse the files since we didn't save the annotations in memory
     for local_path in set(local_file.path for local_file in local_files):
 
@@ -304,7 +309,7 @@ def import_annotations(
         parsed_files = [parsed_file for parsed_file in parsed_files if parsed_file.full_path not in missing_files]
 
         for parsed_file in track(parsed_files):
-            if parsed_file.annotations or delete_for_empty:
+            if parsed_file.annotations or (delete_for_empty and dataset.version == 2):
                 image_id = remote_files[parsed_file.full_path]
                 _import_annotations(
                     dataset.client, image_id, remote_classes, attributes, parsed_file.annotations, dataset, append

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -1,4 +1,3 @@
-from ast import Or
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -22,7 +21,9 @@ import deprecation
 from darwin.datatypes import PathLike
 from darwin.utils import secure_continue_request
 from darwin.version import __version__
+from rich.console import Console
 from rich.progress import track
+from rich.theme import Theme
 
 DEPRECATION_MESSAGE = """
 
@@ -183,11 +184,12 @@ def import_annotations(
         - If the application is unable to fetch any remote classes.
         - If the application was unable to find/parse any annotation files.
     """
+    console = Console(theme=_console_theme())
 
     if not isinstance(file_paths, list):
         raise ValueError(f"file_paths must be a list of 'Path' or 'str'. Current value: {file_paths}")
 
-    print("Fetching remote class list...")
+    console.print("Fetching remote class list...", style="info")
     team_classes: List[Dict[str, Any]] = dataset.fetch_remote_classes(True)
     if not team_classes:
         raise ValueError("Unable to fetch remote class list.")
@@ -200,7 +202,7 @@ def import_annotations(
     )
     attributes = build_attribute_lookup(dataset)
 
-    print("Retrieving local annotations ...")
+    console.print("Retrieving local annotations ...", style="info")
     local_files = []
     local_files_missing_remotely = []
     maybe_parsed_files: Optional[Iterable[dt.AnnotationFile]] = find_and_parse(importer, file_paths)
@@ -210,7 +212,7 @@ def import_annotations(
     parsed_files = list(maybe_parsed_files)
     filenames: List[str] = [parsed_file.filename for parsed_file in parsed_files]
 
-    print("Fetching remote file list...")
+    console.print("Fetching remote file list...", style="info")
     # This call will only filter by filename; so can return a superset of matched files across different paths
     # There is logic in this function to then include paths to narrow down to the single correct matching file
     remote_files = get_remote_files(dataset, filenames)
@@ -220,11 +222,11 @@ def import_annotations(
         else:
             local_files.append(parsed_file)
 
-    print(f"{len(local_files) + len(local_files_missing_remotely)} annotation file(s) found.")
+    console.print(f"{len(local_files) + len(local_files_missing_remotely)} annotation file(s) found.", style="info")
     if local_files_missing_remotely:
-        print(f"{len(local_files_missing_remotely)} file(s) are missing from the dataset")
+        console.print(f"{len(local_files_missing_remotely)} file(s) are missing from the dataset", style="warning")
         for local_file in local_files_missing_remotely:
-            print(f"\t{local_file.path}: '{local_file.full_path}'")
+            console.print(f"\t{local_file.path}: '{local_file.full_path}'", style="warning")
 
         if class_prompt and not secure_continue_request():
             return
@@ -235,22 +237,26 @@ def import_annotations(
         classes_in_team,
     )
 
-    print(f"{len(local_classes_not_in_team)} classes needs to be created.")
-    print(f"{len(local_classes_not_in_dataset)} classes needs to be added to {dataset.identifier}")
+    console.print(f"{len(local_classes_not_in_team)} classes needs to be created.", style="info")
+    console.print(
+        f"{len(local_classes_not_in_dataset)} classes needs to be added to {dataset.identifier}", style="info"
+    )
 
     missing_skeletons: List[dt.AnnotationClass] = list(filter(_is_skeleton_class, local_classes_not_in_team))
     missing_skeleton_names: str = ", ".join(map(_get_skeleton_name, missing_skeletons))
     if missing_skeletons:
-        print(
-            f"Found missing skeleton classes: {missing_skeleton_names}. Missing Skeleton classes cannot be created. Exiting now."
+        console.print(
+            f"Found missing skeleton classes: {missing_skeleton_names}. Missing Skeleton classes cannot be created. Exiting now.",
+            style="error",
         )
         return
 
     if local_classes_not_in_team:
-        print("About to create the following classes")
+        console.print("About to create the following classes", style="info")
         for missing_class in local_classes_not_in_team:
-            print(
-                f"\t{missing_class.name}, type: {missing_class.annotation_internal_type or missing_class.annotation_type}"
+            console.print(
+                f"\t{missing_class.name}, type: {missing_class.annotation_internal_type or missing_class.annotation_type}",
+                style="info",
             )
         if class_prompt and not secure_continue_request():
             return
@@ -259,7 +265,7 @@ def import_annotations(
                 missing_class.name, missing_class.annotation_internal_type or missing_class.annotation_type
             )
     if local_classes_not_in_dataset:
-        print(f"About to add the following classes to {dataset.identifier}")
+        console.print(f"About to add the following classes to {dataset.identifier}", style="info")
         for cls in local_classes_not_in_dataset:
             dataset.add_annotation_class(cls)
 
@@ -288,10 +294,16 @@ def import_annotations(
         missing_files = [missing_file.full_path for missing_file in local_files_missing_remotely]
         parsed_files = [parsed_file for parsed_file in parsed_files if parsed_file.full_path not in missing_files]
         for parsed_file in track(parsed_files):
-            image_id = remote_files[parsed_file.full_path]
-            _import_annotations(
-                dataset.client, image_id, remote_classes, attributes, parsed_file.annotations, dataset, append
-            )
+            if not parsed_file.annotations:
+                # We want to let the user know if the file has no annotations
+                console.print(
+                    f"\nNo annotations found for file {parsed_file.filename}. Skipping upload.", style="warning"
+                )
+            else:
+                image_id = remote_files[parsed_file.full_path]
+                _import_annotations(
+                    dataset.client, image_id, remote_classes, attributes, parsed_file.annotations, dataset, append
+                )
 
 
 def _is_skeleton_class(the_class: dt.AnnotationClass) -> bool:
@@ -379,3 +391,9 @@ def _import_annotations(
         payload["overwrite"] = "false"
 
     dataset.import_annotation(id, payload=payload)
+
+
+def _console_theme() -> Theme:
+    return Theme(
+        {"success": "bold green", "warning": "bold yellow", "error": "bold red", "info": "bold deep_sky_blue1"}
+    )

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -440,8 +440,6 @@ def _import_annotations(
     payload: Dict[str, Any] = {"annotations": serialized_annotations}
     if append:
         payload["overwrite"] = "false"
-    elif delete_for_empty and not annotations:
-        payload["overwrite"] = "true"
     else:
         payload["overwrite"] = "true"
 

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -318,7 +318,14 @@ def import_annotations(
             if parsed_file.annotations or (delete_for_empty and dataset.version == 2):
                 image_id = remote_files[parsed_file.full_path]
                 _import_annotations(
-                    dataset.client, image_id, remote_classes, attributes, parsed_file.annotations, dataset, append
+                    dataset.client,
+                    image_id,
+                    remote_classes,
+                    attributes,
+                    parsed_file.annotations,
+                    dataset,
+                    append,
+                    delete_for_empty,
                 )
             else:
                 console.print(
@@ -372,6 +379,7 @@ def _import_annotations(
     annotations: List[dt.Annotation],
     dataset: "RemoteDataset",
     append: bool,
+    delete_for_empty: bool,
 ):
     serialized_annotations = []
     for annotation in annotations:
@@ -409,6 +417,9 @@ def _import_annotations(
     payload: Dict[str, Any] = {"annotations": serialized_annotations}
     if append:
         payload["overwrite"] = "false"
+
+    if delete_for_empty and not annotations:
+        payload["overwrite"] = "true"
 
     dataset.import_annotation(id, payload=payload)
 

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -428,8 +428,9 @@ def _import_annotations(
     payload: Dict[str, Any] = {"annotations": serialized_annotations}
     if append:
         payload["overwrite"] = "false"
-
-    if delete_for_empty and not annotations:
+    elif delete_for_empty and not annotations:
+        payload["overwrite"] = "true"
+    else:
         payload["overwrite"] = "true"
 
     dataset.import_annotation(id, payload=payload)

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 import darwin.datatypes as dt
 import deprecation
 from darwin.datatypes import PathLike
+from darwin.exceptions import IncompatibleOptions
 from darwin.utils import secure_continue_request
 from darwin.version import __version__
 from rich.console import Console
@@ -175,13 +176,14 @@ def import_annotations(
         A list of ``Path``'s or strings containing the Annotations we wish to import.
     append : bool
         If ``True`` appends the given annotations to the datasets. If ``False`` will override them.
+        Incompatible with ``delete_for_empty``.
     class_prompt : bool
         If ``False`` classes will be created and added to the datasets without requiring a user's prompt.
     delete_for_empty : bool, default: False
         If ``True`` will use empty annotation files to delete all annotations from the remote file.
         If ``False``, empty annotation files will simply be skipped.
         Only works for V2 datasets.
-        Takes precedence over the ``append`` flag.
+        Incompatible with ``append``.
 
     Raises
     -------
@@ -190,8 +192,17 @@ def import_annotations(
         - If ``file_paths`` is not a list.
         - If the application is unable to fetch any remote classes.
         - If the application was unable to find/parse any annotation files.
+
+    IncompatibleOptions
+
+        - If both ``append`` and ``delete_for_empty`` are specified as ``True``.
     """
     console = Console(theme=_console_theme())
+
+    if append and delete_for_empty:
+        raise IncompatibleOptions(
+            "The options 'append' and 'delete_for_empty' cannot be used together. Use only one of them."
+        )
 
     if not isinstance(file_paths, list):
         raise ValueError(f"file_paths must be a list of 'Path' or 'str'. Current value: {file_paths}")

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -114,7 +114,7 @@ def build_attribute_lookup(dataset: "RemoteDataset") -> Dict[str, Any]:
     details=DEPRECATION_MESSAGE,
 )
 def get_remote_files(dataset: "RemoteDataset", filenames: List[str]) -> Dict[str, int]:
-    """Fetches remote files from the datasets, in chunks of 100 filesnames at a time"""
+    """Fetches remote files from the datasets, in chunks of 100 filenames at a time"""
     remote_files = {}
     for i in range(0, len(filenames), 100):
         chunk = filenames[i : i + 100]

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -181,6 +181,7 @@ def import_annotations(
         If ``True`` will use empty annotation files to delete all annotations from the remote file.
         If ``False``, empty annotation files will simply be skipped.
         Only works for V2 datasets.
+        Takes precedence over the ``append`` flag.
 
     Raises
     -------
@@ -287,9 +288,14 @@ def import_annotations(
 
     if dataset.version == 1:
         console.print("Importing annotations...\nEmpty annotations will be skipped.", style="info")
+    elif dataset.version == 2 and delete_for_empty:
+        console.print(
+            "Importing annotations...\nEmpty annotations will clear all existing annotations in remote files.",
+            style="info",
+        )
     else:
         console.print(
-            "Importing annotations...\nEmpty annotations will be skipped, if you want to delete annotations rerun with '--delete-for-empty' ",
+            "Importing annotations...\nEmpty annotations will be skipped, if you want to delete annotations rerun with '--delete-for-empty'.",
             style="info",
         )
 

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -307,7 +307,7 @@ def import_annotations(
         console.print("Importing annotations...\nEmpty annotations will be skipped.", style="info")
     elif dataset.version == 2 and delete_for_empty:
         console.print(
-            "Importing annotations...\nEmpty annotations will clear all existing annotations in remote files.",
+            "Importing annotations...\nEmpty annotation file(s) will clear all existing annotations in matching remote files.",
             style="info",
         )
     else:

--- a/darwin/item.py
+++ b/darwin/item.py
@@ -86,7 +86,7 @@ class DatasetItem(BaseModel):
                 "path": raw["path"],
                 "status": raw["status"],
                 "archived": raw["archived"],
-                "filesize": sum(file["size_bytes"] for file in raw["slots"]),
+                "filesize": sum(file.get("size_bytes", 0) for file in raw["slots"]),
                 "dataset_id": raw["dataset_id"],
                 "dataset_slug": "n/a",
                 "seq": None,

--- a/darwin/options.py
+++ b/darwin/options.py
@@ -13,7 +13,7 @@ class Options(object):
     def __init__(self):
 
         self.parser: ArgumentParser = ArgumentParser(
-            description="Commandline tool to create/upload/download datasets on darwin."
+            description="Command line tool to create/upload/download datasets on darwin."
         )
 
         subparsers = self.parser.add_subparsers(dest="command")
@@ -173,6 +173,7 @@ class Options(object):
         parser_import.add_argument(
             "--yes", action="store_true", help="Skips prompts for creating and adding classes to dataset."
         )
+        parser_import.add_argument("--delete-for-empty", action="store_true", help="Empty annotations will delete annotations from remote files.")
 
         # Convert
         parser_convert = dataset_action.add_parser("convert", help="Converts darwin json to other annotation formats.")


### PR DESCRIPTION
- Fixes crash when importing an annotations file that has no annotations
- Revamped the print messages to use Rich instead of `print` (consistency changes).

Ticket: https://linear.app/v7labs/issue/SWAT-450/regression-error-when-importing-empty-annotation-files