### PR TITLE
[IO-874] removing annotation data as input to _get_annotation_data

### DIFF
--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -585,10 +585,7 @@ def _handle_annotators(annotation: dt.Annotation, import_annotators: bool) -> Li
 
 
 def _get_annotation_data(
-    annotation: dt.AnnotationLike,
-    annotation_class_id: str,
-    attributes: dt.DictFreeForm,
-    data: dt.DictFreeForm,
+    annotation: dt.AnnotationLike, annotation_class_id: str, attributes: dt.DictFreeForm
 ) -> dt.DictFreeForm:
     annotation_class = annotation.annotation_class
     if isinstance(annotation, dt.VideoAnnotation):
@@ -639,7 +636,7 @@ def _import_annotations(
         annotation_type = annotation_class.annotation_internal_type or annotation_class.annotation_type
         annotation_class_id: str = remote_classes[annotation_type][annotation_class.name]
 
-        data = _get_annotation_data(annotation, annotation_class_id, attributes, annotation.data)
+        data = _get_annotation_data(annotation, annotation_class_id, attributes)
 
         actors: List[dt.DictFreeForm] = []
         actors.extend(_handle_annotators(annotation, import_annotators))

--- a/tests/darwin/importer/importer_test.py
+++ b/tests/darwin/importer/importer_test.py
@@ -181,8 +181,8 @@ def test__get_annotation_data() -> None:
         mock_hcp.return_value = "TEST DATA_HCP"
         mock_hs.return_value = "TEST DATA_HS"
 
-        assert _get_annotation_data(video_annotation, "video_class_id", {}, {}) == "TEST VIDEO DATA"
-        assert _get_annotation_data(annotation, "class_id", {}, {}) == "TEST DATA_HS"
+        assert _get_annotation_data(video_annotation, "video_class_id", {}) == "TEST VIDEO DATA"
+        assert _get_annotation_data(annotation, "class_id", {}) == "TEST DATA_HS"
 
         assert mock_hcp.call_count == 1
         assert mock_hs.call_count == 1
@@ -192,7 +192,7 @@ def test__get_annotation_data() -> None:
 
         mock_hs.return_value = {"TEST_TYPE": "TEST DATA"}
 
-        assert _get_annotation_data(annotation, "class_id", {}, {}) == {"TEST_TYPE": "TEST DATA"}
+        assert _get_annotation_data(annotation, "class_id", {}) == {"TEST_TYPE": "TEST DATA"}
 
         assert mock_hcp.call_args_list[0][0][0] == annotation
         assert mock_hcp.call_args_list[0][0][1] == {"TEST_TYPE": "TEST DATA"}


### PR DESCRIPTION
Removing the fourth input to _get_annotation_data as it's unnecessary and causes an issue with videoAnnotations.

### Changelog
fixed bug with video annotations import