### PR TITLE
[IO-751] api client v2

### DIFF
--- a/darwin/future/core/client.py
+++ b/darwin/future/core/client.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Callable, Dict, List, Optional, Union, overload
 
 import requests
-from pydantic import BaseModel, HttpUrl, parse_obj_as, validator
+from pydantic import BaseModel, validator
 from requests.adapters import HTTPAdapter, Retry
 
 from darwin.future.core.types.query import Query
@@ -84,7 +84,7 @@ class Page(BaseModel):
     detail: PageDetail
 
 
-class Cursor:
+class Cursor(ABC):
     """Abstract class for a cursor
 
     Attributes

--- a/darwin/future/core/client.py
+++ b/darwin/future/core/client.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from urlp
+
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Union, overload

--- a/darwin/future/core/client.py
+++ b/darwin/future/core/client.py
@@ -12,7 +12,6 @@ from darwin.future.core.types.query import Query
 from darwin.future.data_objects.darwin_meta import Team
 from darwin.future.exceptions.client import NotFound, Unauthorized
 
-# HTTPMethod = TypeVar("HTTPMethod", bound=Callable[..., requests.Response])
 HTTPMethod = Union[Callable[[str], requests.Response], Callable[[str, dict], requests.Response]]
 
 

--- a/darwin/future/data_objects/typing.py
+++ b/darwin/future/data_objects/typing.py
@@ -1,0 +1,5 @@
+from typing import Any, Dict
+
+UnknownType = Any  # type:ignore
+
+KeyValuePairDict = Dict[str, UnknownType]

--- a/darwin/future/exceptions/__init__.py
+++ b/darwin/future/exceptions/__init__.py
@@ -1,1 +1,1 @@
-from base import DarwinException  # noqa
+from .base import DarwinException  # noqa

--- a/darwin/future/exceptions/base.py
+++ b/darwin/future/exceptions/base.py
@@ -1,5 +1,58 @@
+from typing import Any, List, Optional
+
+from darwin.future.data_objects.typing import KeyValuePairDict, UnknownType
+
+
 class DarwinException(Exception):
-    pass
+    """
+    Generic Darwin exception.
+
+    Used to differentiate from errors that originate in our code, and those that originate in
+    third-party libraries.
+
+    Extends `Exception` and adds a `parent_exception` field to store the original exception.
+
+    Also has a `combined_exceptions` field to store a list of exceptions that were combined into
+    """
+
+    parent_exception: Optional[Exception] = None
+    combined_exceptions: Optional[List[Exception]] = None
+
+    def __init__(self, *args: UnknownType, **kwargs: KeyValuePairDict) -> None:
+        super().__init__(*args, **kwargs)
+
+    @classmethod
+    def from_exception(cls, exc: Exception) -> "DarwinException":
+        """
+        Creates a new exception from an existing exception.
+
+        Parameters
+        ----------
+        exc: Exception
+            The existing exception.
+
+        Returns
+        -------
+        DarwinException
+            The new exception.
+        """
+        instance = cls(str(exc))
+        instance.parent_exception = exc
+
+        return instance
+
+    def __str__(self) -> str:
+        output_string = f"{self.__class__.__name__}: {super().__str__()}\n"
+        if self.parent_exception:
+            output_string += f"Parent exception: {self.parent_exception}\n"
+
+        if self.combined_exceptions:
+            output_string += f"Combined exceptions: {self.combined_exceptions}\n"
+
+        return output_string
+
+    def __repr__(self) -> str:
+        return super().__repr__()
 
 
 class ValidationError(DarwinException):

--- a/darwin/future/tests/core/test_client.py
+++ b/darwin/future/tests/core/test_client.py
@@ -1,0 +1,130 @@
+import unittest
+from urllib.parse import urlparse
+
+import pytest
+import responses
+from pydantic import ValidationError
+from requests import HTTPError
+
+from darwin.future.core.client import Client, Config
+from darwin.future.exceptions.base import DarwinException
+from darwin.future.exceptions.client import NotFound, Unauthorized
+
+
+@pytest.fixture
+def base_config() -> Config:
+    return Config(api_key="test_key", base_url="http://test_url.com/", default_team=None)
+
+
+@pytest.fixture
+def base_client(base_config: Config) -> Client:
+    return Client(base_config)
+
+
+def test_create_config(base_config: Config) -> None:
+    assert base_config.api_key == "test_key"
+    assert base_config.base_url == "http://test_url.com/"
+    assert base_config.default_team is None
+
+
+def test_config_base_url(base_config: Config) -> None:
+    assert base_config.base_url == "http://test_url.com/"
+
+    # Test that the base_url validates after being created
+    base_config.base_url = "https://test_url.com"
+    assert base_config.base_url == "https://test_url.com/"
+
+    # Test that the base_url fails validation on invalid url strings
+    with pytest.raises(ValidationError):
+        base_config.base_url = "test_url.com"
+        base_config.base_url = "ftp://test_url.com"
+        base_config.base_url = ""
+
+
+def test_client(base_client: Client) -> None:
+    assert base_client.config.api_key == "test_key"
+    assert base_client.config.base_url == "http://test_url.com/"
+    assert base_client.config.default_team is None
+
+    assert base_client.session is not None
+    assert base_client.headers is not None
+    assert base_client.headers == {"Content-Type": "application/json", "Authorization": "ApiKey test_key"}
+
+    # Test client functionality works
+    with responses.RequestsMock() as rsps:
+        rsps.add(responses.GET, "http://test_url.com/test_endpoint", json={"test": "test"}, status=200)
+        rsps.add(responses.PUT, "http://test_url.com/test_endpoint", json={"test": "test"}, status=200)
+        rsps.add(responses.POST, "http://test_url.com/test_endpoint", json={"test": "test"}, status=200)
+        rsps.add(responses.DELETE, "http://test_url.com/test_endpoint", json={"test": "test"}, status=200)
+        rsps.add(responses.PATCH, "http://test_url.com/test_endpoint", json={"test": "test"}, status=200)
+
+        # Test get
+        response = base_client.get("test_endpoint")
+        assert response == {"test": "test"}
+
+        # Test put
+        response = base_client.put("test_endpoint", {"test": "test"})
+        assert response == {"test": "test"}
+
+        # Test post
+        response = base_client.post("test_endpoint", {"test": "test"})
+        assert response == {"test": "test"}
+
+        # Test delete
+        response = base_client.delete("test_endpoint")
+        assert response == {"test": "test"}
+
+        # Test patch
+        response = base_client.patch("test_endpoint", {"test": "test"})
+        assert response == {"test": "test"}
+
+
+@pytest.mark.parametrize(
+    "status_code, exception",
+    [(401, Unauthorized), (404, NotFound)],
+)
+def test_client_raises_darwin(status_code: int, exception: DarwinException, base_client: Client) -> None:
+    with responses.RequestsMock() as rsps:
+        rsps.add(responses.GET, "http://test_url.com/test_endpoint", json={"test": "test"}, status=status_code)
+        with pytest.raises(exception):  # type: ignore
+            base_client.get("test_endpoint")
+        rsps.reset()
+        rsps.add(responses.PUT, "http://test_url.com/test_endpoint", json={"test": "test"}, status=status_code)
+        with pytest.raises(exception):  # type: ignore
+            base_client.put("test_endpoint", {"test": "test"})
+        rsps.reset()
+        rsps.add(responses.POST, "http://test_url.com/test_endpoint", json={"test": "test"}, status=status_code)
+        with pytest.raises(exception):  # type: ignore
+            base_client.post("test_endpoint", {"test": "test"})
+        rsps.reset()
+        rsps.add(responses.DELETE, "http://test_url.com/test_endpoint", json={"test": "test"}, status=status_code)
+        with pytest.raises(exception):  # type: ignore
+            base_client.delete("test_endpoint")
+        rsps.reset()
+        rsps.add(responses.PATCH, "http://test_url.com/test_endpoint", json={"test": "test"}, status=status_code)
+        with pytest.raises(exception):  # type: ignore
+            base_client.patch("test_endpoint", {"test": "test"})
+
+
+def test_client_raises_generic(base_client: Client) -> None:
+    status_code = 499
+    with responses.RequestsMock() as rsps:
+        rsps.add(responses.GET, "http://test_url.com/test_endpoint", json={"test": "test"}, status=status_code)
+        with pytest.raises(HTTPError):
+            base_client.get("test_endpoint")
+        rsps.reset()
+        rsps.add(responses.PUT, "http://test_url.com/test_endpoint", json={"test": "test"}, status=status_code)
+        with pytest.raises(HTTPError):
+            base_client.put("test_endpoint", {"test": "test"})
+        rsps.reset()
+        rsps.add(responses.POST, "http://test_url.com/test_endpoint", json={"test": "test"}, status=status_code)
+        with pytest.raises(HTTPError):
+            base_client.post("test_endpoint", {"test": "test"})
+        rsps.reset()
+        rsps.add(responses.DELETE, "http://test_url.com/test_endpoint", json={"test": "test"}, status=status_code)
+        with pytest.raises(HTTPError):
+            base_client.delete("test_endpoint")
+        rsps.reset()
+        rsps.add(responses.PATCH, "http://test_url.com/test_endpoint", json={"test": "test"}, status=status_code)
+        with pytest.raises(HTTPError):
+            base_client.patch("test_endpoint", {"test": "test"})

--- a/darwin/future/tests/core/test_client.py
+++ b/darwin/future/tests/core/test_client.py
@@ -40,6 +40,12 @@ def test_config_base_url(base_config: Config) -> None:
         base_config.base_url = ""
 
 
+@pytest.mark.parametrize("base_url", ["test_url.com", "ftp://test_url.com", ""])
+def test_invalid_config_url_validation(base_url: str) -> None:
+    with pytest.raises(ValidationError):
+        config = Config(api_key="test_key", base_url=base_url, default_team=None)
+
+
 def test_client(base_client: Client) -> None:
     assert base_client.config.api_key == "test_key"
     assert base_client.config.base_url == "http://test_url.com/"

--- a/darwin/future/tests/core/test_client.py
+++ b/darwin/future/tests/core/test_client.py
@@ -1,5 +1,4 @@
 import unittest
-from urllib.parse import urlparse
 
 import pytest
 import responses

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,6 @@ plugins = [
 follow_imports = "silent"
 warn_redundant_casts = true
 warn_unused_ignores = true
-# disallow_any_generics = true
 check_untyped_defs = true
 no_implicit_reexport = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,12 +72,19 @@ profile = "black"
 plugins = [
     "pydantic.mypy"
 ]
+
+follow_imports = "silent"
+warn_redundant_casts = true
+warn_unused_ignores = true
+# disallow_any_generics = true
+check_untyped_defs = true
+no_implicit_reexport = true
+
 ignore_missing_imports = true
 disallow_any_unimported = true
 disallow_any_expr = false
 disallow_any_decorated = false
 disallow_any_explicit = true
-disallow_any_generics = false
 disallow_subclassing_any = true
 python_version = "3.10"
 disallow_untyped_calls = true

--- a/test.py
+++ b/test.py
@@ -1,26 +1,25 @@
-from unittest.mock import Mock, patch
+from typing import Optional, Union
 
-from requests import HTTPError
-
-import darwin
-
-api_key = "d7YQUUx.Gr_KwrCej3Qu43izHqIFDUIIjGUpUwYs"
-dataset_identifier = "v7-labs/random-images"
+from pydantic import BaseModel, HttpUrl, parse_obj_as, validator
 
 
-def i_fail():
-    raise HTTPError("404")
+class Config(BaseModel):
+    url: Union[HttpUrl, str]
+
+    @validator("url", always=True)
+    def validate_url(cls, v: Union[HttpUrl, str]) -> HttpUrl:
+        if isinstance(v, str):
+            return parse_obj_as(HttpUrl, v)
+        return v
 
 
-@patch("darwin.dataset.remote_dataset.download_all_images_from_annotations")
-def test(mock_method):
-    mock_method.return_value = (lambda: [i_fail, i_fail], 2)
-    # mock_method.side_effect = Mock(side_effect=HTTPError("404"))
-    client = darwin.Client.from_api_key(api_key=api_key)
-    dataset = client.get_remote_dataset(dataset_identifier)
-    release = dataset.get_release()
-    dataset.pull(release=release)
+url = "http://test_url.com"
+test_config = Config(url=url)
 
+print(test_config.url)
+print(isinstance(test_config.url, HttpUrl))
 
-if __name__ == "__main__":
-    test()
+test_config2 = Config(url=parse_obj_as(HttpUrl, url))
+print(test_config2.url)
+print(isinstance(test_config2.url, HttpUrl))
+print(test_config2.url)


### PR DESCRIPTION
Adding in the core api client functionality that can make generic http requets. Will be built on for the meta apiclient that is presented to the user and acts as a core base. 
- Generic call method that is invoked by oither calls, get/put/post etc
- Checks for known exceptions
### Changelog
Continuing work on darwin py v2 functionality. Added Core Client