### PR TITLE
[IO-901] Capturing and printing download errors

### DIFF
--- a/darwin/dataset/download_manager.py
+++ b/darwin/dataset/download_manager.py
@@ -428,7 +428,6 @@ def _download_image(url: str, path: Path, api_key: str, slot: Optional[dt.Slot] 
     transform_file_function = None
     if slot and slot.metadata and slot.metadata.get("colorspace") == "RG16":
         transform_file_function = _rg16_to_grayscale
-
     while True:
         if "token" in url:
             response: requests.Response = requests.get(url, stream=True)

--- a/darwin/dataset/remote_dataset.py
+++ b/darwin/dataset/remote_dataset.py
@@ -335,7 +335,7 @@ class RemoteDataset(ABC):
             if errors:
                 self.console.print(f"Encountered errors downloading {len(errors)} files")
             for error in errors:
-                self.console.print(f"\t - {str(error)}")
+                self.console.print(f"\t - {error}")
             return None, count
         else:
             return progress, count

--- a/darwin/dataset/remote_dataset.py
+++ b/darwin/dataset/remote_dataset.py
@@ -329,7 +329,13 @@ class RemoteDataset(ABC):
             if env_max_workers and int(env_max_workers) > 0:
                 max_workers = int(env_max_workers)
 
-            exhaust_generator(progress=progress(), count=count, multi_threaded=multi_threaded, worker_count=max_workers)
+            successes, errors = exhaust_generator(
+                progress=progress(), count=count, multi_threaded=multi_threaded, worker_count=max_workers
+            )
+            if errors:
+                self.console.print(f"Encountered errors downloading {len(errors)} files")
+            for error in errors:
+                self.console.print(f"\t - {str(error)}")
             return None, count
         else:
             return progress, count

--- a/darwin/dataset/utils.py
+++ b/darwin/dataset/utils.py
@@ -169,6 +169,7 @@ def _f(x: Any) -> Any:
     """Support function for ``pool.map()`` in ``_exhaust_generator()``."""
     if callable(x):
         return x()
+    return x
 
 
 def exhaust_generator(

--- a/tests/darwin/dataset/download_manager_test.py
+++ b/tests/darwin/dataset/download_manager_test.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import responses
+
+from darwin.client import Client
+from darwin.config import Config
+from darwin.dataset import RemoteDataset
+from darwin.dataset import download_manager as dm
+from darwin.dataset.identifier import DatasetIdentifier
+from darwin.dataset.remote_dataset_v1 import RemoteDatasetV1
+from tests.fixtures import *


### PR DESCRIPTION
Downloading of images would fail silently in both single and multi-threaded setups, causing issues when downloading large datasets and tokens expired, but would also fail generally for all other raised exceptions. Capturing these errors and printing to console to now provide a better UX and prevent blocking of models team when download fails

### Changelog
Errors downloading dataset items now captured and printed to console