### PR TITLE
[SWAT-605] [External] Darwin rename file format .JPG to .jpg when exporting

### DIFF
--- a/darwin/utils.py
+++ b/darwin/utils.py
@@ -267,7 +267,10 @@ def persist_client_configuration(
 
 
 def _get_local_filename(metadata: Dict[str, Any]) -> str:
-    return metadata["filename"]
+    if "original_filename" in metadata:
+        return metadata["original_filename"]
+    else:
+        return metadata["filename"]
 
 
 def parse_darwin_json(path: Path, count: Optional[int]) -> Optional[dt.AnnotationFile]:


### PR DESCRIPTION
Take `original_filename` as filename, if not available, fallback to `filename`