### PR TITLE
[IO-1154][V7-5112][internal] Fix annotation import with no source_info

### DIFF
--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -481,6 +481,8 @@ def import_annotations(
             for parsed_file in track(files_to_track):
 
                 image_id, default_slot_name = remote_files[parsed_file.full_path]
+                # We need to check if name is not-None as Darwin JSON 1.0 
+                # defaults to name=None
                 if parsed_file.slots and parsed_file.slots[0].name:
                     default_slot_name = parsed_file.slots[0].name
 

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -481,7 +481,7 @@ def import_annotations(
             for parsed_file in track(files_to_track):
 
                 image_id, default_slot_name = remote_files[parsed_file.full_path]
-                if parsed_file.slots:
+                if parsed_file.slots and parsed_file.slots[0].name:
                     default_slot_name = parsed_file.slots[0].name
 
                 errors, succes = _import_annotations(

--- a/darwin/utils/utils.py
+++ b/darwin/utils/utils.py
@@ -497,7 +497,7 @@ def _parse_darwin_v2(path: Path, data: Dict[str, Any]) -> dt.AnnotationFile:
             image_height=slot.height,
             image_url=None if len(slot.source_files or []) == 0 else slot.source_files[0]["url"],
             image_thumbnail_url=slot.thumbnail_url,
-            workview_url=item_source["workview_url"],
+            workview_url=item_source.get("workview_url", None),
             seq=0,
             frame_urls=slot.frame_urls,
             remote_path=item["path"],


### PR DESCRIPTION
This fixes an issue where `source_info` is required if any slots are provided. This doesn't need to be the case. 