### PR TITLE
[SWAT-647][internal] Fix bug with "push -p".

### DIFF
--- a/darwin/dataset/remote_dataset_v2.py
+++ b/darwin/dataset/remote_dataset_v2.py
@@ -184,7 +184,7 @@ class RemoteDatasetV2(RemoteDataset):
                 if source_files:
                     local_path = str(found_file.relative_to(source_files[0]).parent)
             uploading_files.append(
-                LocalFile(found_file, fps=fps, as_frames=as_frames, extract_views=extract_views, spath=local_path)
+                LocalFile(found_file, fps=fps, as_frames=as_frames, extract_views=extract_views, path=local_path)
             )
 
         if not uploading_files:


### PR DESCRIPTION
# Problem

`darwin dataset push -p` was broken with v2 datasets, since v0.8.3 (it worked fine in 0.8.2).

# Solution

It looked like a simple typo in a parameter name, which meant the path wasn't getting passed through when doing the upload.