### PR TITLE
[SWAT-734][Internal] Fixing conversion to darwin_json_1.0

### DIFF
--- a/darwin/exporter/formats/darwin_1_0.py
+++ b/darwin/exporter/formats/darwin_1_0.py
@@ -1,10 +1,8 @@
+import json
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Union
-
-import orjson as json
+from typing import Any, Dict, Iterable, Union
 
 import darwin.datatypes as dt
-from darwin.exporter.formats.numpy_encoder import NumpyEncoder
 
 
 def export(annotation_files: Iterable[dt.AnnotationFile], output_dir: Path) -> None:
@@ -16,7 +14,7 @@ def _export_file(annotation_file: dt.AnnotationFile, id: int, output_dir: Path):
     output: Dict[str, Any] = _build_json(annotation_file)
     output_file_path: Path = (output_dir / annotation_file.filename).with_suffix(".json")
     with open(output_file_path, "w") as f:
-        op = json.dumps(output, option=json.OPT_INDENT_2 | json.OPT_SERIALIZE_NUMPY).decode("utf-8")
+        op = json.dumps(output)
         f.write(op)
 
 
@@ -42,7 +40,7 @@ def _build_image_json(annotation_file: dt.AnnotationFile):
             **_build_metadata(annotation_file),
         },
         "annotations": list(map(_build_annotation, annotation_file.annotations)),
-        "dataset": str(annotation_file.dataset_name)
+        "dataset": str(annotation_file.dataset_name),
     }
 
 
@@ -63,7 +61,7 @@ def _build_video_json(annotation_file: dt.AnnotationFile):
             **_build_metadata(annotation_file),
         },
         "annotations": list(map(_build_annotation, annotation_file.annotations)),
-        "dataset": str(annotation_file.dataset_name)
+        "dataset": str(annotation_file.dataset_name),
     }
 
 


### PR DESCRIPTION
Conversions from darwin_2.0 to darwin_1.0 are broken right now. 
This PR aims to fix that with a temporary quick fix that reverts the json encoder used.

Ticket: https://linear.app/v7labs/issue/SWAT-734/dataset-conversion-failed-for-ffss
Context:  https://vseven.slack.com/archives/C03LKKX7D0U/p1675160311013969
