### PR TITLE
[IO-1067] Filtering by class ids

### DIFF
--- a/darwin/backend_v2.py
+++ b/darwin/backend_v2.py
@@ -1,15 +1,15 @@
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from urllib import parse
 
 from darwin.datatypes import ItemId
 
 
-def inject_default_team_slug(method):
+def inject_default_team_slug(method: Callable) -> Callable:
     """
     Injects team_slug if not specified
     """
 
-    def wrapper(self, *args, **kwargs):
+    def wrapper(self, *args, **kwargs) -> Callable:
         if "team_slug" not in kwargs:
             kwargs["team_slug"] = self._default_team
         return method(self, *args, **kwargs)

--- a/darwin/dataset/remote_dataset_v2.py
+++ b/darwin/dataset/remote_dataset_v2.py
@@ -12,8 +12,6 @@ from typing import (
 
 from requests.models import Response
 
-from requests.models import Response
-
 from darwin.dataset import RemoteDataset
 from darwin.dataset.release import Release
 from darwin.dataset.upload_manager import (
@@ -395,14 +393,16 @@ class RemoteDatasetV2(RemoteDataset):
             format = None
         else:
             raise UnknownExportVersion(version)
-
+        
+        filters = None if not annotation_class_ids else {"annotation_class_ids": list(map(int, annotation_class_ids))}
+        
         self.client.api_v2.export_dataset(
             format=format,
             name=name,
             include_authorship=include_authorship,
             include_token=include_url_token,
-            annotation_class_ids=annotation_class_ids,
-            filters=None,
+            annotation_class_ids=None,
+            filters=filters,
             dataset_slug=self.slug,
             team_slug=self.team,
         )


### PR DESCRIPTION
Filtering on dataset export currently uses the wrong filter REST payload and instead uses a filtering system intended for UI only use. 

### Changelog
Filters changed to use the same system as UI 'current filters' option rather than 'optionally filter by class'