### PR TITLE
Swat 788 annotation imports multiprocessing

### DIFF
--- a/darwin/cli.py
+++ b/darwin/cli.py
@@ -145,7 +145,7 @@ def _run(args: Namespace, parser: ArgumentParser) -> None:
                 args.delete_for_empty,
                 args.import_annotators,
                 args.import_reviewers,
-                args.cpu_limit,
+                cpu_limit=args.cpu_limit,
             ),
         elif args.action == "convert":
             f.dataset_convert(args.dataset, args.format, args.output_dir)

--- a/darwin/options.py
+++ b/darwin/options.py
@@ -245,8 +245,8 @@ class Options:
             "--cpu_limit",
             type=cpu_default_types,
             required=False,
-            default=None,
-            help="Limits amount of cores used on machine to process results, default to total cores - 2",
+            default=1,
+            help="Limits amount of cores used on machine to process results, default to single core",
         )
 
         # Convert


### PR DESCRIPTION
Changes to default mutli-core processing behaviour. 
Multi processing has caused issues with imports on certain. While working on a wider fix, default to single core processing. 
### Changelog
Defaulting to single core import processing
