### PR TITLE
[IO-1565] video capture check

### DIFF
--- a/darwin/dataset/download_manager.py
+++ b/darwin/dataset/download_manager.py
@@ -566,12 +566,12 @@ def _download_and_extract_video_segment(url: str, api_key: str, path: Path, mani
 def _extract_frames_from_segment(path: Path, manifest: dt.SegmentManifest) -> None:
     # import cv2 here to avoid dependency on OpenCV when not needed if not installed as optional extra
     try:
-        import cv2  # pylint: disable=import-outside-toplevel
+        from cv2 import VideoCapture  # pylint: disable=import-outside-toplevel
     except ImportError as e:
         raise MissingDependency(
             "Missing Dependency: OpenCV required for Video Extraction. Install with `pip install darwin-py\[ocv]`"
         ) from e
-    cap = cv2.VideoCapture(str(path))
+    cap = VideoCapture(str(path))
 
     # Read and save frames. Iterates over every frame because frame seeking in OCV is not reliable or guaranteed.
     frames_to_extract = dict([(item.frame, item.visible_frame) for item in manifest.items if item.visibility])

--- a/darwin/dataset/remote_dataset.py
+++ b/darwin/dataset/remote_dataset.py
@@ -280,7 +280,9 @@ class RemoteDataset(ABC):
                     if video_frames and any([not slot.frame_urls for slot in annotation.slots]):
                         # will raise if not installed via pip install darwin-py[ocv]
                         try:
-                            import cv2  # pylint: disable=import-outside-toplevel
+                            from cv2 import (
+                                VideoCapture,  # pylint: disable=import-outside-toplevel
+                            )
                         except ImportError as e:
                             raise MissingDependency(
                                 "Missing Dependency: OpenCV required for Video Extraction. Install with `pip install darwin-py\[ocv]`"


### PR DESCRIPTION
# Problem
CV2 can fail to import videocapture function and fail elsewhere that isn't captured

# Solution
Make sure cv2 and videocapture function are imported

# Changelog
cv2 failed import should now print the right error message if VideoCapture function isn't found
