### PR TITLE
[IO-1081 ]fix for dot/period/. in filename

### DIFF
--- a/darwin/dataset/download_manager.py
+++ b/darwin/dataset/download_manager.py
@@ -325,7 +325,7 @@ def _download_single_slot_from_json_annotation(
             if not use_folders:
                 suffix = Path(image_filename).suffix
                 stem = annotation_path.stem
-                filename = str(Path(stem).with_suffix(suffix))
+                filename = str(Path(stem + suffix))
             else:
                 filename = slot.source_files[0]["file_name"]
             image_path = parent_path / sanitize_filename(filename or annotation.filename)


### PR DESCRIPTION
dots/periods in filenames cause the last 'segment' between the periods to be lost, and thus causing issues with filenames being downloaded/named incorrectly. This stems from issues with the .with_suffix() function. Replaced with stem + suffix solution that generates the correct filename

### Changelog
filenames with multiple dots now saving filenames correctly