### PR TITLE
Fix docs

### DIFF
--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install setuptools wheel
           pip install --editable ".[test]"
           pip install torch torchvision
           pip install -U sphinx

--- a/darwin/dataset/download_manager.py
+++ b/darwin/dataset/download_manager.py
@@ -201,27 +201,27 @@ def lazy_download_image_from_annotation(
     Returns functions to download an image given an annotation. Same as `download_image_from_annotation`
     but returns Callables that trigger the download instead fetching files interally.
 
-     Parameters
-     ----------
-     api_key : str
-         API Key of the current team
-     annotation_path : Path
-         Path where the annotation is located
-     images_path : Path
-         Path where to download the image
-     annotation_format : str
-         Format of the annotations. Currently only JSON is supported
-     use_folders : bool
-         Recreate folder structure
-     video_frames : bool
-         Pulls video frames images instead of video files
-     force_slots: bool
-         Pulls all slots of items into deeper file structure ({prefix}/{item_name}/{slot_name}/{file_name})
+    Parameters
+    ----------
+    api_key : str
+        API Key of the current team
+    annotation_path : Path
+        Path where the annotation is located
+    images_path : Path
+        Path where to download the image
+    annotation_format : str
+        Format of the annotations. Currently only JSON is supported
+    use_folders : bool
+        Recreate folder structure
+    video_frames : bool
+        Pulls video frames images instead of video files
+    force_slots: bool
+        Pulls all slots of items into deeper file structure ({prefix}/{item_name}/{slot_name}/{file_name})
 
-     Raises
-     ------
-     NotImplementedError
-         If the format of the annotation is not supported.
+    Raises
+    ------
+    NotImplementedError
+        If the format of the annotation is not supported.
     """
 
     console = Console()

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/v7labs/darwin-py",
-    setup_requires=["wheel"],
+    setup_requires=["wheel", "setuptools"],
     install_requires=[
         "argcomplete",
         "dataclasses;python_version<'3.7'",


### PR DESCRIPTION
Not sure why, but recently on python 3.6 it's needed to install `setuptools` explicitly before running anything else. 