### PR TITLE
fixed deprecated dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,8 @@ setuptools.setup(
         "pydantic",
     ],
     extras_require={
-        "test": ["responses", "pytest", "pytest-describe", "sklearn"],
-        "ml": ["sklearn", "torch", "torchvision"],
+        "test": ["responses", "pytest", "pytest-describe", "scikit-learn"],
+        "ml": ["scikit-learn", "torch", "torchvision"],
         "medical": ["nibabel", "connected-components-3d"],
     },
     packages=[


### PR DESCRIPTION
`sklearn` has been deprecated as a way of pip installing `scikit-learn` which makes our master build fail - see  https://pypi.org/project/sklearn/ for more details