### PR TITLE
changed rounding of val and test from int convertion to math.ceil

### DIFF
--- a/darwin/dataset/split_manager.py
+++ b/darwin/dataset/split_manager.py
@@ -1,3 +1,4 @@
+import math
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Set, Tuple
@@ -140,8 +141,8 @@ def split_dataset(
 
     # Compute sizes of each dataset partition
     dataset_size: int = len(annotation_files)
-    val_size: int = int(val_percentage * dataset_size)
-    test_size: int = int(test_percentage * dataset_size)
+    val_size: int = math.ceil(val_percentage * dataset_size)
+    test_size: int = math.ceil(test_percentage * dataset_size)
     train_size: int = dataset_size - val_size - test_size
     split_id = f"{train_size}_{val_size}_{test_size}"
 


### PR DESCRIPTION
# Problem
When using the split_dataset method with small datasets, such as 7 images and a low validation or test split %, we can end up in a situation where we get zero images in the test or val set since we do the rounding by converting to an int. This will cause unnecessary crashing of the code.

```
test_percentage = 0.1
dataset_size = 7

int(dataset_size * test_percentage)
> 0
```

# Solution

By changing the rounding to math.ceil we would not end up in a case where val or test is 0 if not specifically the percentage is set to 0. Making the code more robust.

# Changelog
 - split_dataset Method:
        Problem: Small datasets with low split percentages resulted in zero images for test or validation due to integer rounding.
        Solution: Changed rounding to math.ceil to ensure non-zero splits unless explicitly set to 0%.
