### PR TITLE
Fix name of ocv package

### DIFF
--- a/darwin/dataset/download_manager.py
+++ b/darwin/dataset/download_manager.py
@@ -569,7 +569,7 @@ def _extract_frames_from_segment(path: Path, manifest: dt.SegmentManifest) -> No
         import cv2  # pylint: disable=import-outside-toplevel
     except ImportError as e:
         raise MissingDependency(
-            "Missing Dependency: OpenCV required for Video Extraction. Install with `pip install darwin\[ocv]`"
+            "Missing Dependency: OpenCV required for Video Extraction. Install with `pip install darwin-py\[ocv]`"
         ) from e
     cap = cv2.VideoCapture(str(path))
 

--- a/darwin/dataset/remote_dataset.py
+++ b/darwin/dataset/remote_dataset.py
@@ -278,12 +278,12 @@ class RemoteDataset(ABC):
                         continue
 
                     if video_frames and any([not slot.frame_urls for slot in annotation.slots]):
-                        # will raise if not installed via pip install darwin[ocv]
+                        # will raise if not installed via pip install darwin-py[ocv]
                         try:
                             import cv2  # pylint: disable=import-outside-toplevel
                         except ImportError as e:
                             raise MissingDependency(
-                                "Missing Dependency: OpenCV required for Video Extraction. Install with `pip install darwin\[ocv]`"
+                                "Missing Dependency: OpenCV required for Video Extraction. Install with `pip install darwin-py\[ocv]`"
                             ) from e
                     filename = Path(annotation.filename).stem
                     if filename in stems:


### PR DESCRIPTION
# Problem

```
> $ darwin dataset pull longvideosnoframes/videos-no-frames-extraction:2 --video-frames                                 
Error: Missing Dependency: OpenCV required for Video Extraction. Install with `pip install darwin[ocv]`
                                                                                                                         
> $ pip install darwin\[ocv\]                                                                                           
ERROR: Could not find a version that satisfies the requirement darwin[ocv] (from versions: none)
ERROR: No matching distribution found for darwin[ocv]
```

# Solution

Rename `darwin[ocv]` -> `darwin-py[ocv]`
