### PR TITLE
Made numpy typing optional to support old versions of numpy

### DIFF
--- a/darwin/datatypes.py
+++ b/darwin/datatypes.py
@@ -16,7 +16,10 @@ from typing import (
     Union,
 )
 
-from numpy.typing import NDArray
+try:
+    from numpy.typing import NDArray
+except ImportError:
+    NDArray = Any  # type:ignore
 
 from darwin.path_utils import construct_full_path
 

--- a/darwin/exporter/formats/mask.py
+++ b/darwin/exporter/formats/mask.py
@@ -6,7 +6,11 @@ from pathlib import Path
 from typing import Dict, Iterable, List, Literal, Optional, Set, Tuple, get_args
 
 import numpy as np
-from numpy.typing import NDArray
+
+try:
+    from numpy.typing import NDArray
+except ImportError:
+    NDArray = Any  # type:ignore
 from PIL import Image
 from upolygon import draw_polygon
 

--- a/tests/darwin/exporter/formats/export_mask_test.py
+++ b/tests/darwin/exporter/formats/export_mask_test.py
@@ -7,7 +7,11 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
-from numpy.typing import NDArray
+
+try:
+    from numpy.typing import NDArray
+except ImportError:
+    NDArray = Any  # type:ignore
 from PIL import Image
 from upolygon import draw_polygon
 


### PR DESCRIPTION
Small fix that unblocks databricks envs using darwin py.