### PR TITLE
[IO-432][external] Pull video frames concurrently

### DIFF
--- a/darwin/dataset/download_manager.py
+++ b/darwin/dataset/download_manager.py
@@ -21,7 +21,6 @@ from darwin.utils import (
 )
 from darwin.version import __version__
 from rich.console import Console
-from torch import le
 
 
 @deprecation.deprecated(

--- a/darwin/dataset/download_manager.py
+++ b/darwin/dataset/download_manager.py
@@ -6,8 +6,9 @@ import functools
 import json
 import time
 import urllib
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Any, Callable, Iterator, Tuple
+from typing import Any, Callable, Iterable, Iterator, List, Tuple
 
 import deprecation
 import requests
@@ -21,6 +22,7 @@ from darwin.utils import (
 )
 from darwin.version import __version__
 from rich.console import Console
+from torch import le
 
 
 @deprecation.deprecated(
@@ -40,7 +42,8 @@ def download_all_images_from_annotations(
     use_folders: bool = False,
     video_frames: bool = False,
     force_slots: bool = False,
-) -> Tuple[Callable[[], Iterator[Any]], int]:
+    multi_threaded: bool = True,
+) -> Tuple[Callable[[], Iterable[Any]], int]:
     """
     Downloads the all images corresponding to a project.
 
@@ -115,10 +118,9 @@ def download_all_images_from_annotations(
                 print(f"Removing {existing_image} as there is no corresponding annotation")
                 existing_image.unlink()
     # Create the generator with the partial functions
-    count = len(annotations_to_download_path)
-    generator = lambda: (
-        functools.partial(
-            download_image_from_annotation,
+    download_functions: List = []
+    for annotation_path in annotations_to_download_path:
+        file_download_functions = download_image_from_annotation(
             api_key,
             api_url,
             annotation_path,
@@ -127,10 +129,11 @@ def download_all_images_from_annotations(
             use_folders,
             video_frames,
             force_slots,
+            multi_threaded,
         )
-        for annotation_path in annotations_to_download_path
-    )
-    return generator, count
+        download_functions.extend(file_download_functions)
+
+    return lambda: download_functions, len(download_functions)
 
 
 @deprecation.deprecated(
@@ -148,7 +151,8 @@ def download_image_from_annotation(
     use_folders: bool,
     video_frames: bool,
     force_slots: bool,
-) -> None:
+    multi_threaded: bool,
+) -> Iterable[Callable[[], None]]:
     """
     Dispatches functions to download an image given an annotation.
 
@@ -180,8 +184,8 @@ def download_image_from_annotation(
     console = Console()
 
     if annotation_format == "json":
-        _download_image_from_json_annotation(
-            api_key, annotation_path, images_path, use_folders, video_frames, force_slots
+        return _download_image_from_json_annotation(
+            api_key, annotation_path, images_path, use_folders, video_frames, force_slots, multi_threaded
         )
     else:
         console.print("[bold red]Unsupported file format. Please use 'json'.")
@@ -189,11 +193,17 @@ def download_image_from_annotation(
 
 
 def _download_image_from_json_annotation(
-    api_key: str, annotation_path: Path, image_path: Path, use_folders: bool, video_frames: bool, force_slots: bool
-) -> None:
+    api_key: str,
+    annotation_path: Path,
+    image_path: Path,
+    use_folders: bool,
+    video_frames: bool,
+    force_slots: bool,
+    multi_threaded: bool,
+) -> Iterable[Callable[[], None]]:
     annotation = parse_darwin_json(annotation_path, count=0)
     if annotation is None:
-        return None
+        return []
 
     # If we are using folders, extract the path for the image and create the folder if needed
     sub_path = annotation.remote_path if use_folders else Path("/")
@@ -203,12 +213,17 @@ def _download_image_from_json_annotation(
     annotation.slots.sort(key=lambda slot: slot.name or "0")
     if len(annotation.slots) > 0:
         if force_slots:
-            _download_all_slots_from_json_annotation(annotation, api_key, parent_path, video_frames)
+            return _download_all_slots_from_json_annotation(
+                annotation, api_key, parent_path, video_frames, multi_threaded
+            )
         else:
-            _download_single_slot_from_json_annotation(annotation, api_key, parent_path, annotation_path, video_frames)
+            return _download_single_slot_from_json_annotation(
+                annotation, api_key, parent_path, annotation_path, video_frames, multi_threaded
+            )
 
 
-def _download_all_slots_from_json_annotation(annotation, api_key, parent_path, video_frames):
+def _download_all_slots_from_json_annotation(annotation, api_key, parent_path, video_frames, multi_threaded):
+    generator = []
     for slot in annotation.slots:
         slot_path = parent_path / sanitize_filename(annotation.filename) / sanitize_filename(slot.name)
         slot_path.mkdir(exist_ok=True, parents=True)
@@ -218,30 +233,43 @@ def _download_all_slots_from_json_annotation(annotation, api_key, parent_path, v
             video_path.mkdir(exist_ok=True, parents=True)
             for i, frame_url in enumerate(slot.frame_urls or []):
                 path = video_path / f"{i:07d}.png"
-                _download_image(frame_url, path, api_key)
+                generator.append(functools.partial(_download_image, frame_url, path, api_key))
         else:
             for upload in slot.source_files:
                 file_path = slot_path / sanitize_filename(upload["file_name"])
-                _download_image(upload["url"], file_path, api_key)
-                _update_local_path(annotation, upload["url"], file_path)
+
+                def download_and_update():
+                    _download_image(upload["url"], file_path, api_key)
+                    _update_local_path(annotation, upload["url"], file_path)
+
+                generator.append(download_and_update)
+    return generator
 
 
-def _download_single_slot_from_json_annotation(annotation, api_key, parent_path, annotation_path, video_frames):
+def _download_single_slot_from_json_annotation(
+    annotation, api_key, parent_path, annotation_path, video_frames, multi_threaded
+):
     slot = annotation.slots[0]
+    generator = []
 
     if video_frames and slot.type != "image":
         video_path: Path = parent_path / annotation_path.stem
         video_path.mkdir(exist_ok=True, parents=True)
         for i, frame_url in enumerate(slot.frame_urls or []):
             path = video_path / f"{i:07d}.png"
-            _download_image(frame_url, path, api_key)
+            generator.append(functools.partial(_download_image, frame_url, path, api_key))
     else:
         if len(slot.source_files) > 0:
             image_url = slot.source_files[0]["url"]
             filename = slot.source_files[0]["file_name"]
             image_path = parent_path / sanitize_filename(filename or annotation.filename)
-            _download_image(image_url, image_path, api_key)
-            _update_local_path(annotation, image_url, image_path)
+
+            def download_and_update():
+                _download_image(image_url, image_path, api_key)
+                _update_local_path(annotation, image_url, image_path)
+
+            generator.append(download_and_update)
+    return generator
 
 
 def _update_local_path(annotation: AnnotationFile, url, local_path):

--- a/darwin/dataset/remote_dataset.py
+++ b/darwin/dataset/remote_dataset.py
@@ -304,7 +304,6 @@ class RemoteDataset(ABC):
             use_folders=use_folders,
             video_frames=video_frames,
             force_slots=force_slots,
-            multi_threaded=multi_threaded,
         )
         if count == 0:
             return None, count
@@ -312,7 +311,7 @@ class RemoteDataset(ABC):
         # If blocking is selected, download the dataset on the file system
         if blocking:
             max_workers = None
-            env_max_workers = os.getenv("DARWIN_DOWNLOAD_FRAMES_CONCURRENCY")
+            env_max_workers = os.getenv("DARWIN_DOWNLOAD_FILES_CONCURRENCY")
             if env_max_workers and int(env_max_workers) > 0:
                 max_workers = int(env_max_workers)
 

--- a/darwin/dataset/remote_dataset.py
+++ b/darwin/dataset/remote_dataset.py
@@ -1,4 +1,5 @@
 import json
+import os
 import shutil
 import tempfile
 import zipfile
@@ -303,13 +304,19 @@ class RemoteDataset(ABC):
             use_folders=use_folders,
             video_frames=video_frames,
             force_slots=force_slots,
+            multi_threaded=multi_threaded,
         )
         if count == 0:
             return None, count
 
         # If blocking is selected, download the dataset on the file system
         if blocking:
-            exhaust_generator(progress=progress(), count=count, multi_threaded=multi_threaded)
+            max_workers = None
+            env_max_workers = os.getenv("DARWIN_DOWNLOAD_FRAMES_CONCURRENCY")
+            if env_max_workers and int(env_max_workers) > 0:
+                max_workers = int(env_max_workers)
+
+            exhaust_generator(progress=progress(), count=count, multi_threaded=multi_threaded, worker_count=max_workers)
             return None, count
         else:
             return progress, count

--- a/darwin/dataset/utils.py
+++ b/darwin/dataset/utils.py
@@ -170,7 +170,9 @@ def _f(x: Any) -> Any:
         return x()
 
 
-def exhaust_generator(progress: Generator, count: int, multi_threaded: bool) -> List[Dict[str, Any]]:
+def exhaust_generator(
+    progress: Generator, count: int, multi_threaded: bool, worker_count: Optional[int] = None
+) -> List[Dict[str, Any]]:
     """
     Exhausts the generator passed as parameter. Can be done multi threaded if desired.
 
@@ -182,6 +184,8 @@ def exhaust_generator(progress: Generator, count: int, multi_threaded: bool) -> 
         Size of the generator.
     multi_threaded : bool
         Flag for multi-threaded enabled operations.
+    worker_count : Optional[int]
+        Number of workers to use if multi_threaded=True. By default CPU count is used.
 
     Returns
     -------
@@ -195,8 +199,11 @@ def exhaust_generator(progress: Generator, count: int, multi_threaded: bool) -> 
         def update(*a):
             progress_bar.completed += 1
 
+        if worker_count is None:
+            worker_count = mp.cpu_count()
+
         with Live(progress_bar):
-            with mp.Pool(mp.cpu_count()) as pool:
+            with mp.Pool(worker_count) as pool:
                 for f in progress:
                     responses.append(pool.apply_async(_f, args=(f,), callback=update))
                 pool.close()


### PR DESCRIPTION
This PR makes it so downloading frames is counted in progress bar and uses multi-threading, significantly speeding up single items pulls. 
This also adds `DARWIN_DOWNLOAD_FILES_CONCURRENCY` variable to allow for fine tuning this concurrency. 
