### PR TITLE
QF refactor and mypy cleanup

### DIFF
--- a/darwin/future/core/datasets/remove_dataset.py
+++ b/darwin/future/core/datasets/remove_dataset.py
@@ -26,6 +26,7 @@ def remove_dataset(api_client: Client, id: int, team_slug: Optional[str] = None)
         f"/datasets/{id}/archive",
         {"team_slug": team_slug},
     )
+    assert isinstance(response, dict)
 
     if "id" not in response:
         raise DatasetNotFound(f"Dataset with id {id} not found")

--- a/darwin/future/core/types/query.py
+++ b/darwin/future/core/types/query.py
@@ -189,12 +189,6 @@ class Query(Generic[T], ABC):
             self += item
         return self
 
-    def _parse_dict_param(self, d: Dict[str, Any]) -> QueryFilter:  # type: ignore
-        if "name" not in d or "param" not in d:
-            raise ValueError(f"args must be a QueryFilter or a dict with 'name' and 'param' keys, got {d}")
-        modifier = Modifier(d["modifier"]) if "modifier" in d else None
-        return QueryFilter(name=d["name"], param=str(d["param"]), modifier=modifier)
-
     @abstractmethod
     def collect(self) -> List[T]:
         raise NotImplementedError("Not implemented")

--- a/darwin/future/core/types/query.py
+++ b/darwin/future/core/types/query.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from curses import meta
 from enum import Enum
 from typing import (
     Any,

--- a/darwin/future/meta/client.py
+++ b/darwin/future/meta/client.py
@@ -24,6 +24,7 @@ class MetaClient(Client):
         config = DarwinConfig.from_api_key_with_defaults(api_key=api_key)
         client = Client(config)  # create a temporary client to get the default team
         token_info = client.get("/users/token_info")
+        assert isinstance(token_info, dict)
         default_team: str = token_info["selected_team"]["slug"]
         config.default_team = default_team
         if datasets_dir:

--- a/darwin/future/meta/queries/dataset.py
+++ b/darwin/future/meta/queries/dataset.py
@@ -16,15 +16,8 @@ class DatasetQuery(Query[DatasetMeta]):
     Methods
     -------
 
-    where: Adds a filter to the query
     collect: Executes the query and returns the filtered data
     """
-
-    def where(self, param: Param) -> DatasetQuery:
-        filter = QueryFilter.parse_obj(param)
-        query = self + filter
-
-        return DatasetQuery(self.client, query.filters)
 
     def collect(self) -> List[DatasetMeta]:
         datasets, exceptions = list_datasets(self.client)

--- a/darwin/future/meta/queries/stage.py
+++ b/darwin/future/meta/queries/stage.py
@@ -10,12 +10,6 @@ from darwin.future.meta.objects.stage import StageMeta
 
 
 class StageQuery(Query[StageMeta]):
-    def where(self, param: Param) -> StageQuery:
-        filter = QueryFilter.parse_obj(param)
-        query = self + filter
-
-        return StageQuery(self.client, query.filters, self.meta_params)
-
     def collect(self) -> List[StageMeta]:
         if not self.meta_params:
             raise ValueError("Must specify workflow_id to query stages")

--- a/darwin/future/meta/queries/team_member.py
+++ b/darwin/future/meta/queries/team_member.py
@@ -10,16 +10,9 @@ from darwin.future.meta.objects.team_member import TeamMemberMeta
 class TeamMemberQuery(Query[TeamMemberMeta]):
     """TeamMemberQuery object with methods to manage filters, retrieve data, and execute filters
     Methods:
-    where: Adds a filter to the query
     collect: Executes the query and returns the filtered data
     _execute_filter: Executes a filter on a list of objects
     """
-
-    def where(self, param: Param) -> TeamMemberQuery:
-        filter = QueryFilter.parse_obj(param)
-        query = self + filter
-
-        return TeamMemberQuery(self.client, query.filters)
 
     def collect(self) -> List[TeamMemberMeta]:
         members, exceptions = get_team_members(self.client)

--- a/darwin/future/meta/queries/workflow.py
+++ b/darwin/future/meta/queries/workflow.py
@@ -19,15 +19,8 @@ class WorkflowQuery(Query[WorkflowMeta]):
     Methods
     -------
 
-    where: Adds a filter to the query
     collect: Executes the query and returns the filtered data
     """
-
-    def where(self, param: Param) -> "WorkflowQuery":
-        filter = QueryFilter.parse_obj(param)
-        query = self + filter
-
-        return WorkflowQuery(self.client, query.filters)
 
     def collect(self) -> List[WorkflowMeta]:
         workflows_core, exceptions = list_workflows(self.client)
@@ -75,7 +68,9 @@ class WorkflowQuery(Query[WorkflowMeta]):
 
         if filter.name == "has_stages":
             stages_to_find = [s for s in filter.param.split(",")]
-            return [w for w in workflows if w._item is not None and self._stages_contains(w._item.stages, stages_to_find)]
+            return [
+                w for w in workflows if w._item is not None and self._stages_contains(w._item.stages, stages_to_find)
+            ]
 
         return self._generic_execute_filter(workflows, filter)
 

--- a/darwin/future/tests/core/test_client.py
+++ b/darwin/future/tests/core/test_client.py
@@ -34,10 +34,11 @@ def test_config_base_url(base_config: DarwinConfig) -> None:
 
 
 @pytest.mark.parametrize("base_url", ["test_url.com", "ftp://test_url.com", ""])
-def test_invalid_config_url_validation(base_url: str) -> None:
+def test_invalid_config_url_validation(base_url: str, tmp_path: Path) -> None:
     with pytest.raises(ValidationError):
         config = DarwinConfig(
             api_key="test_key",
+            datasets_dir=tmp_path,
             api_endpoint="http://test_url.com/api/",
             base_url=base_url,
             default_team="default-team",

--- a/darwin/future/tests/core/test_query.py
+++ b/darwin/future/tests/core/test_query.py
@@ -1,5 +1,4 @@
 import unittest
-from cgi import test
 from typing import Any, List, Optional, Type
 
 import pytest

--- a/darwin/future/tests/core/test_query.py
+++ b/darwin/future/tests/core/test_query.py
@@ -1,4 +1,5 @@
 import unittest
+from cgi import test
 from typing import Any, List, Optional, Type
 
 import pytest
@@ -33,12 +34,16 @@ def test_team() -> Team:
     return Team(slug="test-team", id=0)
 
 
-def test_query_instantiated(base_client: Client, basic_filters: List[Query.QueryFilter], non_abc_query: Type[Query.Query]) -> None:
+def test_query_instantiated(
+    base_client: Client, basic_filters: List[Query.QueryFilter], non_abc_query: Type[Query.Query]
+) -> None:
     q = non_abc_query(base_client, basic_filters)
     assert q.filters == basic_filters
 
 
-def test_query_filter_functionality(base_client: Client, basic_filters: List[Query.QueryFilter], non_abc_query: Type[Query.Query]) -> None:
+def test_query_filter_functionality(
+    base_client: Client, basic_filters: List[Query.QueryFilter], non_abc_query: Type[Query.Query]
+) -> None:
     q = non_abc_query(base_client)
     for f in basic_filters:
         q = q.filter(f)
@@ -57,7 +62,6 @@ def test_query_filter_functionality(base_client: Client, basic_filters: List[Que
     basic_filters.append(dropped_filter)
     q = q + dropped_filter
     assert q.filters == basic_filters
-
 
 
 @pytest.mark.parametrize(
@@ -91,3 +95,33 @@ def test_query_filter_filters(mod: Optional[str], param: Any, check: Any, expect
         modifier = None
     QF = Query.QueryFilter(name="test", param=param, modifier=modifier)
     assert QF.filter_attr(check) == expected
+
+
+def test_QF_from_asteriks() -> None:
+    # Builds with dictionary args
+    QF = Query.QueryFilter._from_args(
+        {"name": "test", "param": "test"}, {"name": "test2", "param": "test2", "modifier": "!="}
+    )
+    assert len(QF) == 2
+    assert QF[0].name == "test"
+    assert QF[0].param == "test"
+    assert QF[0].modifier is None
+    assert QF[1].name == "test2"
+    assert QF[1].param == "test2"
+    assert QF[1].modifier == Query.Modifier("!=")
+
+    # Builds with kwargs
+    QF = Query.QueryFilter._from_args(test="test", test2="!=:test2")
+    assert len(QF) == 2
+    assert QF[0].name == "test"
+    assert QF[0].param == "test"
+    assert QF[0].modifier is None
+    assert QF[1].name == "test2"
+    assert QF[1].param == "test2"
+    assert QF[1].modifier == Query.Modifier("!=")
+
+    # fails on bad args
+    with pytest.raises(ValueError):
+        Query.QueryFilter._from_args({})
+        Query.QueryFilter._from_args([])
+        Query.QueryFilter._from_args(1, 2, 3)


### PR DESCRIPTION
# Problem
QueryFilter objects are a bit unweildy atm, having to call them with a quite verbose dictionary like syntax

# Solution
Added in ability to create filter objects from kwargs while keeping existing functionality, also supports modifier instantiation using 'modifier:value' syntax
```python
QueryFilter._from_args(test='test1') # QueryFilter(name='test', param='test1')
QueryFilter._from_args(test='>=:6') # QueryFilter(name='test', param='6', modifier='>=')
```
Also cleaned up Query code further to handle generalized and inherited `where(*args, **kwargs)` that creates these filter objects and doesn't require overwriting in meta query code.

# Changelog
Streamlined creation and usage of QueryFilters