### PR TITLE
[IO-1050][internal] Detect rasters based on class, not data

### DIFF
--- a/darwin/exporter/formats/mask.py
+++ b/darwin/exporter/formats/mask.py
@@ -121,9 +121,7 @@ def get_render_mode(annotations: List[dt.AnnotationLike]) -> dt.MaskTypes.TypeOf
     if not non_video_annotations:
         return "polygon"
 
-    list_of_class_types: List[str] = reduce(
-        list.__add__, [a.annotation_class.annotation_type for a in non_video_annotations]
-    )
+    list_of_class_types: List[str] = [a.annotation_class.annotation_type for a in non_video_annotations]
     class_types: Set[str] = set(list_of_class_types)
 
     is_raster_mask = ("mask" in class_types) and ("raster_layer" in class_types)

--- a/darwin/exporter/formats/mask.py
+++ b/darwin/exporter/formats/mask.py
@@ -122,7 +122,7 @@ def get_render_mode(annotations: List[dt.AnnotationLike]) -> dt.MaskTypes.TypeOf
         return "polygon"
 
     list_of_class_types: List[str] = reduce(
-        list.__add__, [list(a.annotation_class.annotation_type) for a in non_video_annotations]
+        list.__add__, [a.annotation_class.annotation_type for a in non_video_annotations]
     )
     class_types: Set[str] = set(list_of_class_types)
 

--- a/tests/darwin/exporter/formats/export_mask_test.py
+++ b/tests/darwin/exporter/formats/export_mask_test.py
@@ -164,7 +164,7 @@ def annotations() -> List[dt.Annotation]:
 
 
 def test_get_render_mode_returns_raster_when_given_raster_mask(annotations: List[dt.AnnotationLike]) -> None:
-    assert get_render_mode([annotations[0]]) == "raster"
+    assert get_render_mode([annotations[0], annotations[3]]) == "raster"
 
 
 def test_get_render_mode_returns_polygon_when_given_polygon(annotations: List[dt.AnnotationLike]) -> None:
@@ -180,7 +180,7 @@ def test_get_render_mode_raises_value_error_when_given_both_raster_mask_and_poly
 
 
 def test_get_render_mode_raises_value_error_when_no_renderable_annotations_found() -> None:
-    with pytest.raises(ValueError, match="No renderable annotations found in file, found keys:"):
+    with pytest.raises(ValueError, match="No renderable annotations found in file, found classes:"):
         get_render_mode([dt.Annotation(dt.AnnotationClass("class_3", "invalid"), data={"line": "data"})])  # type: ignore
 
 

--- a/tests/darwin/exporter/formats/export_mask_test.py
+++ b/tests/darwin/exporter/formats/export_mask_test.py
@@ -156,9 +156,10 @@ def test_get_or_generate_colour() -> None:
 @pytest.fixture
 def annotations() -> List[dt.Annotation]:
     return [
-        dt.Annotation(dt.AnnotationClass("class_1", "raster_layer"), data={"mask": "data", "raster_layer": "raster"}),
+        dt.Annotation(dt.AnnotationClass("class_1", "raster_layer"), data={"raster_layer": "raster"}),
         dt.Annotation(dt.AnnotationClass("class_2", "polygon"), data={"path": "data"}),
         dt.Annotation(dt.AnnotationClass("class_2", "polygon"), data={"paths": "data"}),
+        dt.Annotation(dt.AnnotationClass("class_1", "mask"), data={"mask": "data"}),
     ]
 
 
@@ -484,7 +485,6 @@ def test_export(
     expected_mask_file: Optional[Path],
     expected_csv_file: Optional[Path],
 ) -> None:
-
     with TemporaryDirectory() as output_dir, patch(
         "darwin.exporter.formats.mask.get_render_mode"
     ) as mock_get_render_mode, patch("darwin.exporter.formats.mask.render_raster") as mock_render_raster, patch(
@@ -494,7 +494,6 @@ def test_export(
     ) as mock_get_palette, patch(
         "darwin.exporter.formats.mask.get_rgb_colours"
     ) as mock_get_rgb_colours:
-
         height, width = renderer_output[1].shape
 
         annotation_files = [


### PR DESCRIPTION
This is an improvement to class detection in SM exporter to reduce chances for regressions caused by internal `data` changes. We detect class by actual class type now instead. 