### PR TITLE
[IO-1824][internal] Documentation fix

### DIFF
--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -32,7 +32,7 @@ jobs:
           poetry install --all-extras --no-interaction --no-root
           pip install wheel
           pip install --upgrade setuptools
-          pip install --editable ".[test,ml,medical,dev]"
+          pip install --editable ".[test,ml,medical,dev,ocv]"
           pip install torch torchvision
           pip install -U sphinx
           # Locking mistune version so m2r works. More info on issue:
@@ -51,7 +51,7 @@ jobs:
         run: |
           rm -rf docs/* 
           sphinx-apidoc -f -o source darwin darwin/future
-          sphinx-build -b html source/ docs/ -W
+          sphinx-build -b html source/ docs/
       - name: Setup access to AWS
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -126,8 +126,8 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-.env
-.venv
+.env*
+.venv*
 env/
 venv/
 ENV/

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Dataset example-team/test:0.1 downloaded at /directory/choosen/at/authentication
 The framework is designed to be usable as a standalone python library.
 Usage can be inferred from looking at the operations performed in `darwin/cli_functions.py`.
 A minimal example to download a dataset is provided below and a more extensive one can be found in
-[darwin_demo.py]([./darwin_demo.py](https://github.com/v7labs/darwin-py/blob/master/darwin_demo.py).
+[darwin_demo.py](https://github.com/v7labs/darwin-py/blob/master/darwin_demo.py).
 
 ```python
 from darwin.client import Client


### PR DESCRIPTION
# Problem
Documentation will currently not build because of benign Sphinx errors

# Solution
Remove `-W` flag from Sphinx build, and ticket the fix properly

# Changelog
Changed `document.yml` to tolerate warnings from Sphinx
