### PR TITLE
[IO-835][external] Fix for a logic flow bug in importer

### DIFF
--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -578,7 +578,7 @@ def _handle_annotators(annotation: dt.Annotation, import_annotators: bool) -> Li
     return []
 
 
-def _handle_video_annotations(
+def _get_annotation_data(
     annotation: dt.AnnotationLike,
     annotation_class_id: str,
     attributes: dt.DictFreeForm,
@@ -594,6 +594,8 @@ def _handle_video_annotations(
         )
     else:
         data = {annotation_class.annotation_type: annotation.data}
+        data = _handle_complex_polygon(annotation, data)
+        data = _handle_subs(annotation, data, annotation_class_id, attributes)
 
     return data
 
@@ -628,9 +630,7 @@ def _import_annotations(
         annotation_type = annotation_class.annotation_internal_type or annotation_class.annotation_type
         annotation_class_id: str = remote_classes[annotation_type][annotation_class.name]
 
-        data = _handle_video_annotations(annotation, annotation_class_id, attributes, annotation.data)
-        data = _handle_complex_polygon(annotation, data)
-        data = _handle_subs(annotation, data, annotation_class_id, attributes)
+        data = _get_annotation_data(annotation, annotation_class_id, attributes, annotation.data)
 
         actors: List[dt.DictFreeForm] = []
         actors.extend(_handle_annotators(annotation, import_annotators))

--- a/tests/darwin/importer/importer_test.py
+++ b/tests/darwin/importer/importer_test.py
@@ -292,6 +292,7 @@ def test__import_annotations() -> None:
         )
 
         assert mock_dataset.import_annotation.call_count == 1
+        # ! Removed, so this test is now co-dependent on function previously mocked. See IO-841 for future action.
         # assert mock_hva.call_count == 1
         assert mock_hcp.call_count == 1
         assert mock_hr.call_count == 1

--- a/tests/darwin/importer/importer_test.py
+++ b/tests/darwin/importer/importer_test.py
@@ -164,7 +164,7 @@ def test__handle_annotators() -> None:
         assert op2 == []
 
 
-def test__handle_video_annotations() -> None:
+def test__get_annotation_data() -> None:
     annotation_class = dt.AnnotationClass("class", "TEST_TYPE")
     video_annotation_class = dt.AnnotationClass("video_class", "video")
 
@@ -173,11 +173,29 @@ def test__handle_video_annotations() -> None:
 
     annotation.data = "TEST DATA"
 
-    with patch.object(dt.VideoAnnotation, "get_data", return_value="TEST VIDEO DATA"):
-        from darwin.importer.importer import _handle_video_annotations
+    with patch_factory("_handle_complex_polygon") as mock_hcp, patch_factory("_handle_subs") as mock_hs, patch.object(
+        dt.VideoAnnotation, "get_data", return_value="TEST VIDEO DATA"
+    ):
+        from darwin.importer.importer import _get_annotation_data
 
-        assert _handle_video_annotations(video_annotation, "video_class_id", {}, {}) == "TEST VIDEO DATA"
-        assert _handle_video_annotations(annotation, "class_id", {}, {}) == {"TEST_TYPE": "TEST DATA"}
+        mock_hcp.return_value = "TEST DATA_HCP"
+        mock_hs.return_value = "TEST DATA_HS"
+
+        assert _get_annotation_data(video_annotation, "video_class_id", {}, {}) == "TEST VIDEO DATA"
+        assert _get_annotation_data(annotation, "class_id", {}, {}) == "TEST DATA_HS"
+
+        assert mock_hcp.call_count == 1
+        assert mock_hs.call_count == 1
+
+    with patch_factory("_handle_complex_polygon") as mock_hcp, patch_factory("_handle_subs") as mock_hs:
+        from darwin.importer.importer import _get_annotation_data
+
+        mock_hs.return_value = {"TEST_TYPE": "TEST DATA"}
+
+        assert _get_annotation_data(annotation, "class_id", {}, {}) == {"TEST_TYPE": "TEST DATA"}
+
+        assert mock_hcp.call_args_list[0][0][0] == annotation
+        assert mock_hcp.call_args_list[0][0][1] == {"TEST_TYPE": "TEST DATA"}
 
 
 def __expectation_factory(i: int, slot_names: List[str]) -> dt.Annotation:
@@ -226,11 +244,9 @@ def test_get_overwrite_value() -> None:
 
 def test__import_annotations() -> None:
 
-    with patch_factory("_handle_video_annotations") as mock_hva, patch_factory(
-        "_handle_complex_polygon"
-    ) as mock_hcp, patch_factory("_handle_reviewers") as mock_hr, patch_factory(
-        "_handle_annotators"
-    ) as mock_ha, patch_factory(
+    with patch_factory("_handle_complex_polygon") as mock_hcp, patch_factory(
+        "_handle_reviewers"
+    ) as mock_hr, patch_factory("_handle_annotators") as mock_ha, patch_factory(
         "_handle_subs"
     ) as mock_hs, patch_factory(
         "_get_overwrite_value"
@@ -276,7 +292,7 @@ def test__import_annotations() -> None:
         )
 
         assert mock_dataset.import_annotation.call_count == 1
-        assert mock_hva.call_count == 1
+        # assert mock_hva.call_count == 1
         assert mock_hcp.call_count == 1
         assert mock_hr.call_count == 1
         assert mock_ha.call_count == 1


### PR DESCRIPTION
**Summary**

@tomvars found a bug in the flow of the importer, by which logic for normal annotations, and logic for video annotations was being applied to both types in errata.  This has been corrected, along with unit test fixes and augmentations.

NB: A ticket is raised for refactoring the importer unit tests which have become untidy as a result of merging and refactoring in several areas: IO-841

# Changelog

* Refactored the importer to correctly separate flow of logic
* Refactored the tests to cover this.