### PR TITLE
[IO-1586][external] Changes to RemoteDataset.pull() to account for identically named files in different export releases

### DIFF
--- a/darwin/dataset/download_manager.py
+++ b/darwin/dataset/download_manager.py
@@ -104,7 +104,7 @@ def download_all_images_from_annotations(
 
         if not force_replace:
             # Check the planned path for the image against the existing images
-            planned_image_path = images_path / Path(annotation.remote_path.lstrip('/')).resolve().absolute() / Path(annotation.filename)
+            planned_image_path = images_path / Path(annotation.remote_path.lstrip('/\\')).resolve().absolute() / Path(annotation.filename)
             if planned_image_path in existing_images:
                 continue
 

--- a/darwin/dataset/download_manager.py
+++ b/darwin/dataset/download_manager.py
@@ -94,7 +94,7 @@ def download_all_images_from_annotations(
 
     # Verify that there is not already image in the images folder
     unfiltered_files = images_path.rglob(f"*") if use_folders else images_path.glob(f"*")
-    existing_images = [image for image in unfiltered_files if is_image_extension_allowed(image.suffix)]
+    existing_images = {image for image in unfiltered_files if is_image_extension_allowed(image.suffix)}
 
     annotations_to_download_path = []
     for annotation_path in annotations_path.glob(f"*.{annotation_format}"):
@@ -116,6 +116,14 @@ def download_all_images_from_annotations(
             if len(slot.source_files) > 1:
                 force_slots = True
 
+    if remove_extra:
+        # Removes existing images for which there is not corresponding annotation
+        annotations_downloaded_stem = [a.stem for a in annotations_path.glob(f"*.{annotation_format}")]
+        for existing_image in existing_images:
+            if existing_image.stem not in annotations_downloaded_stem:
+                print(f"Removing {existing_image} as there is no corresponding annotation")
+                existing_image.unlink()
+    
     # Create the generator with the partial functions
     download_functions: List = []
     for annotation_path in annotations_to_download_path:

--- a/darwin/dataset/download_manager.py
+++ b/darwin/dataset/download_manager.py
@@ -94,7 +94,7 @@ def download_all_images_from_annotations(
 
     # Verify that there is not already image in the images folder
     unfiltered_files = images_path.rglob(f"*") if use_folders else images_path.glob(f"*")
-    existing_images = {image.stem: image for image in unfiltered_files if is_image_extension_allowed(image.suffix)}
+    existing_images = [image for image in unfiltered_files if is_image_extension_allowed(image.suffix)]
 
     annotations_to_download_path = []
     for annotation_path in annotations_path.glob(f"*.{annotation_format}"):
@@ -103,11 +103,11 @@ def download_all_images_from_annotations(
             continue
 
         if not force_replace:
-            # Check collisions on image filename and json filename on the system
-            if annotation.filename in existing_images:
+            # Check the planned path for the image against the existing images
+            planned_image_path = images_path / Path(annotation.remote_path).relative_to('/') / Path(annotation.filename)
+            if planned_image_path in existing_images:
                 continue
-            if sanitize_filename(annotation_path.stem) in existing_images:
-                continue
+
         annotations_to_download_path.append(annotation_path)
         if len(annotation.slots) > 1:
             force_slots = True
@@ -116,13 +116,6 @@ def download_all_images_from_annotations(
             if len(slot.source_files) > 1:
                 force_slots = True
 
-    if remove_extra:
-        # Removes existing images for which there is not corresponding annotation
-        annotations_downloaded_stem = [a.stem for a in annotations_path.glob(f"*.{annotation_format}")]
-        for existing_image in existing_images.values():
-            if existing_image.stem not in annotations_downloaded_stem:
-                print(f"Removing {existing_image} as there is no corresponding annotation")
-                existing_image.unlink()
     # Create the generator with the partial functions
     download_functions: List = []
     for annotation_path in annotations_to_download_path:

--- a/darwin/dataset/download_manager.py
+++ b/darwin/dataset/download_manager.py
@@ -104,7 +104,7 @@ def download_all_images_from_annotations(
 
         if not force_replace:
             # Check the planned path for the image against the existing images
-            planned_image_path = images_path / Path(annotation.remote_path).relative_to('/') / Path(annotation.filename)
+            planned_image_path = images_path / Path(annotation.remote_path.lstrip('/')).resolve().absolute() / Path(annotation.filename)
             if planned_image_path in existing_images:
                 continue
 

--- a/darwin/dataset/remote_dataset.py
+++ b/darwin/dataset/remote_dataset.py
@@ -43,7 +43,7 @@ from darwin.exceptions import MissingDependency, NotFound, UnsupportedExportForm
 from darwin.exporter.formats.darwin import build_image_annotation
 from darwin.item import DatasetItem
 from darwin.item_sorter import ItemSorter
-from darwin.utils import parse_darwin_json, split_video_annotation, urljoin, is_image_extension_allowed
+from darwin.utils import parse_darwin_json, split_video_annotation, urljoin
 
 if TYPE_CHECKING:
     from darwin.client import Client
@@ -350,22 +350,6 @@ class RemoteDataset(ABC):
                 self.console.print(f"Encountered errors downloading {len(errors)} files")
             for error in errors:
                 self.console.print(f"\t - {error}")
-
-            # Remove images that don't have a corresponding annotation file in the release
-            if remove_extra:
-                annotations_paths = [annotation_path for annotation_path in annotations_dir.glob("*.json")]
-                unfiltered_files = self.local_images_path.rglob(f"*") if use_folders else self.local_images_path.glob(f"*")
-                existing_images = [image for image in unfiltered_files if is_image_extension_allowed(image.suffix)] 
-                local_paths = []
-
-                for annotation_path in annotations_dir.glob(f"*.json"):
-                    annotation = parse_darwin_json(annotation_path, count=0)
-                    local_paths.append(Path(annotation.slots[0].source_files[0]['local_path']))
-
-                for existing_image in existing_images:
-                    if existing_image not in local_paths:
-                        print(f"Removing {existing_image} as there is no corresponding annotation in this release")
-                        existing_image.unlink()
 
             downloaded_file_count = len([f for f in self.local_images_path.rglob("*") if f.is_file() and not f.name.startswith('.')])
 


### PR DESCRIPTION
# Problem
As described in [this](https://github.com/v7labs/darwin-py/issues/603) GitHub issue, pulling two different releases using `RemoteDataset.pull()` passing `with_folders=True` **can** result in missing files from the second release unless `force_replace=True` is passed as well. This is because `pull()` does not download files if the stem of the filename is 
already present anywhere in the `~/.darwin/datasets/{team_slug}/{dataset_slug}/images` folder.

A further breakdown of the cause is available in the Linear ticket [IO-1586
](https://linear.app/v7labs/issue/IO-1586/bug-external-issue-with-sequential-dataset-pull-operations)

# Solution
Instead of checking the stem of existing filenames in the images folder, check the full local filepath of each file against the "planned" local path for each file in the export release. This way, if the "planned" local path already exists, we know that file doesn't need to be downloaded again.

This led to the discovery of an issue with the `remove_extra` flag, the purpose of which is to remove files from the `images` folder that aren't contained within the export release currently being pulled. Similarly to above, it was using filename stems to make decisions about which files should be removed, which meant it couldn't account for situations where a release contained duplicate filenames.

To resolve this, the functionality was moved up a level to `remote_dataset.py` where it has access to build a list of full local filepaths from the complete annotation files. Files in the `images` folder are then compared against this list, and those without a path contained in this list are removed.

# Changelog
Changes to RemoteDataset.pull() to prevent situations where identically named files in different folders could be overwritten when pulling different export releases
