### PR TITLE
[IO-1341] YoloV2 file overwriting bug.

### DIFF
--- a/darwin/exporter/formats/yolo.py
+++ b/darwin/exporter/formats/yolo.py
@@ -31,7 +31,7 @@ def export(annotation_files: Iterable[dt.AnnotationFile], output_dir: Path) -> N
 
 def _export_file(annotation_file: dt.AnnotationFile, class_index: ClassIndex, output_dir: Path) -> None:
     txt = _build_txt(annotation_file, class_index)
-    output_file_path = (output_dir / annotation_file.filename).with_suffix(".txt")
+    output_file_path = (output_dir / annotation_file.path.stem).with_suffix(".txt")
     output_file_path.parent.mkdir(parents=True, exist_ok=True)
     with open(output_file_path, "w") as f:
         f.write(txt)

--- a/darwin/exporter/formats/yolo.py
+++ b/darwin/exporter/formats/yolo.py
@@ -31,7 +31,13 @@ def export(annotation_files: Iterable[dt.AnnotationFile], output_dir: Path) -> N
 
 def _export_file(annotation_file: dt.AnnotationFile, class_index: ClassIndex, output_dir: Path) -> None:
     txt = _build_txt(annotation_file, class_index)
-    output_file_path = (output_dir / annotation_file.path.stem).with_suffix(".txt")
+
+    # Just using `.with_suffix(".txt")` would remove all suffixes, so we need to
+    # do it manually.
+    annotation_file_path = Path(output_dir / annotation_file.path.stem)
+    new_suffices = annotation_file_path.suffixes[:-1] + [".txt"]
+    output_file_path = Path(annotation_file_path).with_suffix("".join(new_suffices))
+
     output_file_path.parent.mkdir(parents=True, exist_ok=True)
     with open(output_file_path, "w") as f:
         f.write(txt)


### PR DESCRIPTION
File overwriting bug in YOLO conversions.

# Problem
In a scenario where two files are in a directory structure with the same name:

```
|-image.json
|-image_2.json
|
|--folder_1
|    |-image.png
|--folder_2
|    |-image.png
```

The use of the `AnnotationFile` attribute `filename` is used to define the output filenames (`image.txt` and `image.txt`), and this causes a clash, in which one file output _overwrites_ the other.

# Solution
Instead of using `AnnotationFile.filename`, it's better to use the `.stem` attribute of the path to the json file, as these are in the same directory, and can't share a name.

# Changelog
Changed file to use `Path.stem` instead of `AnnotationFile.filename`
