### PR TITLE
[ANN-2419][internal] Make mask annotation's sparse_rle field optional

### DIFF
--- a/darwin/utils/utils.py
+++ b/darwin/utils/utils.py
@@ -769,10 +769,10 @@ def _parse_darwin_mask_annotation(annotation: dict) -> Optional[dt.Annotation]:
     mask: Optional[dt.JSONFreeForm] = annotation.get("mask")
     slot_names: Optional[List[str]] = parse_slot_names(annotation)
 
-    if not id or not name or mask == None or not slot_names:
+    if not id or not name or mask is None or not slot_names:
         raise ValueError("Mask annotation must have an 'id', 'name', 'slot_names' and 'mask' field")
 
-    if ("sparse_rle" in mask) and (mask["sparse_rle"] != None):
+    if ("sparse_rle" in mask) and (mask["sparse_rle"] is not None):
         raise ValueError("Mask annotation field 'sparse_rle' must contain a null value")
 
     new_annotation = dt.Annotation(

--- a/darwin/utils/utils.py
+++ b/darwin/utils/utils.py
@@ -764,19 +764,16 @@ def _parse_darwin_raster_annotation(annotation: dict) -> Optional[dt.Annotation]
 
 
 def _parse_darwin_mask_annotation(annotation: dict) -> Optional[dt.Annotation]:
-    if not annotation.get("mask"):
-        raise ValueError("Mask annotation must have a 'mask' field")
-
     id: Optional[str] = annotation.get("id")
     name: Optional[str] = annotation.get("name")
     mask: Optional[dt.JSONFreeForm] = annotation.get("mask")
     slot_names: Optional[List[str]] = parse_slot_names(annotation)
 
-    if not id or not name or not mask or not slot_names:
+    if not id or not name or mask == None or not slot_names:
         raise ValueError("Mask annotation must have an 'id', 'name', 'slot_names' and 'mask' field")
 
-    if (not "sparse_rle" in mask) or (not mask["sparse_rle"]) == None:
-        raise ValueError("Mask annotation must have a 'sparse_rle' field containing a null value")
+    if ("sparse_rle" in mask) and (mask["sparse_rle"] != None):
+        raise ValueError("Mask annotation field 'sparse_rle' must contain a null value")
 
     new_annotation = dt.Annotation(
         dt.AnnotationClass(name, "mask"),


### PR DESCRIPTION
# Problem
We made sparse_rle field non required and don't save it in the db anymore. Validation in darwin-py must reflect it.

# Solution
Adjust import validation

# Changelog
Make `sparse_rle` field of mask annotations optional during import
