### PR TITLE
[IO-1334][internal] E2E Testing config

### DIFF
--- a/e2e_tests/.env.sample
+++ b/e2e_tests/.env.sample
@@ -1,0 +1,3 @@
+# Because this is intended to be run in a CI environment, this will normally be unnecessary.
+E2E_ENVIRONMENT=
+E2E_API_KEY=

--- a/e2e_tests/conftest.py
+++ b/e2e_tests/conftest.py
@@ -1,0 +1,54 @@
+from os import environ
+from os.path import dirname, join
+from pathlib import Path
+from typing import Optional, Tuple
+
+import dotenv
+import pytest
+
+
+def pytest_configure(_: pytest.Config) -> None:
+    ...
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    dotenv_file_location: Path = Path(join(dirname(__file__), "../.env")).absolute()
+
+    if not dotenv_file_location.exists():
+        raise FileNotFoundError(f"Could not find .env file at {dotenv_file_location}")
+
+    dotenv.load_dotenv(dotenv_file_location)
+
+    server = environ.get("E2E_ENVIRONMENT")
+    api_key = environ.get("E2E_API_KEY")
+
+    if server is None:
+        raise ValueError("E2E_ENVIRONMENT is not set")
+
+    if api_key is None:
+        raise ValueError("E2E_API_KEY is not set")
+
+    if not isinstance(session.config.cache, pytest.Cache):
+        raise TypeError("Pytest caching is not enabled, but E2E tests require it")
+
+    session.config.cache.set("server", server)
+    session.config.cache.set("api_key", api_key)
+
+
+@pytest.fixture(
+    scope="session", autouse=True
+)  # autouse=True means that this fixture will be automatically used by all tests
+def config_values(session: pytest.Session) -> Tuple[str, str]:
+    if not isinstance(session.config.cache, pytest.Cache):
+        raise TypeError("Pytest caching is not enabled, but E2E tests require it")
+
+    server = session.config.cache.get("server", None)
+    api_key = session.config.cache.get("api_key", None)
+
+    if server is None:
+        raise ValueError("E2E_ENVIRONMENT is not set")
+
+    if api_key is None:
+        raise ValueError("E2E_API_KEY is not set")
+
+    return server, api_key

--- a/e2e_tests/conftest.py
+++ b/e2e_tests/conftest.py
@@ -2,11 +2,11 @@ from collections import namedtuple
 from os import environ
 from os.path import dirname, join
 from pathlib import Path
-from pprint import pprint
 
 import dotenv
 import pytest
 
+from darwin.future.data_objects.typing import UnknownType
 from e2e_tests.exceptions import E2EEnvironmentVariableNotSet
 
 
@@ -42,8 +42,7 @@ ConfigValues = namedtuple("ConfigValues", ["server", "api_key"])
 @pytest.fixture(
     scope="session", autouse=True
 )  # autouse=True means that this fixture will be automatically used by all tests
-def config_values(request) -> ConfigValues:
-    pprint(request)
+def config_values(request: UnknownType) -> ConfigValues:
     session = request.node.session
 
     if not isinstance(session.config.cache, pytest.Cache):

--- a/e2e_tests/conftest.py
+++ b/e2e_tests/conftest.py
@@ -1,32 +1,33 @@
+from collections import namedtuple
 from os import environ
 from os.path import dirname, join
 from pathlib import Path
-from typing import Optional, Tuple
+from pprint import pprint
 
 import dotenv
 import pytest
 
+from e2e_tests.exceptions import E2EEnvironmentVariableNotSet
 
-def pytest_configure(_: pytest.Config) -> None:
-    ...
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line("addopts", "--ignore=../tests/, ../future")
 
 
 def pytest_sessionstart(session: pytest.Session) -> None:
-    dotenv_file_location: Path = Path(join(dirname(__file__), "../.env")).absolute()
-
-    if not dotenv_file_location.exists():
-        raise FileNotFoundError(f"Could not find .env file at {dotenv_file_location}")
-
-    dotenv.load_dotenv(dotenv_file_location)
+    # Use dotenv values _if_ present
+    dotenv_file_location: Path = Path(join(dirname(__file__), ".env")).resolve()
+    if dotenv_file_location.exists():
+        dotenv.load_dotenv(dotenv_file_location)
 
     server = environ.get("E2E_ENVIRONMENT")
     api_key = environ.get("E2E_API_KEY")
 
     if server is None:
-        raise ValueError("E2E_ENVIRONMENT is not set")
+        raise E2EEnvironmentVariableNotSet("E2E_ENVIRONMENT")
 
     if api_key is None:
-        raise ValueError("E2E_API_KEY is not set")
+        raise E2EEnvironmentVariableNotSet("E2E_API_KEY")
 
     if not isinstance(session.config.cache, pytest.Cache):
         raise TypeError("Pytest caching is not enabled, but E2E tests require it")
@@ -35,10 +36,16 @@ def pytest_sessionstart(session: pytest.Session) -> None:
     session.config.cache.set("api_key", api_key)
 
 
+ConfigValues = namedtuple("ConfigValues", ["server", "api_key"])
+
+
 @pytest.fixture(
     scope="session", autouse=True
 )  # autouse=True means that this fixture will be automatically used by all tests
-def config_values(session: pytest.Session) -> Tuple[str, str]:
+def config_values(request) -> ConfigValues:
+    pprint(request)
+    session = request.node.session
+
     if not isinstance(session.config.cache, pytest.Cache):
         raise TypeError("Pytest caching is not enabled, but E2E tests require it")
 
@@ -51,4 +58,4 @@ def config_values(session: pytest.Session) -> Tuple[str, str]:
     if api_key is None:
         raise ValueError("E2E_API_KEY is not set")
 
-    return server, api_key
+    return ConfigValues(server=server, api_key=api_key)

--- a/e2e_tests/exceptions.py
+++ b/e2e_tests/exceptions.py
@@ -1,6 +1,6 @@
 """Custom exceptions for the e2e_tests module."""
 
-from typing import Any, Dict, List
+from typing import Dict, List
 
 from pytest import PytestWarning
 

--- a/e2e_tests/exceptions.py
+++ b/e2e_tests/exceptions.py
@@ -1,0 +1,19 @@
+"""Custom exceptions for the e2e_tests module."""
+
+from typing import Any, Dict, List
+
+from pytest import PytestWarning
+
+
+class E2EException(PytestWarning):
+    """Base class for all exceptions in this module."""
+
+    ...
+
+
+class E2EEnvironmentVariableNotSet(E2EException):
+    """Raised when an environment variable is not set."""
+
+    def __init__(self, name: str, *args: List, **kwargs: Dict) -> None:
+        super().__init__(*args, **kwargs)
+        self.name = name

--- a/e2e_tests/pytest.ini
+++ b/e2e_tests/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+cache_dir = /tmp/pytest_cache

--- a/e2e_tests/pytest.ini
+++ b/e2e_tests/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 cache_dir = /tmp/pytest_cache
+addopts = --ignore=../tests,../future

--- a/e2e_tests/test_example.py
+++ b/e2e_tests/test_example.py
@@ -1,7 +1,13 @@
 import pytest
 
+from e2e_tests.conftest import ConfigValues
 
-def test_example_test_does_nothing() -> None:
+
+@pytest.mark.xfail(reason="Fails unless you set the server and key as below")
+def test_example_test_does_nothing(config_values: ConfigValues) -> None:
+    assert config_values.server == "https://api.example.com"
+    assert config_values.api_key == "1234567890"
+
     assert True
 
 


### PR DESCRIPTION
# Problem
E2E Tests had no config solution

# Solution
Added a `conftest.py` file that incoporated environment variables, with optional `dotenv` for use on local machines.  Also added a fixture that is global, and session bound (runs once per test session, not once per test) that allows for these values to be included in tests easily.  Have also added custom E2E exceptions that the config code can raise so that if our system raises an error we foresee in config, we can easily spot these in CI.

*NB: Have deliberately not included the staging URL in the defaults, as it would go into our public code if I did, and possibly shouldn't*.

# Changelog
e2e_tests/conftest.py
e2e_tests/exceptions.py
e2e_tests/pytest.ini
e2e_tests/test_example.py

* Added test configuration file with hook to accept and parse config, and fixture to share it
* Added custom exceptions for E2E tests
* Added to example test to offer green that this works.
