### PR TITLE
[IO-311][external] Add support to setting 'complete' status on items

### DIFF
--- a/darwin/cli_functions.py
+++ b/darwin/cli_functions.py
@@ -825,8 +825,9 @@ def set_file_status(dataset_slug: str, status: str, files: List[str]) -> None:
     files: List[str]
         Names of the files we want to update.
     """
-    if status not in ["archived", "clear", "new", "restore-archived"]:
-        _error(f"Invalid status '{status}', available statuses: archived, clear, new, restore-archived")
+    available_statuses = ["archived", "clear", "new", "restore-archived", "complete"]
+    if status not in available_statuses:
+        _error(f"Invalid status '{status}', available statuses: {', '.join(available_statuses)}")
 
     client: Client = _load_client(dataset_identifier=dataset_slug)
     try:
@@ -840,8 +841,12 @@ def set_file_status(dataset_slug: str, status: str, files: List[str]) -> None:
             dataset.move_to_new(items)
         elif status == "restore-archived":
             dataset.restore_archived(items)
+        elif status == "complete":
+            dataset.complete(items)
     except NotFound as e:
         _error(f"No dataset with name '{e.name}'")
+    except ValueError as e:
+        _error(e)
 
 
 def delete_files(dataset_slug: str, files: List[str], skip_user_confirmation: bool = False) -> None:

--- a/darwin/client.py
+++ b/darwin/client.py
@@ -3,7 +3,7 @@ import os
 import time
 from logging import Logger
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional, Union, cast
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union, cast
 from urllib import parse
 
 import requests
@@ -25,6 +25,7 @@ from darwin.exceptions import (
     Unauthorized,
     ValidationError,
 )
+from darwin.item import DatasetItem
 from darwin.utils import (
     get_response_content,
     has_json_content_type,
@@ -757,6 +758,27 @@ class Client:
         """
         self._put_raw(f"teams/{team_slug}/datasets/{dataset_slug}/items/reset", payload, team_slug)
 
+    def move_to_stage(self, dataset_slug: str, team_slug: str, filters: Dict[str, Any], stage_id: int) -> None:
+        """
+        Moves the given items to the specified stage
+
+        Parameters
+        ----------
+        dataset_slug: str
+            The slug of the dataset.
+        team_slug: str
+            The slug of the team.
+        filters: Dict[str, Any]
+            A filter Dictionary that defines the items to have the new, selected stage.
+        stage_id: int
+            ID of the stage to set.
+        """
+        payload: Dict[str, Any] = {
+            "filter": filters,
+            "workflow_stage_template_id": stage_id,
+        }
+        self._put_raw(f"teams/{team_slug}/datasets/{dataset_slug}/set_stage", payload, team_slug)
+
     def post_workflow_comment(
         self, workflow_id: int, text: str, x: float = 1, y: float = 1, w: float = 1, h: float = 1
     ) -> int:
@@ -797,7 +819,7 @@ class Client:
 
         return comment_id
 
-    def instantiate_item(self, item_id: int) -> int:
+    def instantiate_item(self, item_id: int, include_metadata: bool = False) -> Union[int, Tuple[int, DatasetItem]]:
         """
         Instantiates the given item with a workflow.
 
@@ -805,6 +827,9 @@ class Client:
         ----------
         item_id: int
             The id of the item to be instantiated.
+
+        include_metadata: bool
+            If set to True, this method returns a tuple instead, with 2nd element being DatasetItem.
 
         Returns
         -------
@@ -822,7 +847,10 @@ class Client:
         if id is None:
             raise ValueError(f"No Workflow Id found for item_id: {item_id}")
 
-        return id
+        if include_metadata:
+            return (id, DatasetItem.parse(response))
+        else:
+            return id
 
     def fetch_binary(self, url: str) -> Response:
         """

--- a/darwin/dataset/remote_dataset.py
+++ b/darwin/dataset/remote_dataset.py
@@ -378,6 +378,17 @@ class RemoteDataset(ABC):
         """
 
     @abstractmethod
+    def complete(self, items: Iterator[DatasetItem]) -> None:
+        """
+        Completes the given ``DatasetItem``\\s.
+
+        Parameters
+        ----------
+        items : Iterator[DatasetItem]
+            The ``DatasetItem``\\s to be completed.
+        """
+
+    @abstractmethod
     def delete_items(self, items: Iterator[DatasetItem]) -> None:
         """
         Deletes the given ``DatasetItem``\\s.

--- a/darwin/dataset/remote_dataset_v1.py
+++ b/darwin/dataset/remote_dataset_v1.py
@@ -1,4 +1,6 @@
+import itertools
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Union
+from xml.dom import ValidationErr
 
 from darwin.dataset.release import Release
 from darwin.dataset.upload_manager import (
@@ -10,7 +12,7 @@ from darwin.dataset.upload_manager import (
 )
 from darwin.dataset.utils import is_relative_to
 from darwin.datatypes import ItemId, PathLike
-from darwin.exceptions import NotFound
+from darwin.exceptions import NotFound, ValidationError
 from darwin.item import DatasetItem
 from darwin.item_sorter import ItemSorter
 from darwin.utils import find_files, urljoin
@@ -293,6 +295,51 @@ class RemoteDatasetV1(RemoteDataset):
         """
         payload: Dict[str, Any] = {"filter": {"dataset_item_ids": [item.id for item in items]}}
         self.client.reset_item(self.slug, self.team, payload)
+
+    def complete(self, items: Iterator[DatasetItem]) -> None:
+        """
+        Completes the given ``DatasetItem``\\s.
+
+        Parameters
+        ----------
+        items : Iterator[DatasetItem]
+            The ``DatasetItem``\\s to be completed.
+        """
+        wf_template_id_mapper = lambda item: item.current_workflow["workflow_template_id"]
+        input_items: List[DatasetItem] = list(items)
+
+        # We split into items with and without workflow
+        items_wf = filter(lambda item: item.current_workflow, input_items)
+        items_no_wf = filter(lambda item: item.current_workflow is None, input_items)
+
+        # All items without workflow get instantiated
+        items_instantiated: List[DatasetItem] = []
+        for old_item in items_no_wf:
+            (_, item) = self.client.instantiate_item(old_item.id, include_metadata=True)
+            items_instantiated.append(item)
+
+        #  We create new list of items from instantiated items and other items with workflow
+        # We also group them by workflow_template_id, because we can't do batch across diff templates
+        items = sorted([*items_wf, *items_instantiated], key=wf_template_id_mapper)
+        items_by_wf_template = itertools.groupby(
+            items,
+            key=wf_template_id_mapper,
+        )
+
+        # For each WF template, we find complete stage template id
+        # and try to set stage for all items in this workflow
+        for wf_template_id, current_items in items_by_wf_template:
+            current_items = list(current_items)
+            sample_item = current_items[0]
+            deep_sample_stages = sample_item.current_workflow["stages"].values()
+            sample_stages = [item for sublist in deep_sample_stages for item in sublist]
+            complete_stage = list(filter(lambda stage: stage["type"] == "complete", sample_stages))[0]
+
+            filters = {"dataset_item_ids": [item.id for item in current_items]}
+            try:
+                self.client.move_to_stage(self.slug, self.team, filters, complete_stage["workflow_stage_template_id"])
+            except ValidationError:
+                raise ValueError("Unable to complete some of provided items. Make sure to assign them to a user first.")
 
     def delete_items(self, items: Iterator[DatasetItem]) -> None:
         """

--- a/darwin/item.py
+++ b/darwin/item.py
@@ -51,6 +51,10 @@ class DatasetItem(BaseModel):
     #: only used for v2 dataset items
     slots: List[Any]
 
+    #: Metadata of this ``DatasetItem``'s workflow. A ``None`` value means this ``DatasetItem`` is
+    #: new and was never worked on, or was reset to the new state.
+    current_workflow: Optional[Dict[str, Any]]
+
     @property
     def full_path(self) -> str:
         """
@@ -104,6 +108,7 @@ class DatasetItem(BaseModel):
                 "dataset_slug": "n/a",
                 "seq": raw["seq"],
                 "current_workflow_id": raw.get("current_workflow_id"),
+                "current_workflow": raw.get("current_workflow"),
                 "path": raw["path"],
                 "slots": [],
             }


### PR DESCRIPTION
This is a new feature that adds ability to set items as "complete" for both V1 and V2 system.
The implementation for V2 is pretty simple and doesn't have anything weird about it.
The implementation for V1 is pretty horrible:
* We store more workflow data now, which is un-parsed and looks like it needs at least 2 more classes to store it "nicely" 
* We have pretty complex logic to circumvent the fact that API works per-workflow template, while items may be in different ones. We bail on any validation error by saying that item needs to be assigned. This feels similar to frontend does and is related to this virtual workflow called `default_auto_complete`. I don't fully understand how this works, so I would appreciate confirmation from @begedin that this logic is sound. The error is mostly reworded error that I saw on our UI.

That being said, I don't want to put more effort into this on V1, I don't think it's worth it. Let's please discuss issues with the logic, or maybe some simple improvements, but I don't want to refactor V1 specific code here. 