### PR TITLE
[SWAT-702][Internal] Locked numpy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
         "argcomplete",
         "dataclasses;python_version<'3.7'",
         "humanize",
-        "numpy==1.23.0",
+        "numpy<=1.23.0",
         "pillow",
         "pyyaml>=5.1",
         "requests",

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
         "argcomplete",
         "dataclasses;python_version<'3.7'",
         "humanize",
-        "numpy",
+        "numpy==1.23.0",
         "pillow",
         "pyyaml>=5.1",
         "requests",


### PR DESCRIPTION
locking numpy version as updates do not following semantic versioning and are not backwards compatible. 