### PR TITLE
Update local datasets to darwin 2.0

### DIFF
--- a/darwin/dataset/local_dataset.py
+++ b/darwin/dataset/local_dataset.py
@@ -102,10 +102,14 @@ class LocalDataset:
                 image_path = images_dir / f"{stem}{ext}"
                 if image_path.exists():
                     images.append(image_path)
-                    break
+                    continue
+                image_path = images_dir / f"{stem}{ext.upper()}"
+                if image_path.exists():
+                    images.append(image_path)
             if len(images) < 1:
                 raise ValueError(f"Annotation ({annotation_path}) does not have a corresponding image")
-            assert len(images) == 1
+            if len(images) > 1:
+                raise ValueError(f"Image ({stem}) is present with multiple extensions. This is forbidden.")
             self.images_path.append(images[0])
             self.annotations_path.append(annotation_path)
 

--- a/darwin/dataset/utils.py
+++ b/darwin/dataset/utils.py
@@ -312,13 +312,13 @@ def get_coco_format_record(
             segmentation = []
 
             for path in paths:
+                if len(path) < 3:  # Discard polygons with less than 3 points
+                    continue
                 px, py = [], []
                 for point in path:
                     px.append(point["x"])
                     py.append(point["y"])
                 poly = [(x, y) for x, y in zip(px, py)]
-                if len(poly) < 3:  # Discard polygons with less than 3 points
-                    continue
                 segmentation.append(list(itertools.chain.from_iterable(poly)))
                 all_px.extend(px)
                 all_py.extend(py)

--- a/darwin/dataset/utils.py
+++ b/darwin/dataset/utils.py
@@ -569,9 +569,9 @@ def compute_max_density(annotations_dir: Path) -> int:
     max_density = 0
     for annotation_path in annotations_dir.glob("**/*.json"):
         annotation_density = 0
-        darwin_json = attempt_decode(annotation_path)
-        for annotation in darwin_json["annotations"]:
-            if "polygon" not in annotation and "complex_polygon" not in annotation:
+        darwin_json = parse_darwin_json(annotation_path)
+        for annotation in darwin_json.annotations:
+            if "path" not in annotation.data and "paths" not in annotation.data:
                 continue
             annotation_density += 1
         if annotation_density > max_density:

--- a/darwin/utils/utils.py
+++ b/darwin/utils/utils.py
@@ -289,7 +289,7 @@ def find_files(
 
     for f in files:
         path = Path(f)
-        if path.is_dir() == True:
+        if path.is_dir() is True:
             found_files.extend(
                 [
                     path_object
@@ -415,7 +415,7 @@ def load_data_from_file(path: Path) -> Tuple[dict, dt.AnnotationFileVersion]:
     return data, version
 
 
-def parse_darwin_json(path: Path, count: Optional[int]) -> Optional[dt.AnnotationFile]:
+def parse_darwin_json(path: Path, count: Optional[int] = None) -> Optional[dt.AnnotationFile]:
     """
     Parses the given JSON file in v7's darwin proprietary format. Works for images, split frame
     videos (treated as images) and playback videos.
@@ -1091,7 +1091,7 @@ def chunk(items: List[Any], size: int) -> Iterator[Any]:
         A chunk of the of the given size.
     """
     for i in range(0, len(items), size):
-        yield items[i : i + size]
+        yield items[i:i + size]
 
 
 def is_unix_like_os() -> bool:

--- a/darwin/utils/utils.py
+++ b/darwin/utils/utils.py
@@ -289,7 +289,7 @@ def find_files(
 
     for f in files:
         path = Path(f)
-        if path.is_dir() is True:
+        if path.is_dir():
             found_files.extend(
                 [
                     path_object


### PR DESCRIPTION
# Problem
`LocalDataset` and other functions that read and parse local files (generally used to train models) do not support Darwin 2.0 format datasets. As it is implemented now, these functions assume datasets are 1.0 so they'll crash when loading a 2.0 dataset due to the mismatch of fields.

# Solution
Standardize the use of the util function `parse_darwin_json` across all these functions, which already abstracts dataset formats and supports both 1.0 and 2.0.

# Changelog
- Support for Darwin 2.0 datasets in `LocalDataset`
- Support for Darwin 2.0 datasets in `get_coco_format_record`
