### PR TITLE
[IO-1279] Functions to move items around stages

### DIFF
--- a/darwin/future/core/client.py
+++ b/darwin/future/core/client.py
@@ -155,7 +155,7 @@ class Client:
 
     @property
     def headers(self) -> Dict[str, str]:
-        http_headers: Dict[str, str] = {"Content-Type": "application/json"}
+        http_headers: Dict[str, str] = {"Content-Type": "application/json", "Accept": "application/json"}
         if self.config.api_key:
             http_headers["Authorization"] = f"ApiKey {self.config.api_key}"
         return http_headers
@@ -172,7 +172,7 @@ class Client:
         endpoint = self._sanitize_endpoint(endpoint)
         url = self.config.api_endpoint + endpoint
         if payload is not None:
-            response = method(url, payload)
+            response = method(url, json=payload)
         else:
             response = method(url)
 

--- a/darwin/future/core/items/get.py
+++ b/darwin/future/core/items/get.py
@@ -1,0 +1,32 @@
+
+
+from typing import List
+from uuid import UUID
+
+from darwin.future.core.client import Client
+from darwin.future.core.types.common import QueryString
+
+
+def get_item_ids(api_client: Client, team_slug: str, dataset_id: str) -> List[UUID]:
+    """
+    Returns a list of item ids for the dataset
+
+    Parameters
+    ----------
+    client: Client
+        The client to use for the request
+    team_slug: str
+        The slug of the team to get item ids for
+    dataset_id: str
+        The id or slug of the dataset to get item ids for
+
+    Returns
+    -------
+    List[UUID]
+        A list of item ids
+    """
+    
+    response = api_client.get(f"/v2/teams/{team_slug}/items/ids", QueryString({"not_statuses": "archived,error", "sort[id]": "desc", "dataset_ids": dataset_id}))
+    assert type(response) == dict
+    uuids = [UUID(uuid) for uuid in response["item_ids"]]
+    return uuids

--- a/darwin/future/core/items/get.py
+++ b/darwin/future/core/items/get.py
@@ -1,13 +1,11 @@
-
-
-from typing import List
+from typing import List, Union
 from uuid import UUID
 
 from darwin.future.core.client import Client
 from darwin.future.core.types.common import QueryString
 
 
-def get_item_ids(api_client: Client, team_slug: str, dataset_id: str) -> List[UUID]:
+def get_item_ids(api_client: Client, team_slug: str, dataset_id: Union[str, int]) -> List[UUID]:
     """
     Returns a list of item ids for the dataset
 
@@ -25,8 +23,42 @@ def get_item_ids(api_client: Client, team_slug: str, dataset_id: str) -> List[UU
     List[UUID]
         A list of item ids
     """
-    
-    response = api_client.get(f"/v2/teams/{team_slug}/items/ids", QueryString({"not_statuses": "archived,error", "sort[id]": "desc", "dataset_ids": dataset_id}))
+
+    response = api_client.get(
+        f"/v2/teams/{team_slug}/items/ids",
+        QueryString({"not_statuses": "archived,error", "sort[id]": "desc", "dataset_ids": str(dataset_id)}),
+    )
+    assert type(response) == dict
+    uuids = [UUID(uuid) for uuid in response["item_ids"]]
+    return uuids
+
+
+def get_item_ids_stage(
+    api_client: Client, team_slug: str, dataset_id: Union[int, str], stage_id: Union[UUID, str]
+) -> List[UUID]:
+    """
+    Returns a list of item ids for the stage
+
+    Parameters
+    ----------
+    client: Client
+        The client to use for the request
+    team_slug: str
+        The slug of the team to get item ids for
+    dataset_id: str
+        The id or slug of the dataset to get item ids for
+    stage_id: str
+        The id or slug of the stage to get item ids for
+
+    Returns
+    -------
+    List[UUID]
+        A list of item ids
+    """
+    response = api_client.get(
+        f"/v2/teams/{team_slug}/items/ids",
+        QueryString({"workflow_stage_ids": str(stage_id), "dataset_ids": str(dataset_id)}),
+    )
     assert type(response) == dict
     uuids = [UUID(uuid) for uuid in response["item_ids"]]
     return uuids

--- a/darwin/future/core/items/move_items.py
+++ b/darwin/future/core/items/move_items.py
@@ -29,10 +29,12 @@ def move_items_to_stage(api_client: Client, team_slug: str, workflow_id: UUID, d
     """
 
     api_client.post(
-        f"/v2/teams/{team_slug}/items/stage", {"filters": {
+        f"/v2/teams/{team_slug}/items/stage", {
+            "filters": {
             "dataset_ids": [dataset_id],
             "item_ids": [str(id) for id in item_ids],
+            },
             "stage_id": str(stage_id),
             "workflow_id": str(workflow_id)
-        }}
+        }
     )

--- a/darwin/future/core/items/move_items.py
+++ b/darwin/future/core/items/move_items.py
@@ -1,12 +1,12 @@
-
-
 from typing import List
 from uuid import UUID
 
 from darwin.future.core.client import Client
 
 
-def move_items_to_stage(api_client: Client, team_slug: str, workflow_id: UUID, dataset_id: int, stage_id: UUID, item_ids: List[UUID]) -> None:
+def move_items_to_stage(
+    api_client: Client, team_slug: str, workflow_id: UUID, dataset_id: int, stage_id: UUID, item_ids: List[UUID]
+) -> None:
     """
     Moves a list of items to a stage
 
@@ -29,12 +29,13 @@ def move_items_to_stage(api_client: Client, team_slug: str, workflow_id: UUID, d
     """
 
     api_client.post(
-        f"/v2/teams/{team_slug}/items/stage", {
+        f"/v2/teams/{team_slug}/items/stage",
+        {
             "filters": {
-            "dataset_ids": [dataset_id],
-            "item_ids": [str(id) for id in item_ids],
+                "dataset_ids": [dataset_id],
+                "item_ids": [str(id) for id in item_ids],
             },
             "stage_id": str(stage_id),
-            "workflow_id": str(workflow_id)
-        }
+            "workflow_id": str(workflow_id),
+        },
     )

--- a/darwin/future/core/items/move_items.py
+++ b/darwin/future/core/items/move_items.py
@@ -1,12 +1,12 @@
 from typing import List
 from uuid import UUID
 
-from darwin.future.core.client import Client
+from darwin.future.core.client import Client, JSONType
 
 
 def move_items_to_stage(
     api_client: Client, team_slug: str, workflow_id: UUID, dataset_id: int, stage_id: UUID, item_ids: List[UUID]
-) -> None:
+) -> JSONType:
     """
     Moves a list of items to a stage
 
@@ -28,7 +28,7 @@ def move_items_to_stage(
     None
     """
 
-    api_client.post(
+    return api_client.post(
         f"/v2/teams/{team_slug}/items/stage",
         {
             "filters": {

--- a/darwin/future/core/items/move_items_to_stage.py
+++ b/darwin/future/core/items/move_items_to_stage.py
@@ -6,7 +6,7 @@ from uuid import UUID
 from darwin.future.core.client import Client
 
 
-def move_items_to_stage(api_client: Client, team_slug: str, dataset_id: int, stage_id: UUID, item_ids: List[UUID]) -> None:
+def move_items_to_stage(api_client: Client, team_slug: str, workflow_id: UUID, dataset_id: int, stage_id: UUID, item_ids: List[UUID]) -> None:
     """
     Moves a list of items to a stage
 
@@ -29,5 +29,10 @@ def move_items_to_stage(api_client: Client, team_slug: str, dataset_id: int, sta
     """
 
     api_client.post(
-        f"/v2/teams/{team_slug}/items/stage", {"item_ids": [str(item_id) for item_id in item_ids]}
+        f"/v2/teams/{team_slug}/items/stage", {"filters": {
+            "dataset_ids": [dataset_id],
+            "item_ids": [str(id) for id in item_ids],
+            "stage_id": str(stage_id),
+            "workflow_id": str(workflow_id)
+        }}
     )

--- a/darwin/future/core/items/move_items_to_stage.py
+++ b/darwin/future/core/items/move_items_to_stage.py
@@ -1,0 +1,33 @@
+
+
+from typing import List
+from uuid import UUID
+
+from darwin.future.core.client import Client
+
+
+def move_items_to_stage(api_client: Client, team_slug: str, dataset_id: int, stage_id: UUID, item_ids: List[UUID]) -> None:
+    """
+    Moves a list of items to a stage
+
+    Parameters
+    ----------
+    client: Client
+        The client to use for the request
+    team_slug: str
+        The slug of the team to move items for
+    dataset_id: str
+        The id or slug of the dataset to move items for
+    stage_id: str
+        The id or slug of the stage to move items to
+    item_ids: List[UUID]
+        A list of item ids to move to the stage
+
+    Returns
+    -------
+    None
+    """
+
+    api_client.post(
+        f"/v2/teams/{team_slug}/items/stage", {"item_ids": [str(item_id) for item_id in item_ids]}
+    )

--- a/darwin/future/core/types/query.py
+++ b/darwin/future/core/types/query.py
@@ -193,5 +193,21 @@ class Query(Generic[T], ABC):
     def collect(self) -> List[T]:
         raise NotImplementedError("Not implemented")
 
+    def collect_one(self) -> T:
+        if self.results is None:
+            self.results = list(self.collect())
+        if len(self.results) == 0:
+            raise ValueError("No results found")
+        if len(self.results) > 1:
+            raise ValueError("More than one result found")
+        return self.results[0]
+
+    def first(self) -> Optional[T]:
+        if self.results is None:
+            self.results = list(self.collect())
+        if len(self.results) == 0:
+            return None
+        return self.results[0]
+
     def _generic_execute_filter(self, objects: List[T], filter: QueryFilter) -> List[T]:
         return [m for m in objects if filter.filter_attr(getattr(m._item, filter.name))]

--- a/darwin/future/data_objects/team.py
+++ b/darwin/future/data_objects/team.py
@@ -44,7 +44,7 @@ class Team(DefaultDarwin):
     ----------
     _slug_validator: validates and auto formats the slug variable
     """
-
+    name: str
     slug: str
     id: int
     datasets: Optional[DatasetList] = None

--- a/darwin/future/data_objects/workflow.py
+++ b/darwin/future/data_objects/workflow.py
@@ -81,6 +81,12 @@ class WFType(Enum):
     ANNOTATE = "annotate"
     REVIEW = "review"
     COMPLETE = "complete"
+    DISCARD = "discard"
+    MODEL = "model"
+    WEBHOOK = "webhook"
+    ARCHIVE = "archive"
+    CONSENSUS_TEST = "consensus_test"
+    CONSENSUS_ENTRYPOINT = "consensus_entrypoint"
 
 
 class WFUser(DefaultDarwin):
@@ -173,7 +179,7 @@ class Workflow(DefaultDarwin):
     inserted_at: datetime
     updated_at: datetime
 
-    dataset: WFDataset
+    dataset: Optional[WFDataset]
     stages: List[WFStage]
 
     thumbnails: List[str]

--- a/darwin/future/meta/client.py
+++ b/darwin/future/meta/client.py
@@ -39,6 +39,6 @@ class MetaClient(Client):
             self._team = TeamMeta(self)
         return self._team
 
-    @property
-    def workflows(self) -> WorkflowQuery:
-        return WorkflowQuery(self, meta_params={"team_slug": self.team.slug})
+    # @property
+    # def workflows(self) -> WorkflowQuery:
+    #     return WorkflowQuery(self, meta_params={"team_slug": self.team.slug})

--- a/darwin/future/meta/client.py
+++ b/darwin/future/meta/client.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 from requests.adapters import Retry
 
 from darwin.future.core.client import Client, DarwinConfig
 from darwin.future.meta.objects.team import TeamMeta
+from darwin.future.meta.objects.workflow import WorkflowMeta
+from darwin.future.meta.queries.workflow import WorkflowQuery
 
 
 class MetaClient(Client):
@@ -36,3 +38,8 @@ class MetaClient(Client):
         if self._team is None:
             self._team = TeamMeta(self)
         return self._team
+
+    @property
+    def workflows(self) -> WorkflowQuery:
+        return WorkflowQuery(self)
+    

--- a/darwin/future/meta/client.py
+++ b/darwin/future/meta/client.py
@@ -41,5 +41,4 @@ class MetaClient(Client):
 
     @property
     def workflows(self) -> WorkflowQuery:
-        return WorkflowQuery(self)
-    
+        return WorkflowQuery(self, meta_params={"team_slug": self.team.slug})

--- a/darwin/future/meta/objects/base.py
+++ b/darwin/future/meta/objects/base.py
@@ -1,20 +1,22 @@
 from __future__ import annotations
 
-from typing import Generic, List, Optional, TypeVar
+from typing import Dict, Generic, List, Optional, TypeVar
 
 from darwin.future.core.client import Client
 from darwin.future.pydantic_base import DefaultDarwin
 
 R = TypeVar("R", bound=DefaultDarwin)
+Param = Dict[str, object]
 
 
 class MetaBase(Generic[R]):
     _item: Optional[R]
     client: Client
 
-    def __init__(self, client: Client, item: Optional[R] = None) -> None:
+    def __init__(self, client: Client, item: Optional[R] = None, meta_params: Optional[Param] = None) -> None:
         self.client = client
         self._item = item
+        self.meta_params = meta_params or {}
 
     def __str__(self) -> str:
         if self._item is None:

--- a/darwin/future/meta/objects/base.py
+++ b/darwin/future/meta/objects/base.py
@@ -16,7 +16,7 @@ class MetaBase(Generic[R]):
     def __init__(self, client: Client, item: Optional[R] = None, meta_params: Optional[Param] = None) -> None:
         self.client = client
         self._item = item
-        self.meta_params = meta_params or {}
+        self.meta_params = meta_params or dict()
 
     def __str__(self) -> str:
         if self._item is None:

--- a/darwin/future/meta/objects/dataset.py
+++ b/darwin/future/meta/objects/dataset.py
@@ -1,10 +1,12 @@
 from typing import List, Optional, Tuple, Union
+from uuid import UUID
 
 from darwin.future.core.client import Client
 from darwin.future.core.datasets.create_dataset import create_dataset
 from darwin.future.core.datasets.get_dataset import get_dataset
 from darwin.future.core.datasets.list_datasets import list_datasets
 from darwin.future.core.datasets.remove_dataset import remove_dataset
+from darwin.future.core.items.get import get_item_ids
 from darwin.future.data_objects.dataset import Dataset
 from darwin.future.helpers.assertion import assert_is
 from darwin.future.meta.objects.base import MetaBase
@@ -20,6 +22,22 @@ class DatasetMeta(MetaBase[Dataset]):
         _type_: DatasetMeta
     """
 
+    @property
+    def id(self) -> int:
+        assert self._item is not None
+        assert self._item.id is not None
+        return self._item.id
+
+    def item_ids(self, team_slug: str) -> List[UUID]:
+        """Returns a list of item ids for the dataset
+
+        Returns:
+            List[UUID]: A list of item ids
+        """
+        assert self._item is not None
+        assert self._item.id is not None
+        return get_item_ids(self.client, team_slug, str(self._item.id))
+        
     def get_dataset_by_id(self) -> Dataset:
         # TODO: implement
         raise NotImplementedError()

--- a/darwin/future/meta/objects/dataset.py
+++ b/darwin/future/meta/objects/dataset.py
@@ -1,6 +1,11 @@
-from typing import List, Optional, Tuple, Union
+from __future__ import annotations
+
+from typing import List, Optional, Sequence, Tuple, Union
 from uuid import UUID
 
+from darwin.cli_functions import upload_data
+from darwin.dataset.upload_manager import LocalFile
+from darwin.datatypes import PathLike
 from darwin.future.core.client import Client
 from darwin.future.core.datasets.create_dataset import create_dataset
 from darwin.future.core.datasets.get_dataset import get_dataset
@@ -37,7 +42,7 @@ class DatasetMeta(MetaBase[Dataset]):
         assert self._item is not None
         assert self._item.id is not None
         return get_item_ids(self.client, team_slug, str(self._item.id))
-        
+
     def get_dataset_by_id(self) -> Dataset:
         # TODO: implement
         raise NotImplementedError()
@@ -173,3 +178,20 @@ class DatasetMeta(MetaBase[Dataset]):
 
         VALID_SLUG_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
         assert_is(all(c in VALID_SLUG_CHARS for c in slug_copy), "slug must only contain valid characters")
+
+    def upload_files(
+        self,
+        files: Sequence[Union[PathLike, LocalFile]],
+        files_to_exclude: Optional[List[PathLike]] = None,
+        fps: int = 1,
+        path: Optional[str] = None,
+        frames: bool = False,
+        extract_views: bool = False,
+        preserve_folders: bool = False,
+        verbose: bool = False,
+    ) -> DatasetMeta:
+        assert self._item is not None
+        upload_data(
+            self._item.name, files, files_to_exclude, fps, path, frames, extract_views, preserve_folders, verbose
+        )
+        return self

--- a/darwin/future/meta/objects/dataset.py
+++ b/darwin/future/meta/objects/dataset.py
@@ -26,14 +26,24 @@ class DatasetMeta(MetaBase[Dataset]):
     Returns:
         _type_: DatasetMeta
     """
-
+    @property
+    def name(self) -> str:
+        assert self._item is not None
+        assert self._item.name is not None
+        return self._item.name
+    @property
+    def slug(self) -> str:
+        assert self._item is not None
+        assert self._item.slug is not None
+        return self._item.slug
     @property
     def id(self) -> int:
         assert self._item is not None
         assert self._item.id is not None
         return self._item.id
 
-    def item_ids(self, team_slug: str) -> List[UUID]:
+    @property
+    def item_ids(self) -> List[UUID]:
         """Returns a list of item ids for the dataset
 
         Returns:
@@ -41,7 +51,8 @@ class DatasetMeta(MetaBase[Dataset]):
         """
         assert self._item is not None
         assert self._item.id is not None
-        return get_item_ids(self.client, team_slug, str(self._item.id))
+        assert self.meta_params["team_slug"] is not None and type(self.meta_params["team_slug"]) == str
+        return get_item_ids(self.client, self.meta_params["team_slug"], str(self._item.id))
 
     def get_dataset_by_id(self) -> Dataset:
         # TODO: implement

--- a/darwin/future/meta/objects/stage.py
+++ b/darwin/future/meta/objects/stage.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import List
 from uuid import UUID
 
-from darwin.future.core.client import Client
 from darwin.future.core.items.get import get_item_ids_stage
 from darwin.future.core.items.move_items import move_items_to_stage
 from darwin.future.data_objects.workflow import WFStage

--- a/darwin/future/meta/objects/stage.py
+++ b/darwin/future/meta/objects/stage.py
@@ -21,3 +21,8 @@ class StageMeta(MetaBase[WFStage]):
     ) -> None:
         self._workflow_id = workflow_id
         super().__init__(client, item)
+
+    @property
+    def id(self) -> UUID:
+        assert self._item is not None
+        return self._item.id

--- a/darwin/future/meta/objects/stage.py
+++ b/darwin/future/meta/objects/stage.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 from typing import List, Optional
 from uuid import UUID
 
 from darwin.future.core.client import Client
 from darwin.future.core.items.get import get_item_ids_stage
+from darwin.future.core.items.move_items import move_items_to_stage
 from darwin.future.data_objects.workflow import WFStage
 from darwin.future.meta.objects.base import MetaBase
 
@@ -26,6 +29,18 @@ class StageMeta(MetaBase[WFStage]):
         return get_item_ids_stage(
             self.client, str(self.meta_params["team_slug"]), str(self.meta_params["dataset_id"]), self.id
         )
+
+    def move_attached_files_to_stage(self, new_stage_id: UUID) -> StageMeta:
+        assert self.meta_params["team_slug"] is not None and type(self.meta_params["team_slug"]) == str
+        assert self.meta_params["workflow_id"] is not None and type(self.meta_params["workflow_id"]) == UUID
+        assert self.meta_params["dataset_id"] is not None and type(self.meta_params["dataset_id"]) == int
+        slug, w_id, d_id = (
+            self.meta_params["team_slug"],
+            self.meta_params["workflow_id"],
+            self.meta_params["dataset_id"],
+        )
+        move_items_to_stage(self.client, slug, w_id, d_id, new_stage_id, self.item_ids)
+        return self
 
     @property
     def id(self) -> UUID:

--- a/darwin/future/meta/objects/stage.py
+++ b/darwin/future/meta/objects/stage.py
@@ -1,7 +1,8 @@
-from typing import Optional
+from typing import List, Optional
 from uuid import UUID
 
 from darwin.future.core.client import Client
+from darwin.future.core.items.get import get_item_ids_stage
 from darwin.future.data_objects.workflow import WFStage
 from darwin.future.meta.objects.base import MetaBase
 
@@ -13,14 +14,18 @@ class StageMeta(MetaBase[WFStage]):
         MetaBase (_type_): _description_
     """
 
-    def __init__(
-        self,
-        client: Client,
-        item: Optional[WFStage] = None,
-        workflow_id: Optional[UUID] = None,
-    ) -> None:
-        self._workflow_id = workflow_id
-        super().__init__(client, item)
+    @property
+    def item_ids(self) -> List[UUID]:
+        """_summary_
+
+        Returns:
+            _type_: _description_
+        """
+        assert self._item is not None
+        assert self._item.id is not None
+        return get_item_ids_stage(
+            self.client, str(self.meta_params["team_slug"]), str(self.meta_params["dataset_id"]), self.id
+        )
 
     @property
     def id(self) -> UUID:

--- a/darwin/future/meta/objects/team.py
+++ b/darwin/future/meta/objects/team.py
@@ -30,8 +30,7 @@ class TeamMeta(MetaBase[Team]):
     @property
     def name(self) -> str:
         assert self._item is not None
-        assert self._item.slug is not None
-        return self._item.slug
+        return self._item.name
 
     @property
     def id(self) -> int:
@@ -58,5 +57,5 @@ class TeamMeta(MetaBase[Team]):
     
     def __str__(self) -> str:
         assert self._item is not None
-        return f"TeamMeta(slug='{self.slug}', id='{self.id}' - {len(self._item.members if self._item.members else [])} members)"
+        return f"TeamMeta(name='{self.name}', slug='{self.slug}', id='{self.id}' - {len(self._item.members if self._item.members else [])} members)"
         

--- a/darwin/future/meta/objects/team.py
+++ b/darwin/future/meta/objects/team.py
@@ -34,11 +34,11 @@ class TeamMeta(MetaBase[Team]):
     def slug(self) -> str:
         assert self._item is not None
         return self._item.slug
-    
+
     @property
     def datasets(self) -> DatasetQuery:
-        return DatasetQuery(self.client)
-    
+        return DatasetQuery(self.client, meta_params={"team_slug": self.slug})
+
     # @property
     # def workflows(self) -> WorkflowQuery:
     #     return WorkflowQuery(self.client)

--- a/darwin/future/meta/objects/team.py
+++ b/darwin/future/meta/objects/team.py
@@ -6,6 +6,7 @@ from darwin.future.helpers.assertion import assert_is
 from darwin.future.meta.objects.base import MetaBase
 from darwin.future.meta.queries.dataset import DatasetQuery
 from darwin.future.meta.queries.team_member import TeamMemberQuery
+from darwin.future.meta.queries.workflow import WorkflowQuery
 
 
 class TeamMeta(MetaBase[Team]):
@@ -27,8 +28,20 @@ class TeamMeta(MetaBase[Team]):
         super().__init__(client, team)
 
     @property
+    def name(self) -> str:
+        assert self._item is not None
+        assert self._item.slug is not None
+        return self._item.slug
+
+    @property
+    def id(self) -> int:
+        assert self._item is not None
+        assert self._item.id is not None
+        return self._item.id
+    
+    @property
     def members(self) -> TeamMemberQuery:
-        return TeamMemberQuery(self.client)
+        return TeamMemberQuery(self.client, meta_params={"team_slug": self.slug})
 
     @property
     def slug(self) -> str:
@@ -39,6 +52,11 @@ class TeamMeta(MetaBase[Team]):
     def datasets(self) -> DatasetQuery:
         return DatasetQuery(self.client, meta_params={"team_slug": self.slug})
 
-    # @property
-    # def workflows(self) -> WorkflowQuery:
-    #     return WorkflowQuery(self.client)
+    @property
+    def workflows(self) -> WorkflowQuery:
+        return WorkflowQuery(self.client, meta_params={"team_slug": self.slug})
+    
+    def __str__(self) -> str:
+        assert self._item is not None
+        return f"TeamMeta(slug='{self.slug}', id='{self.id}' - {len(self._item.members if self._item.members else [])} members)"
+        

--- a/darwin/future/meta/objects/team.py
+++ b/darwin/future/meta/objects/team.py
@@ -4,6 +4,7 @@ from darwin.future.core.client import Client
 from darwin.future.data_objects.team import Team, get_team
 from darwin.future.helpers.assertion import assert_is
 from darwin.future.meta.objects.base import MetaBase
+from darwin.future.meta.queries.dataset import DatasetQuery
 from darwin.future.meta.queries.team_member import TeamMemberQuery
 
 
@@ -29,6 +30,15 @@ class TeamMeta(MetaBase[Team]):
     def members(self) -> TeamMemberQuery:
         return TeamMemberQuery(self.client)
 
+    @property
+    def slug(self) -> str:
+        assert self._item is not None
+        return self._item.slug
+    
+    @property
+    def datasets(self) -> DatasetQuery:
+        return DatasetQuery(self.client)
+    
     # @property
     # def workflows(self) -> WorkflowQuery:
     #     return WorkflowQuery(self.client)

--- a/darwin/future/meta/objects/workflow.py
+++ b/darwin/future/meta/objects/workflow.py
@@ -1,6 +1,7 @@
 from uuid import UUID
 
-from darwin.future.data_objects.workflow import Workflow
+from darwin.future.core.items.move_items import move_items_to_stage
+from darwin.future.data_objects.workflow import WFDataset, Workflow
 from darwin.future.meta.objects.base import MetaBase
 from darwin.future.meta.queries.stage import StageQuery
 
@@ -10,8 +11,20 @@ class WorkflowMeta(MetaBase[Workflow]):
     def stages(self) -> StageQuery:
         if self._item is None:
             raise ValueError("WorkflowMeta has no item")
-        meta_params = {"workflow_id": self._item.id}
+        meta_params = self.meta_params.copy()
+        meta_params["workflow_id"] = self._item.id
+        if self.dataset is not None:
+            meta_params["dataset_id"] = self.dataset.id
+            meta_params["dataset_name"] = self.dataset.name
         return StageQuery(self.client, meta_params=meta_params)
+
+    @property
+    def dataset(self) -> WFDataset:
+        if self._item is None:
+            raise ValueError("WorkflowMeta has no item")
+        if self._item.dataset is None:
+            raise ValueError("WorkflowMeta has no associated dataset")
+        return self._item.dataset
 
     @property
     def id(self) -> UUID:
@@ -24,3 +37,16 @@ class WorkflowMeta(MetaBase[Workflow]):
         if self._item is None:
             raise ValueError("WorkflowMeta has no item")
         return self._item.name
+
+    def push_from_dataset_stage(self) -> None:
+        assert self._item is not None
+        assert self._item.dataset is not None
+        stages = self.stages
+        assert len(stages) > 1
+        ds_stage = stages[0]
+        item_ids = ds_stage.item_ids
+        assert ds_stage._item is not None
+        next_stage = ds_stage._item.edges[0].target_stage_id
+        assert next_stage is not None
+        slug, d_id, w_id = self.meta_params["team_slug"], self._item.dataset.id, self._item.id
+        move_items_to_stage(self.client, str(slug), w_id, d_id, next_stage, item_ids)

--- a/darwin/future/meta/objects/workflow.py
+++ b/darwin/future/meta/objects/workflow.py
@@ -1,7 +1,14 @@
+from __future__ import annotations
+
+from enum import auto
+from pathlib import Path
+from typing import List, Optional, Union
 from uuid import UUID
 
-from darwin.future.core.items.move_items import move_items_to_stage
-from darwin.future.data_objects.workflow import WFDataset, Workflow
+from darwin.cli_functions import upload_data
+from darwin.dataset.upload_manager import LocalFile
+from darwin.datatypes import PathLike
+from darwin.future.data_objects.workflow import WFDataset, WFType, Workflow
 from darwin.future.meta.objects.base import MetaBase
 from darwin.future.meta.queries.stage import StageQuery
 
@@ -38,15 +45,35 @@ class WorkflowMeta(MetaBase[Workflow]):
             raise ValueError("WorkflowMeta has no item")
         return self._item.name
 
-    def push_from_dataset_stage(self) -> None:
+    def push_from_dataset_stage(self) -> WorkflowMeta:
         assert self._item is not None
         assert self._item.dataset is not None
         stages = self.stages
-        assert len(stages) > 1
         ds_stage = stages[0]
-        item_ids = ds_stage.item_ids
-        assert ds_stage._item is not None
+        assert len(stages) > 1
+        assert ds_stage._item is not None and ds_stage._item.type == WFType.DATASET
         next_stage = ds_stage._item.edges[0].target_stage_id
         assert next_stage is not None
-        slug, d_id, w_id = self.meta_params["team_slug"], self._item.dataset.id, self._item.id
-        move_items_to_stage(self.client, str(slug), w_id, d_id, next_stage, item_ids)
+        ds_stage.move_attached_files_to_stage(next_stage)
+        return self
+
+    def upload_files(
+        self,
+        files: Optional[List[Union[PathLike, LocalFile]]],
+        files_to_exclude: Optional[List[PathLike]] = None,
+        fps: int = 1,
+        path: Optional[str] = None,
+        frames: bool = False,
+        extract_views: bool = False,
+        preserve_folders: bool = False,
+        verbose: bool = False,
+        auto_push: bool = True,
+    ) -> WorkflowMeta:
+        assert self._item is not None
+        assert self._item.dataset is not None
+        upload_data(
+            self.dataset.name, files, files_to_exclude, fps, path, frames, extract_views, preserve_folders, verbose
+        )
+        if auto_push:
+            self.push_from_dataset_stage()
+        return self

--- a/darwin/future/meta/objects/workflow.py
+++ b/darwin/future/meta/objects/workflow.py
@@ -20,18 +20,18 @@ class WorkflowMeta(MetaBase[Workflow]):
             raise ValueError("WorkflowMeta has no item")
         meta_params = self.meta_params.copy()
         meta_params["workflow_id"] = self._item.id
-        if self.dataset is not None:
-            meta_params["dataset_id"] = self.dataset.id
-            meta_params["dataset_name"] = self.dataset.name
+        if self.datasets is not None:
+            meta_params["dataset_id"] = self.datasets[0].id
+            meta_params["dataset_name"] = self.datasets[0].name
         return StageQuery(self.client, meta_params=meta_params)
 
     @property
-    def dataset(self) -> WFDataset:
+    def datasets(self) -> List[WFDataset]:
         if self._item is None:
             raise ValueError("WorkflowMeta has no item")
         if self._item.dataset is None:
             raise ValueError("WorkflowMeta has no associated dataset")
-        return self._item.dataset
+        return [self._item.dataset]
 
     @property
     def id(self) -> UUID:
@@ -72,7 +72,7 @@ class WorkflowMeta(MetaBase[Workflow]):
         assert self._item is not None
         assert self._item.dataset is not None
         upload_data(
-            self.dataset.name, files, files_to_exclude, fps, path, frames, extract_views, preserve_folders, verbose
+            self.datasets[0].name, files, files_to_exclude, fps, path, frames, extract_views, preserve_folders, verbose
         )
         if auto_push:
             self.push_from_dataset_stage()

--- a/darwin/future/meta/objects/workflow.py
+++ b/darwin/future/meta/objects/workflow.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from enum import auto
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import List, Optional, Sequence, Union
 from uuid import UUID
 
 from darwin.cli_functions import upload_data
@@ -59,7 +59,7 @@ class WorkflowMeta(MetaBase[Workflow]):
 
     def upload_files(
         self,
-        files: Optional[List[Union[PathLike, LocalFile]]],
+        files: Sequence[Union[PathLike, LocalFile]],
         files_to_exclude: Optional[List[PathLike]] = None,
         fps: int = 1,
         path: Optional[str] = None,

--- a/darwin/future/meta/queries/dataset.py
+++ b/darwin/future/meta/queries/dataset.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import List
 
+from darwin.cli_functions import upload_data
 from darwin.future.core.datasets.list_datasets import list_datasets
 from darwin.future.core.types.query import Param, Query, QueryFilter
 from darwin.future.data_objects.dataset import Dataset
@@ -18,6 +19,7 @@ class DatasetQuery(Query[DatasetMeta]):
 
     collect: Executes the query and returns the filtered data
     """
+
     def collect(self) -> List[DatasetMeta]:
         datasets, exceptions = list_datasets(self.client)
         if exceptions:

--- a/darwin/future/meta/queries/dataset.py
+++ b/darwin/future/meta/queries/dataset.py
@@ -18,7 +18,6 @@ class DatasetQuery(Query[DatasetMeta]):
 
     collect: Executes the query and returns the filtered data
     """
-
     def collect(self) -> List[DatasetMeta]:
         datasets, exceptions = list_datasets(self.client)
         if exceptions:

--- a/darwin/future/meta/queries/stage.py
+++ b/darwin/future/meta/queries/stage.py
@@ -14,7 +14,7 @@ class StageQuery(Query[StageMeta]):
         if not self.meta_params:
             raise ValueError("Must specify workflow_id to query stages")
         workflow_id: UUID = self.meta_params["workflow_id"]
-        meta_params = self.meta_params.copy()
+        meta_params = self.meta_params
         workflow, exceptions = get_workflow(self.client, str(workflow_id))
         assert workflow is not None
         stages = [StageMeta(self.client, s, meta_params=meta_params) for s in workflow.stages]

--- a/darwin/future/meta/queries/stage.py
+++ b/darwin/future/meta/queries/stage.py
@@ -14,9 +14,10 @@ class StageQuery(Query[StageMeta]):
         if not self.meta_params:
             raise ValueError("Must specify workflow_id to query stages")
         workflow_id: UUID = self.meta_params["workflow_id"]
+        meta_params = self.meta_params.copy()
         workflow, exceptions = get_workflow(self.client, str(workflow_id))
         assert workflow is not None
-        stages = [StageMeta(self.client, s, workflow_id) for s in workflow.stages]
+        stages = [StageMeta(self.client, s, meta_params=meta_params) for s in workflow.stages]
         if not self.filters:
             self.filters = []
         for filter in self.filters:

--- a/darwin/future/meta/queries/workflow.py
+++ b/darwin/future/meta/queries/workflow.py
@@ -1,4 +1,3 @@
-from curses import meta
 from datetime import datetime, timezone
 from typing import List
 from uuid import UUID

--- a/darwin/future/meta/queries/workflow.py
+++ b/darwin/future/meta/queries/workflow.py
@@ -1,12 +1,12 @@
+from curses import meta
 from datetime import datetime, timezone
 from typing import List
 from uuid import UUID
 
 from darwin.exceptions import DarwinException
-from darwin.future.core.client import Client
 from darwin.future.core.types.query import Param, Query, QueryFilter
 from darwin.future.core.workflows.list_workflows import list_workflows
-from darwin.future.data_objects.workflow import WFStage, Workflow
+from darwin.future.data_objects.workflow import WFStage
 from darwin.future.helpers.exception_handler import handle_exception
 from darwin.future.meta.objects.workflow import WorkflowMeta
 
@@ -27,8 +27,7 @@ class WorkflowQuery(Query[WorkflowMeta]):
         if exceptions:
             handle_exception(exceptions)
             raise DarwinException from exceptions[0]
-
-        workflows = [WorkflowMeta(self.client, workflow) for workflow in workflows_core]
+        workflows = [WorkflowMeta(self.client, workflow, self.meta_params) for workflow in workflows_core]
         if not self.filters:
             return workflows
 
@@ -60,7 +59,13 @@ class WorkflowQuery(Query[WorkflowMeta]):
 
         if filter.name == "dataset_id":
             datasets_to_find_id: List[int] = [int(s) for s in filter.param.split(",")]
-            return [w for w in workflows if w._item is not None and w._item.dataset is not None and int(w._item.dataset.id) in datasets_to_find_id]
+            return [
+                w
+                for w in workflows
+                if w._item is not None
+                and w._item.dataset is not None
+                and int(w._item.dataset.id) in datasets_to_find_id
+            ]
 
         if filter.name == "dataset_name":
             datasets_to_find_name: List[str] = [str(s) for s in filter.param.split(",")]

--- a/darwin/future/meta/queries/workflow.py
+++ b/darwin/future/meta/queries/workflow.py
@@ -60,7 +60,7 @@ class WorkflowQuery(Query[WorkflowMeta]):
 
         if filter.name == "dataset_id":
             datasets_to_find_id: List[int] = [int(s) for s in filter.param.split(",")]
-            return [w for w in workflows if w._item is not None and int(w._item.dataset) in datasets_to_find_id]
+            return [w for w in workflows if w._item is not None and w._item.dataset is not None and int(w._item.dataset.id) in datasets_to_find_id]
 
         if filter.name == "dataset_name":
             datasets_to_find_name: List[str] = [str(s) for s in filter.param.split(",")]

--- a/darwin/future/tests/core/fixtures.py
+++ b/darwin/future/tests/core/fixtures.py
@@ -30,7 +30,7 @@ def base_client(base_config: DarwinConfig) -> Client:
 
 @pytest.fixture
 def base_team_json() -> dict:
-    return {"slug": "test-team", "id": "0"}
+    return {"slug": "test-team", "id": "0", "name": "test-team"}
 
 
 @pytest.fixture

--- a/darwin/future/tests/core/items/fixtures.py
+++ b/darwin/future/tests/core/items/fixtures.py
@@ -1,0 +1,21 @@
+from typing import List
+from uuid import UUID, uuid4
+
+import pytest
+
+
+@pytest.fixture
+def UUIDs() -> List[UUID]:
+    return [uuid4() for i in range(10)]
+
+@pytest.fixture
+def UUIDs_str(UUIDs: List[UUID]) -> List[str]:
+    return [str(uuid) for uuid in UUIDs]
+
+@pytest.fixture
+def stage_id() -> UUID:
+    return uuid4()
+
+@pytest.fixture
+def workflow_id() -> UUID:
+    return uuid4()

--- a/darwin/future/tests/core/items/test_get_items.py
+++ b/darwin/future/tests/core/items/test_get_items.py
@@ -1,21 +1,13 @@
 from typing import List
 from uuid import UUID, uuid4
 
-import pytest
 import responses
 
 from darwin.future.core.client import Client
 from darwin.future.core.items.get import get_item_ids, get_item_ids_stage
 from darwin.future.tests.core.fixtures import *
+from darwin.future.tests.core.items.fixtures import *
 
-
-@pytest.fixture
-def UUIDs() -> List[UUID]:
-    return [uuid4() for i in range(10)]
-
-@pytest.fixture
-def UUIDs_str(UUIDs: List[UUID]) -> List[str]:
-    return [str(uuid) for uuid in UUIDs]
 
 def test_get_item_ids(UUIDs: List[UUID], UUIDs_str: List[str], base_client: Client) -> None:
     with responses.RequestsMock() as rsps:

--- a/darwin/future/tests/core/items/test_get_items.py
+++ b/darwin/future/tests/core/items/test_get_items.py
@@ -1,0 +1,41 @@
+from typing import List
+from uuid import UUID, uuid4
+
+import pytest
+import responses
+
+from darwin.future.core.client import Client
+from darwin.future.core.items.get import get_item_ids, get_item_ids_stage
+from darwin.future.tests.core.fixtures import *
+
+
+@pytest.fixture
+def UUIDs() -> List[UUID]:
+    return [uuid4() for i in range(10)]
+
+@pytest.fixture
+def UUIDs_str(UUIDs: List[UUID]) -> List[str]:
+    return [str(uuid) for uuid in UUIDs]
+
+def test_get_item_ids(UUIDs: List[UUID], UUIDs_str: List[str], base_client: Client) -> None:
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            rsps.GET,
+            base_client.config.api_endpoint + f"v2/teams/default-team/items/ids?not_statuses=archived,error&sort[id]=desc&dataset_ids=1337",
+            json={"item_ids": UUIDs_str},
+            status=200,
+        )
+        item_ids = get_item_ids(base_client, "default-team", "1337")
+        assert item_ids == UUIDs
+
+def test_get_item_ids_stage(UUIDs: List[UUID], UUIDs_str: List[str], base_client: Client) -> None:
+    stage_id = str(uuid4())
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            rsps.GET,
+            base_client.config.api_endpoint + f"v2/teams/default-team/items/ids?workflow_stage_ids={stage_id}&dataset_ids=1337",
+            json={"item_ids": UUIDs_str},
+            status=200,
+        )
+        item_ids = get_item_ids_stage(base_client, "default-team", "1337", stage_id)
+        assert item_ids == UUIDs

--- a/darwin/future/tests/core/items/test_move_items.py
+++ b/darwin/future/tests/core/items/test_move_items.py
@@ -1,0 +1,33 @@
+from typing import Dict, List
+from uuid import UUID, uuid4
+
+import pytest
+import responses
+
+from darwin.future.core.client import Client
+from darwin.future.core.items.move_items import move_items_to_stage
+from darwin.future.tests.core.fixtures import *
+from darwin.future.tests.core.items.fixtures import *
+
+
+@pytest.fixture
+def move_payload(UUIDs_str: List[str], stage_id: UUID, workflow_id: UUID) -> Dict:
+    return {
+            "filters": {
+                "dataset_ids": [1337],
+                "item_ids": UUIDs_str,
+            },
+            "stage_id": str(stage_id),
+            "workflow_id": str(workflow_id),
+        }
+    
+def test_move_items(base_client: Client, move_payload: Dict, stage_id: UUID, workflow_id: UUID, UUIDs_str: List[str], UUIDs: List[UUID]) -> None:
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            rsps.POST,
+            base_client.config.api_endpoint + "v2/teams/default-team/items/stage",
+            json={"success": UUIDs_str}, 
+            status=200,
+        )
+        item_ids = move_items_to_stage(base_client, "default-team", workflow_id, 1337, stage_id, UUIDs)
+        assert rsps.assert_call_count(base_client.config.api_endpoint + "v2/teams/default-team/items/stage", 1)

--- a/darwin/future/tests/core/test_client.py
+++ b/darwin/future/tests/core/test_client.py
@@ -53,7 +53,11 @@ def test_client(base_client: Client) -> None:
 
     assert base_client.session is not None
     assert base_client.headers is not None
-    assert base_client.headers == {"Content-Type": "application/json", "Authorization": "ApiKey test_key"}
+    assert base_client.headers == {
+        "Content-Type": "application/json",
+        "Authorization": "ApiKey test_key",
+        "Accept": "application/json",
+    }
 
     # Test client functionality works
     endpoint = base_client.config.api_endpoint + "test_endpoint"

--- a/darwin/future/tests/core/test_query.py
+++ b/darwin/future/tests/core/test_query.py
@@ -1,8 +1,8 @@
-import unittest
 from typing import Any, List, Optional, Type
 
 import pytest
 
+from darwin import item
 from darwin.future.core.client import Client
 from darwin.future.core.types import query as Query
 from darwin.future.data_objects.team import Team
@@ -124,3 +124,19 @@ def test_QF_from_asteriks() -> None:
         Query.QueryFilter._from_args({})
         Query.QueryFilter._from_args([])
         Query.QueryFilter._from_args(1, 2, 3)
+
+def test_query_first(non_abc_query: Type[Query.Query], base_client: Client) -> None:
+    query = non_abc_query(base_client)
+    query.results = [1, 2, 3]
+    first = query.first()
+    assert first == 1
+    
+def test_query_collect_one(non_abc_query: Type[Query.Query], base_client: Client) -> None:
+    query = non_abc_query(base_client)
+    query.results = [1, 2, 3]
+    with pytest.raises(ValueError):
+        query.collect_one()
+        
+    query.results = [1]
+    assert query.collect_one() == 1
+    

--- a/darwin/future/tests/data_objects/fixtures.py
+++ b/darwin/future/tests/data_objects/fixtures.py
@@ -13,7 +13,7 @@ valid_workflow_json = test_data_path / "workflow.json"
 
 @pytest.fixture
 def basic_team() -> dict:
-    return {"slug": "test-team", "id": 0}
+    return {"slug": "test-team", "id": 0, "name": "test-team"}
 
 
 @pytest.fixture

--- a/darwin/future/tests/meta/objects/test_stagemeta.py
+++ b/darwin/future/tests/meta/objects/test_stagemeta.py
@@ -1,15 +1,57 @@
+from typing import List
+from uuid import UUID
+
+import responses
 from pytest import fixture, mark, raises
 from responses import RequestsMock
+from sklearn import base
 
 from darwin.future.core.client import DarwinConfig
+from darwin.future.data_objects.workflow import WFStage, WFType
 from darwin.future.meta.client import MetaClient
 from darwin.future.meta.objects.stage import StageMeta
 from darwin.future.tests.core.fixtures import *
+from darwin.future.tests.core.items.fixtures import *
+from darwin.future.tests.meta.fixtures import *
 
-# TODO: fill out as stage meta gets more functionality
 
-def test_item_ids() -> None:
-    pass
+@fixture
+def uuid_str() -> str:
+    return "00000000-0000-0000-0000-000000000000"
 
-def test_move_attached_files_to_stage() -> None:
-    pass
+@fixture
+def base_WFStage(uuid_str: str) -> WFStage:
+    return WFStage(id=UUID(uuid_str), name="test-stage", type=WFType.ANNOTATE, assignable_users=[],edges=[])
+
+@fixture
+def stage_meta(base_meta_client: MetaClient, base_WFStage: WFStage, workflow_id: UUID) -> StageMeta:
+    return StageMeta(base_meta_client, base_WFStage, {"team_slug": "default-team", "dataset_id": 1337, "workflow_id": workflow_id})
+
+def test_item_ids(base_meta_client: MetaClient, stage_meta: StageMeta, UUIDs_str: List[str], UUIDs: List[UUID]) -> None:
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            rsps.GET,
+            base_meta_client.config.api_endpoint + f"v2/teams/default-team/items/ids?workflow_stage_ids={str(stage_meta.id)}&dataset_ids=1337",
+            json={"item_ids": UUIDs_str},
+            status=200,
+        )
+        item_ids = stage_meta.item_ids
+        assert item_ids == UUIDs
+
+def test_move_attached_files_to_stage(base_meta_client: MetaClient, stage_meta: StageMeta, UUIDs_str: List[str], UUIDs: List[UUID]) -> None:
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            rsps.GET,
+            base_meta_client.config.api_endpoint + f"v2/teams/default-team/items/ids?workflow_stage_ids={str(stage_meta.id)}&dataset_ids=1337",
+            json={"item_ids": UUIDs_str},
+            status=200,
+        )
+        rsps.add(
+            rsps.POST,
+            base_meta_client.config.api_endpoint + "v2/teams/default-team/items/stage",
+            json={"success": UUIDs_str}, 
+            status=200,
+        )
+        stage_meta.move_attached_files_to_stage(stage_meta.id)
+        assert rsps.assert_call_count(base_meta_client.config.api_endpoint + "v2/teams/default-team/items/stage", 1)
+        assert rsps.assert_call_count(base_meta_client.config.api_endpoint + f"v2/teams/default-team/items/ids?workflow_stage_ids={str(stage_meta.id)}&dataset_ids=1337", 1)

--- a/darwin/future/tests/meta/objects/test_stagemeta.py
+++ b/darwin/future/tests/meta/objects/test_stagemeta.py
@@ -7,3 +7,9 @@ from darwin.future.meta.objects.stage import StageMeta
 from darwin.future.tests.core.fixtures import *
 
 # TODO: fill out as stage meta gets more functionality
+
+def test_item_ids() -> None:
+    pass
+
+def test_move_attached_files_to_stage() -> None:
+    pass


### PR DESCRIPTION
# Problem
Don't have any way to move items around workflows in darwin-py at the moment

# Solution
Add in functions to stage items as well as backend core functions to move items

# Changelog
Can move items in workflows, see item's attached to a stage and manage workflows better
