### PR TITLE
Fix the dataset create bug where num_videos could be missing in RemoteDatasetV1

### DIFF
--- a/darwin/client.py
+++ b/darwin/client.py
@@ -111,7 +111,7 @@ class Client:
                     slug=dataset["slug"],
                     team=team_slug or self.default_team,
                     dataset_id=dataset["id"],
-                    item_count=dataset["num_images"] + dataset["num_videos"],
+                    item_count=dataset.get("num_images", 0) + dataset.get("num_videos", 0),
                     progress=dataset["progress"],
                     client=self,
                 )
@@ -176,7 +176,7 @@ class Client:
                     slug=dataset["slug"],
                     team=parsed_dataset_identifier.team_slug,
                     dataset_id=dataset["id"],
-                    item_count=dataset.get("num_items", dataset["num_images"] + dataset["num_videos"]),
+                    item_count=dataset.get("num_items", dataset.get("num_images", 0) + dataset.get("num_videos", 0)),
                     progress=0,
                     client=self,
                 )
@@ -217,7 +217,7 @@ class Client:
                 team=team_slug or self.default_team,
                 slug=dataset["slug"],
                 dataset_id=dataset["id"],
-                item_count=dataset.get("num_items", dataset["num_images"] + dataset["num_videos"]),
+                item_count=dataset.get("num_items", dataset.get("num_images", 0) + dataset.get("num_videos", 0)),
                 progress=0,
                 client=self,
             )


### PR DESCRIPTION
Hello,

It was a fix for a bug with dataset create in RemoteDatasetV2 [here](https://github.com/v7labs/darwin-py/commit/7bebe08a4e416ddfb0aee70d3de2e9e5176d887e). However, the issue still persists with RemoteDatasetV1.

This fix is about to solve it.