### PR TITLE
[Io-1103][Internal] --ignore-slots option added to dataset pull

### DIFF
--- a/darwin/cli.py
+++ b/darwin/cli.py
@@ -128,7 +128,14 @@ def _run(args: Namespace, parser: ArgumentParser) -> None:
         elif args.action == "releases":
             f.dataset_list_releases(args.dataset)
         elif args.action == "pull":
-            f.pull_dataset(args.dataset, args.only_annotations, args.folders, args.video_frames, args.force_slots)
+            f.pull_dataset(
+                args.dataset,
+                args.only_annotations,
+                args.folders,
+                args.video_frames,
+                args.force_slots,
+                args.ignore_slots,
+            )
         elif args.action == "import":
             f.dataset_import(
                 args.dataset,
@@ -140,7 +147,7 @@ def _run(args: Namespace, parser: ArgumentParser) -> None:
                 args.import_annotators,
                 args.import_reviewers,
                 cpu_limit=args.cpu_limit,
-            ),
+            )
         elif args.action == "convert":
             f.dataset_convert(args.dataset, args.format, args.output_dir)
         elif args.action == "set-file-status":

--- a/darwin/cli_functions.py
+++ b/darwin/cli_functions.py
@@ -385,6 +385,7 @@ def pull_dataset(
     folders: bool = False,
     video_frames: bool = False,
     force_slots: bool = False,
+    ignore_slots: bool = False,
 ) -> None:
     """
     Downloads a remote dataset (images and annotations) in the datasets directory.
@@ -424,6 +425,7 @@ def pull_dataset(
             use_folders=folders,
             video_frames=video_frames,
             force_slots=force_slots,
+            ignore_slots=ignore_slots,
         )
         print_new_version_info(client)
         if release.format == "darwin_json_2":

--- a/darwin/dataset/download_manager.py
+++ b/darwin/dataset/download_manager.py
@@ -45,6 +45,7 @@ def download_all_images_from_annotations(
     use_folders: bool = False,
     video_frames: bool = False,
     force_slots: bool = False,
+    ignore_slots: bool = False,
 ) -> Tuple[Callable[[], Iterable[Any]], int]:
     """
     Downloads the all images corresponding to a project.
@@ -130,6 +131,7 @@ def download_all_images_from_annotations(
             use_folders,
             video_frames,
             force_slots,
+            ignore_slots,
         )
         download_functions.extend(file_download_functions)
 
@@ -151,6 +153,7 @@ def download_image_from_annotation(
     use_folders: bool,
     video_frames: bool,
     force_slots: bool,
+    ignore_slots: bool = False,
 ) -> None:
     """
     Dispatches functions to download an image given an annotation.
@@ -184,7 +187,7 @@ def download_image_from_annotation(
 
     if annotation_format == "json":
         downloadables = _download_image_from_json_annotation(
-            api_key, annotation_path, images_path, use_folders, video_frames, force_slots
+            api_key, annotation_path, images_path, use_folders, video_frames, force_slots, ignore_slots
         )
         for downloadable in downloadables:
             downloadable()
@@ -201,6 +204,7 @@ def lazy_download_image_from_annotation(
     use_folders: bool,
     video_frames: bool,
     force_slots: bool,
+    ignore_slots: bool = False,
 ) -> Iterable[Callable[[], None]]:
     """
     Returns functions to download an image given an annotation. Same as `download_image_from_annotation`
@@ -233,7 +237,7 @@ def lazy_download_image_from_annotation(
 
     if annotation_format == "json":
         return _download_image_from_json_annotation(
-            api_key, annotation_path, images_path, use_folders, video_frames, force_slots
+            api_key, annotation_path, images_path, use_folders, video_frames, force_slots, ignore_slots
         )
     else:
         console.print("[bold red]Unsupported file format. Please use 'json'.")
@@ -247,6 +251,7 @@ def _download_image_from_json_annotation(
     use_folders: bool,
     video_frames: bool,
     force_slots: bool,
+    ignore_slots: bool = False,
 ) -> Iterable[Callable[[], None]]:
     annotation = parse_darwin_json(annotation_path, count=0)
     if annotation is None:
@@ -259,6 +264,10 @@ def _download_image_from_json_annotation(
 
     annotation.slots.sort(key=lambda slot: slot.name or "0")
     if len(annotation.slots) > 0:
+        if ignore_slots:
+            return _download_single_slot_from_json_annotation(
+                annotation, api_key, parent_path, annotation_path, video_frames, use_folders
+            )
         if force_slots:
             return _download_all_slots_from_json_annotation(annotation, api_key, parent_path, video_frames)
         else:

--- a/darwin/dataset/remote_dataset.py
+++ b/darwin/dataset/remote_dataset.py
@@ -190,6 +190,7 @@ class RemoteDataset(ABC):
         use_folders: bool = False,
         video_frames: bool = False,
         force_slots: bool = False,
+        ignore_slots: bool = False,
     ) -> Tuple[Optional[Callable[[], Iterator[Any]]], int]:
         """
         Downloads a remote dataset (images and annotations) to the datasets directory.
@@ -321,6 +322,7 @@ class RemoteDataset(ABC):
             use_folders=use_folders,
             video_frames=video_frames,
             force_slots=force_slots,
+            ignore_slots=ignore_slots,
         )
         if count == 0:
             return None, count

--- a/darwin/options.py
+++ b/darwin/options.py
@@ -11,7 +11,6 @@ class Options:
     """
 
     def __init__(self) -> None:
-
         self.parser: ArgumentParser = ArgumentParser(
             description="Command line tool to create/upload/download datasets on darwin."
         )
@@ -192,13 +191,18 @@ class Options:
         parser_pull.add_argument(
             "--video-frames", action="store_true", help="Pulls video frame images instead of video files."
         )
-        parser_pull.add_argument(
+        slots_group = parser_pull.add_mutually_exclusive_group()
+        slots_group.add_argument(
             "--force-slots",
             action="store_true",
             help="Forces pull of all slots of items into deeper file structure ({prefix}/{item_name}/{slot_name}/{file_name}). "
             + "If your dataset includes items with multiple slots, or multiple source files per slot, this option becomes implicitly enabled.",
         )
-
+        slots_group.add_argument(
+            "--ignore-slots",
+            action="store_true",
+            help="Ignores slots and only pulls the first slot of each item into a flat file structure ({prefix}/{file_name}).",
+        )
         # Import
         parser_import = dataset_action.add_parser("import", help="Import data to an existing (remote) dataset.")
         parser_import.add_argument(

--- a/test.py
+++ b/test.py
@@ -1,7 +1,0 @@
-from darwin.future.core.client import Client, DarwinConfig
-from darwin.future.meta.queries.team_member import TeamMemberQuery
-
-client = Client.local()
-
-members = TeamMemberQuery().collect(client)
-print(len(members))


### PR DESCRIPTION
Adding in the option to forcibly ignore slots even if dataset includes slots. Defaults to taking the first slot item and building the regular flat structure

### Changelog
--ignore-slots option added to `dataset pull` command