### PR TITLE
[IO-1464] add in unknown parsing for WFTypes

### DIFF
--- a/darwin/future/data_objects/workflow.py
+++ b/darwin/future/data_objects/workflow.py
@@ -87,6 +87,11 @@ class WFType(Enum):
     ARCHIVE = "archive"
     CONSENSUS_TEST = "consensus_test"
     CONSENSUS_ENTRYPOINT = "consensus_entrypoint"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls, value: str) -> "WFType":
+        return WFType.UNKNOWN
 
 
 class WFUser(DefaultDarwin):

--- a/darwin/future/tests/meta/queries/test_stage.py
+++ b/darwin/future/tests/meta/queries/test_stage.py
@@ -35,6 +35,11 @@ def multi_stage_workflow_object(base_single_workflow_object: dict) -> dict:
     return base_single_workflow_object
 
 
+def test_WFTypes_accept_unknonwn() -> None:
+    assert WFType("unknown") == WFType.UNKNOWN
+    assert WFType("test") == WFType.UNKNOWN
+
+
 def test_stage_collects_basic(
     filled_query: StageQuery, base_single_workflow_object: dict, base_workflow_meta: WorkflowMeta
 ) -> None:


### PR DESCRIPTION
# Problem
WFType enum doesn't accept unknown values and this breaks certain testing with older/experimental Workflow types

# Solution
Introduce default parsing that accepts unknown values and casting them to an UNKNOWN enum type

# Changelog
Workflow stage enum no longer breaks on experimental and testing types