### PR TITLE
[IO-1062][External] Handle 422 API response for dataset exports

### DIFF
--- a/darwin/cli_functions.py
+++ b/darwin/cli_functions.py
@@ -374,8 +374,8 @@ def export_dataset(
             include_authorship=include_authorship,
             version=version,
         )
-    except ValidationError as e:
-        _error(str(e))
+    except ValidationError:
+        _error("Nothing to export")
     else: 
         identifier.version = name
         print(f"Dataset {dataset_slug} successfully exported to {identifier}")

--- a/darwin/cli_functions.py
+++ b/darwin/cli_functions.py
@@ -366,17 +366,20 @@ def export_dataset(
     identifier: DatasetIdentifier = DatasetIdentifier.parse(dataset_slug)
     ds: RemoteDataset = client.get_remote_dataset(identifier)
 
-    ds.export(
-        annotation_class_ids=annotation_class_ids,
-        name=name,
-        include_url_token=include_url_token,
-        include_authorship=include_authorship,
-        version=version,
-    )
-
-    identifier.version = name
-    print(f"Dataset {dataset_slug} successfully exported to {identifier}")
-    print_new_version_info(client)
+    try:
+        ds.export(
+            annotation_class_ids=annotation_class_ids,
+            name=name,
+            include_url_token=include_url_token,
+            include_authorship=include_authorship,
+            version=version,
+        )
+    except ValidationError as e:
+        _error(str(e))
+    else: 
+        identifier.version = name
+        print(f"Dataset {dataset_slug} successfully exported to {identifier}")
+        print_new_version_info(client)
 
 
 def pull_dataset(


### PR DESCRIPTION
Handle 422 API response for dataset exports. When there is nothing to export we present:

```python
Error: Nothing to export
```