### PR TITLE
[SWAT-716][internal]: Fix .json extension parsing for dataset splitting

### DIFF
--- a/darwin/dataset/split_manager.py
+++ b/darwin/dataset/split_manager.py
@@ -393,7 +393,7 @@ def _write_to_file(annotation_path: Path, annotation_files: List[Path], file_pat
         for i in split_idx:
             # To deal with recursive search, we want to write the difference between the annotation path
             # and its parent, without the file extension
-            stem = str(annotation_files[i]).replace(f"{annotation_path}/", "").split(".json")[0]
+            stem = str(annotation_files[i]).replace(f"{annotation_path}/", "").rsplit(".json", 1)[0]
             f.write(f"{stem}\n")
 
 


### PR DESCRIPTION
The current logic does not take into account files that may have `.json` in the middle of the file name. The change ensure that the split happens only for the last `.json` occurrence