### PR TITLE
[IO-1018][internal] Create Dataset meta method

### DIFF
--- a/darwin/future/meta/objects/dataset.py
+++ b/darwin/future/meta/objects/dataset.py
@@ -149,9 +149,9 @@ class DatasetMeta:
         ------
         AssertionError
         """
-        slug = slug.lower().strip()
-        assert_is(isinstance(slug, str), "slug must be a string")
-        assert_is(len(slug) > 0, "slug must not be empty")
+        slug_copy = str(slug).lower().strip()
+        assert_is(isinstance(slug_copy, str), "slug must be a string")
+        assert_is(len(slug_copy) > 0, "slug must not be empty")
 
         VALID_SLUG_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
-        assert_is(all(c in VALID_SLUG_CHARS for c in slug), "slug must only contain valid characters")
+        assert_is(all(c in VALID_SLUG_CHARS for c in slug_copy), "slug must only contain valid characters")

--- a/darwin/future/meta/objects/dataset.py
+++ b/darwin/future/meta/objects/dataset.py
@@ -1,5 +1,6 @@
 from typing import List, Optional, Tuple, Union
 
+from darwin.future.core.datasets.create_dataset import create_dataset
 from darwin.future.core.datasets.get_dataset import get_dataset
 from darwin.future.core.datasets.remove_dataset import remove_dataset
 from darwin.future.data_objects.dataset import Dataset
@@ -23,15 +24,50 @@ class DatasetMeta:
         # TODO: implement
         raise NotImplementedError()
 
-    def create_dataset(self) -> Dataset:
-        # TODO: implement in IO-1018
-        raise NotImplementedError()
+    def create_dataset(self, slug: str) -> Tuple[Optional[List[Exception]], Optional[Dataset]]:
+        """
+        Creates a new dataset for the given team
+
+        Parameters
+        ----------
+        slug: str [a-b0-9-_]
+            The slug of the dataset to create
+
+        Returns
+        -------
+        Tuple[Optional[List[Exception]], Optional[Dataset]]
+            A tuple containing a list of exceptions and the dataset created
+
+        """
+        exceptions = []
+        dataset: Optional[Dataset] = None
+
+        try:
+            self._validate_slug(slug)
+            dataset = create_dataset(self.client, slug)
+        except Exception as e:
+            exceptions.append(e)
+
+        return exceptions or None, dataset
 
     def update_dataset(self) -> Dataset:
         # TODO: implement in IO-1018
         raise NotImplementedError()
 
     def delete_dataset(self, dataset_id: Union[int, str]) -> Tuple[Optional[List[Exception]], int]:
+        """
+        Deletes a dataset by id or slug
+
+        Parameters
+        ----------
+        dataset_id: Union[int, str]
+            The id or slug of the dataset to delete
+
+        Returns
+        -------
+        Tuple[Optional[List[Exception]], int]
+            A tuple containing a list of exceptions and the number of datasets deleted
+        """
         exceptions = []
         dataset_deleted = -1
 
@@ -48,6 +84,22 @@ class DatasetMeta:
 
     @staticmethod
     def _delete_by_slug(client: MetaClient, slug: str) -> int:
+        """
+        (internal) Deletes a dataset by slug
+
+        Parameters
+        ----------
+        client: MetaClient
+            The client to use to make the request
+
+        slug: str
+            The slug of the dataset to delete
+
+        Returns
+        -------
+        int
+            The dataset deleted
+        """
         assert_is(isinstance(client, MetaClient), "client must be a MetaClient")
         assert_is(isinstance(slug, str), "slug must be a string")
 
@@ -61,8 +113,45 @@ class DatasetMeta:
 
     @staticmethod
     def _delete_by_id(client: MetaClient, dataset_id: int) -> int:
+        """
+        (internal) Deletes a dataset by id
+
+        Parameters
+        ----------
+        client: MetaClient
+            The client to use to make the request
+
+        dataset_id: int
+            The id of the dataset to delete
+
+        Returns
+        -------
+        int
+            The dataset deleted
+        """
         assert_is(isinstance(client, MetaClient), "client must be a MetaClient")
         assert_is(isinstance(dataset_id, int), "dataset_id must be an integer")
 
         dataset_deleted = remove_dataset(client, dataset_id)
         return dataset_deleted
+
+    @staticmethod
+    def _validate_slug(slug: str) -> None:
+        """
+        Validates a slug
+
+        Parameters
+        ----------
+        slug: str
+            The slug to validate
+
+        Raises
+        ------
+        AssertionError
+        """
+        slug = slug.lower().strip()
+        assert_is(isinstance(slug, str), "slug must be a string")
+        assert_is(len(slug) > 0, "slug must not be empty")
+
+        VALID_SLUG_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
+        assert_is(all(c in VALID_SLUG_CHARS for c in slug), "slug must only contain valid characters")

--- a/darwin/future/tests/meta/objects/test_datasetmeta.py
+++ b/darwin/future/tests/meta/objects/test_datasetmeta.py
@@ -43,8 +43,32 @@ def test_create_dataset_returns_exceptions_thrown(base_config: DarwinConfig) -> 
         exceptions, dataset_created = dataset_meta.create_dataset(valid_slug)
 
         assert exceptions is not None
-        assert str(exceptions[0]) == "500 Server Error: None for url: https://api.darwinai.com/api/datasets"
+        assert "500 Server Error" in str(exceptions[0])
         assert dataset_created is None
+
+
+def test_create_dataset_returns_dataset_created_if_dataset_created(base_config: DarwinConfig) -> None:
+    valid_client = MetaClient(base_config)
+    valid_slug = "test_dataset"
+
+    base_url = base_config.base_url + "api/datasets"
+
+    with RequestsMock() as rsps:
+        rsps.add(
+            rsps.POST,
+            base_url,
+            json={"id": 1, "name": "Test Dataset", "slug": "test_dataset"},
+            status=201,
+        )
+        dataset_meta = DatasetMeta(valid_client)
+
+        exceptions, dataset_created = dataset_meta.create_dataset(valid_slug)
+
+        assert exceptions is None
+        assert dataset_created is not None
+        assert dataset_created.id == 1
+        assert dataset_created.name == "test dataset"
+        assert dataset_created.slug == "test_dataset"
 
 
 # `update_dataset` tests


### PR DESCRIPTION
# Problem
Meta objects had no way of creating datasets, which blocks workflows.

# Solution
Added a simple create dataset function to the `DatasetMeta` object, with tests.

# Changelog
Implemented previously `NotRaisedException` raising function `create_dataset` on `DatasetMeta`
Added unit tests for creation of datasets.
