### PR TITLE
[SWAT-735][internal] Added nifti to supported formats.

### DIFF
--- a/darwin/exporter/formats/__init__.py
+++ b/darwin/exporter/formats/__init__.py
@@ -13,4 +13,5 @@ supported_formats: List[str] = [
     "semantic_mask_grey",
     "semantic_mask_index",
     "yolo",
+    "nifti",
 ]


### PR DESCRIPTION
# Problem

We are missing nifti in error message of supported formats:

```
$ darwin convert asd /home/pedro/Downloads/v7-support-test-1675683152 /home/pedro/Downloads/output 
asd
Error: Unsupported export format, currently supported: ['coco', 'cvat', 'dataloop', 'darwin_1.0', 'instance_mask', 'pascalvoc', 'semantic_mask', 'semantic_mask_grey', 'semantic_mask_index', 'yolo']
```

# Solution

Add nifti to list