### PR TITLE
[IO-1138] Semantic Mask colour map fix

### DIFF
--- a/darwin/exporter/formats/mask.py
+++ b/darwin/exporter/formats/mask.py
@@ -271,8 +271,7 @@ def render_polygons(
             else:
                 raise ValueError(f"Unknown annotation type {a.annotation_class.annotation_type}")
             sequence = convert_polygons_to_sequences(polygon, height=height, width=width)
-
-            colour_to_draw = get_or_generate_colour(cat, colours)
+            colour_to_draw = categories.index(cat)
             mask = draw_polygon(mask, sequence, colour_to_draw)
 
             if cat not in colours:

--- a/tests/darwin/exporter/formats/export_mask_test.py
+++ b/tests/darwin/exporter/formats/export_mask_test.py
@@ -238,7 +238,7 @@ def test_render_polygons() -> None:
     # Create some mock data for testing
     mask = np.zeros((100, 100), dtype=np.uint8)
     colours: dt.MaskTypes.ColoursDict = {}
-    categories: dt.MaskTypes.CategoryList = []
+    categories: dt.MaskTypes.CategoryList = ["__background__"]
     annotations: List[dt.AnnotationLike] = [
         dt.Annotation(
             dt.AnnotationClass("cat1", "polygon"),
@@ -286,7 +286,7 @@ def test_render_polygons() -> None:
     assert_array_equal(mask, new_mask)  # type: ignore
 
     # Check that the categories and colours were updated correctly
-    assert new_categories == ["cat1", "cat2", "cat3"]
+    assert new_categories == ["__background__", "cat1", "cat2", "cat3"]
     assert new_colours == {"cat1": 1, "cat2": 2, "cat3": 3}
 
     # Check that the polygons were drawn correctly
@@ -484,7 +484,6 @@ def test_export(
     expected_mask_file: Optional[Path],
     expected_csv_file: Optional[Path],
 ) -> None:
-
     with TemporaryDirectory() as output_dir, patch(
         "darwin.exporter.formats.mask.get_render_mode"
     ) as mock_get_render_mode, patch("darwin.exporter.formats.mask.render_raster") as mock_render_raster, patch(
@@ -494,7 +493,6 @@ def test_export(
     ) as mock_get_palette, patch(
         "darwin.exporter.formats.mask.get_rgb_colours"
     ) as mock_get_rgb_colours:
-
         height, width = renderer_output[1].shape
 
         annotation_files = [


### PR DESCRIPTION
Fix to the mapping of class colour mapping with semantic mask exports. Existing behaviour creates a new colour map for each file, leading to an issue where multiple file exports that have a mixture of classes between files get the wrong colour assigned to them. New logic pulls the colour from the category dictionary which is populated with the entire exports list of classes

### Changelog
Fix for class colour mapping in csv for semantic masks