### PR TITLE
[IO-727] Changes to background class for SemanticSegmentationDataset

### DIFF
--- a/darwin/torch/dataset.py
+++ b/darwin/torch/dataset.py
@@ -471,7 +471,7 @@ class SemanticSegmentationDataset(LocalDataset):
                 sequences[:] = [s for s in sequences if len(s) >= 6]
                 if not sequences:
                     continue
-                # offset the index by 1 so that masks don't get mixed with background classes
+
                 annotations.append(
                     {
                         "category_id": self.classes.index(obj.annotation_class.name),

--- a/darwin/torch/dataset.py
+++ b/darwin/torch/dataset.py
@@ -392,7 +392,7 @@ class SemanticSegmentationDataset(LocalDataset):
 
         super().__init__(annotation_type="polygon", **kwargs)
         self.classes.insert(0, "__background__")
-        # self.num_classes += 1
+        self.num_classes += 1
         if transform is not None and isinstance(transform, list):
             transform = Compose(transform)
 
@@ -471,7 +471,7 @@ class SemanticSegmentationDataset(LocalDataset):
                     continue
                 # offset the index by 1 so that masks don't get mixed with background classes
                 annotations.append(
-                    {"category_id": self.classes.index(obj.annotation_class.name), "segmentation": sequences}
+                    {"category_id": self.classes.index(obj.annotation_class.name) + 1, "segmentation": sequences}
                 )
         target["annotations"] = annotations
 

--- a/darwin/torch/dataset.py
+++ b/darwin/torch/dataset.py
@@ -437,7 +437,6 @@ class SemanticSegmentationDataset(LocalDataset):
                     {
                         "category_id": int,
                         "segmentation": List[List[float | int]]
-                        "class_name": str
                     }
                 ]
             }
@@ -476,7 +475,6 @@ class SemanticSegmentationDataset(LocalDataset):
                     {
                         "category_id": self.classes.index(obj.annotation_class.name),
                         "segmentation": sequences,
-                        "class_name": obj.annotation_class.name,
                     }
                 )
         target["annotations"] = annotations

--- a/darwin/torch/dataset.py
+++ b/darwin/torch/dataset.py
@@ -1,6 +1,11 @@
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
+import torch
+from PIL import Image as PILImage
+from torch.functional import Tensor
+from torchvision.transforms.functional import to_tensor
+
 from darwin.cli_functions import _error, _load_client
 from darwin.client import Client
 from darwin.dataset import LocalDataset
@@ -12,11 +17,6 @@ from darwin.torch.transforms import (
 )
 from darwin.torch.utils import polygon_area
 from darwin.utils import convert_polygons_to_sequences
-from PIL import Image as PILImage
-from torchvision.transforms.functional import to_tensor
-
-import torch
-from torch.functional import Tensor
 
 
 def get_dataset(
@@ -468,8 +468,9 @@ class SemanticSegmentationDataset(LocalDataset):
                 sequences[:] = [s for s in sequences if len(s) >= 6]
                 if not sequences:
                     continue
+                # offset the index by 1 so that masks don't get mixed with background classes
                 annotations.append(
-                    {"category_id": self.classes.index(obj.annotation_class.name), "segmentation": sequences}
+                    {"category_id": self.classes.index(obj.annotation_class.name) + 1, "segmentation": sequences}
                 )
         target["annotations"] = annotations
 

--- a/darwin/torch/dataset.py
+++ b/darwin/torch/dataset.py
@@ -392,6 +392,7 @@ class SemanticSegmentationDataset(LocalDataset):
 
         super().__init__(annotation_type="polygon", **kwargs)
         self.classes.insert(0, "__background__")
+        # self.num_classes += 1
         if transform is not None and isinstance(transform, list):
             transform = Compose(transform)
 
@@ -488,7 +489,9 @@ class SemanticSegmentationDataset(LocalDataset):
             Weight for each class in the train set (one for each class) as a 1D array normalized.
         """
         # Collect all the labels by iterating over the whole dataset
-        labels = []
+        # specifically add in the background class as it won't be an annotation to include
+        BACKGROUND_CLASS: int = 0
+        labels = [BACKGROUND_CLASS]
         for i, _ in enumerate(self.images_path):
             target = self.get_target(i)
             labels.extend([a["category_id"] for a in target["annotations"]])

--- a/darwin/torch/dataset.py
+++ b/darwin/torch/dataset.py
@@ -391,8 +391,9 @@ class SemanticSegmentationDataset(LocalDataset):
     def __init__(self, transform: Optional[Union[List[Callable], Callable]] = None, **kwargs):
 
         super().__init__(annotation_type="polygon", **kwargs)
-        self.classes.insert(0, "__background__")
-        self.num_classes += 1
+        if not "__background__" in self.classes:
+            self.classes.insert(0, "__background__")
+            self.num_classes += 1
         if transform is not None and isinstance(transform, list):
             transform = Compose(transform)
 

--- a/darwin/torch/dataset.py
+++ b/darwin/torch/dataset.py
@@ -391,7 +391,7 @@ class SemanticSegmentationDataset(LocalDataset):
     def __init__(self, transform: Optional[Union[List[Callable], Callable]] = None, **kwargs):
 
         super().__init__(annotation_type="polygon", **kwargs)
-
+        self.classes.insert(0, "__background__")
         if transform is not None and isinstance(transform, list):
             transform = Compose(transform)
 
@@ -470,7 +470,7 @@ class SemanticSegmentationDataset(LocalDataset):
                     continue
                 # offset the index by 1 so that masks don't get mixed with background classes
                 annotations.append(
-                    {"category_id": self.classes.index(obj.annotation_class.name) + 1, "segmentation": sequences}
+                    {"category_id": self.classes.index(obj.annotation_class.name), "segmentation": sequences}
                 )
         target["annotations"] = annotations
 

--- a/darwin/torch/dataset.py
+++ b/darwin/torch/dataset.py
@@ -436,6 +436,7 @@ class SemanticSegmentationDataset(LocalDataset):
                     {
                         "category_id": int,
                         "segmentation": List[List[float | int]]
+                        "class_name": str
                     }
                 ]
             }
@@ -471,7 +472,11 @@ class SemanticSegmentationDataset(LocalDataset):
                     continue
                 # offset the index by 1 so that masks don't get mixed with background classes
                 annotations.append(
-                    {"category_id": self.classes.index(obj.annotation_class.name) + 1, "segmentation": sequences}
+                    {
+                        "category_id": self.classes.index(obj.annotation_class.name),
+                        "segmentation": sequences,
+                        "class_name": obj.annotation_class.name,
+                    }
                 )
         target["annotations"] = annotations
 

--- a/darwin/torch/transforms.py
+++ b/darwin/torch/transforms.py
@@ -1,12 +1,12 @@
 import random
 from typing import Any, Dict, Optional, Tuple, Union
 
+import torch
 import torchvision.transforms as transforms
 import torchvision.transforms.functional as F
-from darwin.torch.utils import convert_segmentation_to_mask
 from PIL import Image as PILImage
 
-import torch
+from darwin.torch.utils import convert_segmentation_to_mask
 
 TargetKey = Union["boxes", "labels", "mask", "masks", "image_id", "area", "iscrowd"]
 TargetType = Dict[TargetKey, torch.Tensor]

--- a/tests/darwin/torch/dataset_test.py
+++ b/tests/darwin/torch/dataset_test.py
@@ -244,6 +244,7 @@ def describe_get_dataset():
         dataset = get_dataset(f"{v1_or_v2_slug}/coco", "semantic-segmentation")
         assert isinstance(dataset, SemanticSegmentationDataset)
         assert len(dataset) == 20
+        assert "__background__" in dataset.classes
 
         image, label = dataset[0]
         assert image.size() == (3, 50, 50)

--- a/tests/darwin/torch/dataset_test.py
+++ b/tests/darwin/torch/dataset_test.py
@@ -4,6 +4,8 @@ from typing import Any
 from unittest.mock import patch
 
 import numpy as np
+import torch
+
 from darwin.torch.dataset import (
     ClassificationDataset,
     InstanceSegmentationDataset,
@@ -12,8 +14,6 @@ from darwin.torch.dataset import (
     get_dataset,
 )
 from tests.fixtures import *
-
-import torch
 
 
 def generic_dataset_test(ds, n, size):


### PR DESCRIPTION
A fix to overcome the underlying issue of background class in a  semantic segmentation datasets being mixed in with the first user generated class. Background classes were not present in the SemanticSegmentationDataset but was intendid behaviour. Background class now gets added to the class if not present, and class functions that call on class features like compute_weights have been updated to reflect the underlying background class, which is treated differently because it's not a user defined annotation. 

### Changelog
Fix to background classes bug relating to [this bug report](https://github.com/v7labs/darwin-py/issues/526) and leading to an issue losing the first class annotation when using the SemanticSegmentationDataset object