### PR TITLE
[IO-1189] Fix raster import

### DIFF
--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -49,6 +49,9 @@ except ImportError:
 # Classes missing import support on backend side
 UNSUPPORTED_CLASSES = ["string", "graph"]
 
+# Classes that are defined on team level automatically and available in all datasets
+GLOBAL_CLASSES = ['__raster_layer__']
+
 DEPRECATION_MESSAGE = """
 
 This function is going to be turned into private. This means that breaking
@@ -336,11 +339,12 @@ def import_annotations(
             style="warning",
         )
 
+
     classes_in_dataset: dt.DictFreeForm = build_main_annotations_lookup_table(
-        [cls for cls in team_classes if cls["available"] or cls['name'] == '__raster_layer__']
+        [cls for cls in team_classes if cls["available"] or cls['name'] in GLOBAL_CLASSES]
     )
     classes_in_team: dt.DictFreeForm = build_main_annotations_lookup_table(
-        [cls for cls in team_classes if not cls["available"] and cls['name'] != '__raster_layer__']
+        [cls for cls in team_classes if not cls["available"] and cls['name'] not in GLOBAL_CLASSES]
     )
     attributes = build_attribute_lookup(dataset)
 

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -78,6 +78,8 @@ def build_main_annotations_lookup_table(annotation_classes: List[Dict[str, Unkno
         "string",
         "table",
         "graph",
+        "mask",
+        "raster_layer"
     ]
     lookup: Dict[str, Unknown] = {}
     for cls in annotation_classes:
@@ -335,10 +337,10 @@ def import_annotations(
         )
 
     classes_in_dataset: dt.DictFreeForm = build_main_annotations_lookup_table(
-        [cls for cls in team_classes if cls["available"]]
+        [cls for cls in team_classes if cls["available"] or cls['name'] == '__raster_layer__']
     )
     classes_in_team: dt.DictFreeForm = build_main_annotations_lookup_table(
-        [cls for cls in team_classes if not cls["available"]]
+        [cls for cls in team_classes if not cls["available"] and cls['name'] != '__raster_layer__']
     )
     attributes = build_attribute_lookup(dataset)
 
@@ -657,6 +659,9 @@ def _import_annotations(
             "data": data,
             "context_keys": {"slot_names": annotation.slot_names},
         }
+
+        if annotation.id:
+            serial_obj["id"] = annotation.id
 
         if actors:
             serial_obj["actors"] = actors  # type: ignore

--- a/darwin/utils/utils.py
+++ b/darwin/utils/utils.py
@@ -750,15 +750,12 @@ def _parse_darwin_raster_annotation(annotation: dict) -> Optional[dt.Annotation]
     new_annotation = dt.Annotation(
         dt.AnnotationClass(name, "raster_layer"),
         {
-            "id": id,
-            "name": name,
-            "raster_layer": {
-                "dense_rle": dense_rle,
-                "mask_annotation_ids_mapping": mask_annotation_ids_mapping,
-                "total_pixels": total_pixels,
-            },
+            "dense_rle": dense_rle,
+            "mask_annotation_ids_mapping": mask_annotation_ids_mapping,
+            "total_pixels": total_pixels,
         },
         slot_names=slot_names,
+        id=id,
     )
 
     return new_annotation
@@ -781,12 +778,9 @@ def _parse_darwin_mask_annotation(annotation: dict) -> Optional[dt.Annotation]:
 
     new_annotation = dt.Annotation(
         dt.AnnotationClass(name, "mask"),
-        {
-            "id": id,
-            "name": name,
-            "mask": mask,
-        },
+        mask,
         slot_names=slot_names,
+        id=id,
     )
 
     return new_annotation

--- a/tests/darwin/utils_test.py
+++ b/tests/darwin/utils_test.py
@@ -752,9 +752,10 @@ def describe__parse_darwin_raster_annotation() -> None:
         assert annotation.annotation_class.name == "my_raster_annotation"
         assert annotation.annotation_class.annotation_type == "raster_layer"
 
-        assert annotation.data["raster_layer"]["dense_rle"] == "ABCD"
-        assert annotation.data["raster_layer"]["mask_annotation_ids_mapping"] == {"1": 1}
-        assert annotation.data["raster_layer"]["total_pixels"] == 100
+        assert annotation.data["dense_rle"] == "ABCD"
+        assert annotation.data["mask_annotation_ids_mapping"] == {"1": 1}
+        assert annotation.data["total_pixels"] == 100
+        assert annotation.id == "abc123"
 
     # Sad paths
     @pytest.mark.parametrize("parameter_name", ["id", "name", "raster_layer", "slot_names"])
@@ -797,7 +798,7 @@ def describe__parse_darwin_mask_annotation() -> None:
         assert annotation.annotation_class.name == "my_raster_annotation"
         assert annotation.annotation_class.annotation_type == "mask"
 
-        assert annotation.data["mask"]["sparse_rle"] == None
+        assert annotation.data["sparse_rle"] == None
 
     # Sad paths
     @pytest.mark.parametrize("parameter_name", ["id", "name", "mask", "slot_names"])


### PR DESCRIPTION
This PR fixes few issues with Darwin rasters import:
* Raster specific annotation types are no "visible" on target datasets
* Raster specific annotation data now has proper depth to it
* Annotation ID is sent to import APIs if it's loaded for given annotation