### PR TITLE
Loosen requirement on `jsonschema`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
         "requests",
         "rich",
         "upolygon==0.1.8",
-        "jsonschema==3.2.0",
+        "jsonschema>=3.2.0,<5.0",
         "deprecation",
         "pydantic",
     ],


### PR DESCRIPTION
Any Python project depending on `darwin-py` and `jsonschema` simultaneously is forced to use `jsonschema==3.2.0` if the version is pinned by `darwin-py`. This is causing trouble as my project requires jsonschema 4, which is anyways backwards compatible with jsonschema 3 and therefore should not be a problem for `darwin-py`.

Adding `jsonschema<5.0` allows to avoid potential future trouble from breaking changes the next time that `jsonschema` makes a major release.