### PR TITLE
[IO-1203] Fix and test for complex polygons

### DIFF
--- a/darwin/exporter/formats/mask.py
+++ b/darwin/exporter/formats/mask.py
@@ -549,6 +549,19 @@ def offset_polygon(polygon: List, offset_x: int, offset_y: int) -> List:
     Returns:
         List: polygon with offset applied
     """
+    if isinstance(polygon[0], list):
+        return offset_complex_polygon(polygon, offset_x, offset_y)
+    else:
+        return offset_simple_polygon(polygon, offset_x, offset_y)
+
+
+def offset_complex_polygon(polygons: List, offset_x: int, offset_y: int) -> List:
+    new_polygons = []
+    for polygon in polygons:
+        new_polygons.append(offset_simple_polygon(polygon, offset_x, offset_y))
+    return new_polygons
+
+def offset_simple_polygon(polygon: List, offset_x: int, offset_y: int) -> List:
     new_polygon = []
     for point in polygon:
         new_polygon.append({

--- a/tests/darwin/exporter/formats/export_mask_test.py
+++ b/tests/darwin/exporter/formats/export_mask_test.py
@@ -233,7 +233,7 @@ def test_rle_decoder() -> None:
         rle_decode(odd_number_of_integers)
 
 
-def test_beyond_bb_window() -> None:
+def test_beyond_polygon_beyond_window() -> None:
     mask = np.zeros((5,5), dtype=np.uint8)
     colours: dt.MaskTypes.ColoursDict = {}
     categories: dt.MaskTypes.CategoryList = ["__background__"]
@@ -254,14 +254,50 @@ def test_beyond_bb_window() -> None:
         mask, colours, categories, annotations, annotation_file, height, width
     )
     
-    expected = np.array([[1, 1, 0, 0, 0],
+    expected = np.array([
+       [1, 1, 0, 0, 0],
        [1, 1, 0, 0, 0],
        [0, 0, 0, 0, 0],
        [0, 0, 0, 0, 0],
        [0, 0, 0, 0, 0]], dtype=np.uint8)
     assert np.array_equal(new_mask, expected)
     assert not errors
+
+def test_beyond_complex_polygon() -> None:
+    mask = np.zeros((5,5), dtype=np.uint8)
+    colours: dt.MaskTypes.ColoursDict = {}
+    categories: dt.MaskTypes.CategoryList = ["__background__"]
+    annotations: List[dt.AnnotationLike] = [
+        dt.Annotation(
+            dt.AnnotationClass("cat3", "complex_polygon"),
+            {
+                "paths": [
+                    [{"x": -1, "y": -1},{"x": -1, "y": 1},{"x": 1, "y": 1},{"x": 1, "y": -1},{"x": -1, "y": -1}],
+                    [{"x": 3, "y": 3},{"x": 3, "y": 4},{"x": 4, "y": 4},{"x": 4, "y": 3},{"x": 3, "y": 3}],
+                ], "bounding_box": {"x": -1, "y": -1, "w": 6, "h": 6}
+            },
+        ),
+    ]
+    annotation_file = dt.AnnotationFile(
+        Path("testfile"),
+        "testfile",
+        set([a.annotation_class for a in annotations]),
+        annotations,
+    )
+    height, width = 5, 5
+    errors, new_mask, new_categories, new_colours = render_polygons(
+        mask, colours, categories, annotations, annotation_file, height, width
+    )
     
+    expected = np.array([
+       [1, 1, 0, 0, 0],
+       [1, 1, 0, 0, 0],
+       [0, 0, 0, 0, 0],
+       [0, 0, 0, 1, 1],
+       [0, 0, 0, 1, 1]], dtype=np.uint8)
+    assert np.array_equal(new_mask, expected)
+    assert not errors
+
 # Test render_polygons
 def test_render_polygons() -> None:
     # Create some mock data for testing


### PR DESCRIPTION
# Problem
Latest fix for semantic mask didn't account for the problem of having complex polygons vs simple polygons

# Solution
Polygon offsets now account for complex polygons and deal with simple/complex accordingly

# Changelog
Fixed a problem with new semantic mask export logic not accounting for complex polygon datasets with out of bounds polygons. It should now handle complex polygons.
