### PR TITLE
[IO-864][external] Fix Coco importer

### DIFF
--- a/darwin/helpers/__init__.py
+++ b/darwin/helpers/__init__.py
@@ -1,0 +1,1 @@
+from .flatten_list import flatten_list

--- a/darwin/helpers/flatten_list.py
+++ b/darwin/helpers/flatten_list.py
@@ -1,0 +1,34 @@
+from typing import Generator, List
+
+from darwin.datatypes import UnknownType
+
+
+def flatten_list(list_of_lists: List[UnknownType]) -> List[UnknownType]:
+    """
+    Flattens a list of lists into a single list.
+
+    Parameters
+    ----------
+    list_of_lists : List[List[Any]]
+        The list of lists to flatten.
+
+    Returns
+    -------
+    List[Any]
+        The flattened list.
+    """
+
+    if not isinstance(list_of_lists, list):
+        raise TypeError("Expected a list")
+
+    def flatten(lists: List[UnknownType]) -> Generator[list, UnknownType, UnknownType]:
+        if isinstance(lists, list) and len(lists) == 0:
+            return lists
+        for item in lists:
+            if isinstance(item, list):
+                for i in flatten(item):
+                    yield i
+            else:
+                yield item
+
+    return list(flatten(list_of_lists))

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -41,6 +41,7 @@ from rich.theme import Theme
 import darwin.datatypes as dt
 from darwin.datatypes import PathLike
 from darwin.exceptions import IncompatibleOptions, RequestEntitySizeExceeded
+from darwin.helpers import flatten_list
 from darwin.utils import secure_continue_request
 from darwin.version import __version__
 
@@ -351,7 +352,8 @@ def import_annotations(
     if not maybe_parsed_files:
         raise ValueError("Not able to parse any files.")
 
-    parsed_files = list(maybe_parsed_files)
+    parsed_files: List[AnnotationFile] = flatten_list(list(maybe_parsed_files))
+
     filenames: List[str] = [parsed_file.filename for parsed_file in parsed_files if parsed_file is not None]
 
     console.print("Fetching remote file list...", style="info")

--- a/tests/darwin/helpers/flatten_list_test.py
+++ b/tests/darwin/helpers/flatten_list_test.py
@@ -1,0 +1,33 @@
+import pytest
+
+from darwin.helpers import flatten_list
+
+
+def test_raises_if_passed_non_array() -> None:
+    with pytest.raises(TypeError):
+        flatten_list("string")  # type: ignore
+
+
+def test_returns_empty_list_if_passed_empty_list() -> None:
+    assert flatten_list([]) == []
+
+
+def test_returns_list_if_passed_list() -> None:
+    assert flatten_list([1, 2, 3]) == [1, 2, 3]
+
+
+def test_returns_flattened_list_if_passed_nested_list() -> None:
+    assert flatten_list([[1, 2], [3, 4]]) == [1, 2, 3, 4]
+
+
+def test_returns_flattened_list_if_passed_nested_list_with_different_depth() -> None:
+    assert flatten_list([[1, 2], [3, [4, 5]]]) == [1, 2, 3, 4, 5]
+
+
+# Makes file directly runnable with python
+if __name__ == "__main__":
+    import sys
+
+    import pytest
+
+    sys.exit(pytest.main(["-v", "-x", __file__]))


### PR DESCRIPTION
# Description

The COCO `parse_path` function generates a multidimensional list, where other importers generate a 1D list.  This introduces a `flatten_lists` function that is used to make up for this, and flatten the output of all importer parsers.

# Motivation

Currently this issue is blocking COCO imports on the live version, and this corrects that.