### PR TITLE
Update CLI dataset pull success message

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ And to finally download a release.
 
 ```
 $ darwin dataset pull test:0.1
-Dataset example-team/test:0.1 downloaded at /directory/choosen/at/authentication/time.
+Dataset example-team/test:0.1 downloaded at /directory/choosen/at/authentication/time .
 ```
 
 ---

--- a/darwin/cli_functions.py
+++ b/darwin/cli_functions.py
@@ -444,7 +444,7 @@ def pull_dataset(
             f"only the darwin formats ('json', 'darwin_json_2') are supported for `darwin dataset pull`"
         )
 
-    print(f"Dataset {release.identifier} downloaded at {dataset.local_path}. ")
+    print(f"Dataset {release.identifier} downloaded at {dataset.local_path} .")
 
 
 def split(dataset_slug: str, val_percentage: float, test_percentage: float, seed: int = 0) -> None:

--- a/darwin/dataset/remote_dataset.py
+++ b/darwin/dataset/remote_dataset.py
@@ -334,7 +334,7 @@ class RemoteDataset(ABC):
             if env_max_workers and int(env_max_workers) > 0:
                 max_workers = int(env_max_workers)
 
-            console.print(f"Going to download {str(count)} files to {self.local_images_path.as_posix()}.")
+            console.print(f"Going to download {str(count)} files to {self.local_images_path.as_posix()} .")
             successes, errors = exhaust_generator(
                 progress=progress(), count=count, multi_threaded=multi_threaded, worker_count=max_workers
             )


### PR DESCRIPTION
# Problem
Right now, after you download the dataset via `dataset pull` one of the messages is `Going to download ... files to /Users/..../images.`. 

As is, when you copy this path you also copy the dot in the end, which leads to `/Users/...../images. does not exist.`. This is inconvenient.

# Solution
Separate the path and the dot in the message formatting. 

# Changelog
Improve dataset download message. 
