### PR TITLE
[IO-1205] Semantic Mask annotations outside of frame

### DIFF
--- a/darwin/exporter/formats/mask.py
+++ b/darwin/exporter/formats/mask.py
@@ -285,7 +285,6 @@ def render_polygons(
                 sequence = convert_polygons_to_sequences(polygon_off, height=new_height, width=new_width)
             else:
                 sequence = convert_polygons_to_sequences(polygon, height=height, width=width)
-            sequence = convert_polygons_to_sequences(polygon, height=height, width=width)
             colour_to_draw = categories.index(cat)
             mask = draw_polygon(mask, sequence, colour_to_draw)
 

--- a/darwin/exporter/formats/mask.py
+++ b/darwin/exporter/formats/mask.py
@@ -500,6 +500,8 @@ def annotations_exceed_window(annotations: List[dt.Annotation], height: int, wid
         bool: True if any annotation exceeds window, false otherwise
     """
     for item in annotations:
+        if "bounding_box" not in item.data:
+            continue
         bbox = item.data["bounding_box"]
         if bbox["x"] < 0:
             return True
@@ -526,6 +528,8 @@ def get_extents(annotations: List[dt.Annotation], height: int = 0, width: int = 
     x_min = y_min = 0
     x_max, y_max = width, height
     for item in annotations:
+        if "bounding_box" not in item.data:
+            continue
         bbox = item.data["bounding_box"]
         x_min = min(x_min, bbox["x"])
         x_max = max(x_max, bbox["x"] + bbox["w"])

--- a/darwin/exporter/formats/mask.py
+++ b/darwin/exporter/formats/mask.py
@@ -546,9 +546,9 @@ def offset_polygon(polygon: List, offset_x: int, offset_y: int) -> List:
         List: polygon with offset applied
     """
     new_polygon = []
-    for i in range(0, len(polygon)):
+    for point in polygon:
         new_polygon.append({
-            'x': polygon[i]['x'] + offset_x,
-            'y': polygon[i]['y'] + offset_y
+            'x': point['x'] + offset_x,
+            'y': point['y'] + offset_y
         })
     return new_polygon

--- a/darwin/exporter/formats/mask.py
+++ b/darwin/exporter/formats/mask.py
@@ -271,8 +271,7 @@ def render_polygons(
             else:
                 raise ValueError(f"Unknown annotation type {a.annotation_class.annotation_type}")
             sequence = convert_polygons_to_sequences(polygon, height=height, width=width)
-
-            colour_to_draw = get_or_generate_colour(cat, colours)
+            colour_to_draw = categories.index(cat)
             mask = draw_polygon(mask, sequence, colour_to_draw)
 
             if cat not in colours:

--- a/test/class_mapping.csv
+++ b/test/class_mapping.csv
@@ -1,7 +1,0 @@
-class_name,class_color
-__background__,0 0 0
-Billboard,255 50 50
-SemanticTest1,255 255 50
-SemanticTest2,50 255 50
-SemanticTest3,50 255 255
-Structure,50 50 255

--- a/test/class_mapping.csv
+++ b/test/class_mapping.csv
@@ -1,0 +1,7 @@
+class_name,class_color
+__background__,0 0 0
+Billboard,255 50 50
+SemanticTest1,255 255 50
+SemanticTest2,50 255 50
+SemanticTest3,50 255 255
+Structure,50 50 255

--- a/tests/darwin/exporter/formats/export_mask_test.py
+++ b/tests/darwin/exporter/formats/export_mask_test.py
@@ -233,6 +233,35 @@ def test_rle_decoder() -> None:
         rle_decode(odd_number_of_integers)
 
 
+def test_beyond_bb_window() -> None:
+    mask = np.zeros((5,5), dtype=np.uint8)
+    colours: dt.MaskTypes.ColoursDict = {}
+    categories: dt.MaskTypes.CategoryList = ["__background__"]
+    annotations: List[dt.AnnotationLike] = [
+        dt.Annotation(
+            dt.AnnotationClass("cat1", "polygon"),
+            {"path": [{"x": -1, "y": -1},{"x": -1, "y": 1},{"x": 1, "y": 1},{"x": 1, "y": -1},{"x": -1, "y": -1}], "bounding_box": {"x": -1, "y": -1, "w": 2, "h": 2}},
+        )
+    ]
+    annotation_file = dt.AnnotationFile(
+        Path("testfile"),
+        "testfile",
+        set([a.annotation_class for a in annotations]),
+        annotations,
+    )
+    height, width = 5, 5
+    errors, new_mask, new_categories, new_colours = render_polygons(
+        mask, colours, categories, annotations, annotation_file, height, width
+    )
+    
+    expected = np.array([[1, 1, 0, 0, 0],
+       [1, 1, 0, 0, 0],
+       [0, 0, 0, 0, 0],
+       [0, 0, 0, 0, 0],
+       [0, 0, 0, 0, 0]], dtype=np.uint8)
+    assert np.array_equal(new_mask, expected)
+    assert not errors
+    
 # Test render_polygons
 def test_render_polygons() -> None:
     # Create some mock data for testing

--- a/tests/darwin/exporter/formats/export_mask_test.py
+++ b/tests/darwin/exporter/formats/export_mask_test.py
@@ -239,22 +239,23 @@ def test_render_polygons() -> None:
     mask = np.zeros((100, 100), dtype=np.uint8)
     colours: dt.MaskTypes.ColoursDict = {}
     categories: dt.MaskTypes.CategoryList = ["__background__"]
+    base_bb = {"x": 0, "y": 0, "w": 1, "h": 1}
     annotations: List[dt.AnnotationLike] = [
         dt.Annotation(
             dt.AnnotationClass("cat1", "polygon"),
-            {"path": [{"x": 10, "y": 10}, {"x": 20, "y": 10}, {"x": 20, "y": 20}, {"x": 10, "y": 20}]},
+            {"path": [{"x": 10, "y": 10}, {"x": 20, "y": 10}, {"x": 20, "y": 20}, {"x": 10, "y": 20}], "bounding_box": base_bb},
         ),
         dt.Annotation(
             dt.AnnotationClass("cat2", "polygon"),
-            {"path": [{"x": 30, "y": 30}, {"x": 40, "y": 30}, {"x": 40, "y": 40}, {"x": 30, "y": 40}]},
+            {"path": [{"x": 30, "y": 30}, {"x": 40, "y": 30}, {"x": 40, "y": 40}, {"x": 30, "y": 40}], "bounding_box": base_bb},
         ),
         dt.Annotation(
             dt.AnnotationClass("cat1", "polygon"),
-            {"path": [{"x": 50, "y": 50}, {"x": 60, "y": 50}, {"x": 60, "y": 60}, {"x": 50, "y": 60}]},
+            {"path": [{"x": 50, "y": 50}, {"x": 60, "y": 50}, {"x": 60, "y": 60}, {"x": 50, "y": 60}], "bounding_box": base_bb},
         ),
         dt.Annotation(
             dt.AnnotationClass("cat1", "polygon"),
-            {"path": [{"x": 10, "y": 80}, {"x": 20, "y": 80}, {"x": 20, "y": 60}]},
+            {"path": [{"x": 10, "y": 80}, {"x": 20, "y": 80}, {"x": 20, "y": 60}], "bounding_box": base_bb},
         ),
         dt.Annotation(
             dt.AnnotationClass("cat3", "complex_polygon"),
@@ -262,7 +263,7 @@ def test_render_polygons() -> None:
                 "paths": [
                     [{"x": 70, "y": 70}, {"x": 80, "y": 70}, {"x": 80, "y": 80}, {"x": 70, "y": 80}],
                     [{"x": 75, "y": 75}, {"x": 75, "y": 78}, {"x": 78, "y": 78}],
-                ]
+                ], "bounding_box": base_bb
             },
         ),
     ]

--- a/tests/darwin/exporter/formats/export_mask_test.py
+++ b/tests/darwin/exporter/formats/export_mask_test.py
@@ -238,7 +238,7 @@ def test_render_polygons() -> None:
     # Create some mock data for testing
     mask = np.zeros((100, 100), dtype=np.uint8)
     colours: dt.MaskTypes.ColoursDict = {}
-    categories: dt.MaskTypes.CategoryList = []
+    categories: dt.MaskTypes.CategoryList = ["__background__"]
     annotations: List[dt.AnnotationLike] = [
         dt.Annotation(
             dt.AnnotationClass("cat1", "polygon"),
@@ -286,7 +286,7 @@ def test_render_polygons() -> None:
     assert_array_equal(mask, new_mask)  # type: ignore
 
     # Check that the categories and colours were updated correctly
-    assert new_categories == ["cat1", "cat2", "cat3"]
+    assert new_categories == ["__background__", "cat1", "cat2", "cat3"]
     assert new_colours == {"cat1": 1, "cat2": 2, "cat3": 3}
 
     # Check that the polygons were drawn correctly
@@ -484,7 +484,6 @@ def test_export(
     expected_mask_file: Optional[Path],
     expected_csv_file: Optional[Path],
 ) -> None:
-
     with TemporaryDirectory() as output_dir, patch(
         "darwin.exporter.formats.mask.get_render_mode"
     ) as mock_get_render_mode, patch("darwin.exporter.formats.mask.render_raster") as mock_render_raster, patch(
@@ -494,7 +493,6 @@ def test_export(
     ) as mock_get_palette, patch(
         "darwin.exporter.formats.mask.get_rgb_colours"
     ) as mock_get_rgb_colours:
-
         height, width = renderer_output[1].shape
 
         annotation_files = [


### PR DESCRIPTION
## Problem
Polygons that extend beyond the frame of reference (image height and width) get points truncated and this causes issues with the exported mask

## Solution
Checks if any annotation exceeds the window frame, if so it creates a larger mask defined by the full extent of all polygons in the annotations, creating and then offsetting the polygons to capture the entire space, before subsampling the full mask with the image dimensions in the correct location

## Changelog
Resolved an issue where out of bounds polygons caused semantic mask exports to truncate points and generate a wrong mask