### PR TITLE
[IO-1004][internal] Default to polygon if no annotations present

### DIFF
--- a/darwin/exporter/formats/mask.py
+++ b/darwin/exporter/formats/mask.py
@@ -119,7 +119,7 @@ def get_render_mode(annotations: List[dt.AnnotationLike]) -> dt.MaskTypes.TypeOf
     non_video_annotations: List[dt.Annotation] = [a for a in annotations if not isinstance(a, dt.VideoAnnotation)]
 
     if not non_video_annotations:
-        raise ValueError("No suitable annotations found in file.")
+        return "polygon"
 
     list_of_keys: List[str] = reduce(list.__add__, [list(a.data.keys()) for a in non_video_annotations])
     keys: Set[str] = set(list_of_keys)


### PR DESCRIPTION
This is a regression fix for a deployment issue.

# Motivation

Previously, you could export an empty list of annotations to a blank image.  Whilst there's no particular need for this, the introduction of an error to prevent it caused a regression on front end.

This undoes that.