### PR TITLE
Fix optional properties in LocalFile.serialize_v2()

### DIFF
--- a/darwin/dataset/upload_manager.py
+++ b/darwin/dataset/upload_manager.py
@@ -164,15 +164,18 @@ class LocalFile:
     def serialize_v2(self):
         optional_properties = ["tags", "fps", "as_frames", "extract_views"]
         slot = {"file_name": self.data["filename"], "slot_name": "0"}
+        for optional_property in optional_properties:
+                if optional_property in self.data:
+                    slot[optional_property] = self.data.get(optional_property)
         serialized = {
             "slots": [slot],
             "name": self.data["filename"],
             "path": self.data["path"],
         }
-        for optional_property in optional_properties:
-            if optional_property in self.data:
-                serialized[optional_property] = self.data.get(optional_property)
+        if "tags" in self.data:
+            serialized["tags"] = self.data["tags"]
         return serialized
+
 
 
     @property

--- a/darwin/dataset/upload_manager.py
+++ b/darwin/dataset/upload_manager.py
@@ -164,15 +164,16 @@ class LocalFile:
     def serialize_v2(self):
         optional_properties = ["tags", "fps", "as_frames", "extract_views"]
         slot = {"file_name": self.data["filename"], "slot_name": "0"}
-        for optional_property in optional_properties:
-            if optional_property in self.data:
-                slot[optional_property] = self.data.get(optional_property)
-
-        return {
+        serialized = {
             "slots": [slot],
             "name": self.data["filename"],
             "path": self.data["path"],
         }
+        for optional_property in optional_properties:
+            if optional_property in self.data:
+                serialized[optional_property] = self.data.get(optional_property)
+        return serialized
+
 
     @property
     def full_path(self) -> str:

--- a/darwin/dataset/upload_manager.py
+++ b/darwin/dataset/upload_manager.py
@@ -165,8 +165,8 @@ class LocalFile:
         optional_properties = ["tags", "fps", "as_frames", "extract_views"]
         slot = {"file_name": self.data["filename"], "slot_name": "0"}
         for optional_property in optional_properties:
-                if optional_property in self.data:
-                    slot[optional_property] = self.data.get(optional_property)
+            if optional_property in self.data:
+                slot[optional_property] = self.data.get(optional_property)
         serialized = {
             "slots": [slot],
             "name": self.data["filename"],

--- a/darwin/dataset/upload_manager.py
+++ b/darwin/dataset/upload_manager.py
@@ -167,6 +167,7 @@ class LocalFile:
         for optional_property in optional_properties:
             if optional_property in self.data:
                 slot[optional_property] = self.data.get(optional_property)
+
         serialized = {
             "slots": [slot],
             "name": self.data["filename"],
@@ -175,8 +176,6 @@ class LocalFile:
         if "tags" in self.data:
             serialized["tags"] = self.data["tags"]
         return serialized
-
-
 
     @property
     def full_path(self) -> str:


### PR DESCRIPTION
# Problem
I tried to upload a file to a V7 2.0 dataset and wanted to add a tag to it while uploading.

```py
local_file = LocalFile("~/test.png", tags=["some-tag"])
dataset.push([local_file])
```

While the image is uploaded correctly, no tags are set.

#### Incorrect behavior of `darwin-py==0.8.27`
```py
>>> local_file.serialize_v2()
{'slots': [{'file_name': 'test.png', 'slot_name': '0', 'tags': ['some-tag']}],
 'name': 'test.png',
 'path': '/'}
```

#### Fixed behavior
```py
>>> local_file.serialize_v2()
{'slots': [{'file_name': 'test.png', 'slot_name': '0'}],
 'name': 'test.png',
 'path': '/',
 'tags': ['some-tag']}
```

# Solution
Store `optional_properties` on the dictionary root instead of `slots[0]` (c.f. [Register data for proceessing](https://docs.v7labs.com/reference/imports-process-upload)).

<details>

<summary>Example cURL request from the 2.0 REST API</summary>

```bash
curl --request POST \
     --url https://darwin.v7labs.com/api/v2/teams/my-team/items/register_existing \
     --header 'accept: application/json' \
     --header 'content-type: application/json' \
     --data '
{
  "items": [
    {
      "path": "/",
      "name": "test.png",
      "slots": [
        {
          "as_frames": false,
          "extract_views": false,
          "file_name": "test.png"
        }
      ],
      "tags": [
        "some-tag"
      ]
    }
  ],
  "options": {
    "force_tiling": false,
    "ignore_dicom_layout": true
  },
  "dataset_slug": "my-dataset"
}
'
```
</details>

# Changelog
- Fix `LocalFile` serialization for v7 2.0