### PR TITLE
[IO-1829] Tests refactor and timing changes

### DIFF
--- a/e2e_tests/helpers.py
+++ b/e2e_tests/helpers.py
@@ -3,16 +3,33 @@ import tempfile
 import uuid
 from pathlib import Path
 from subprocess import run
+from time import sleep
 from typing import Generator, Optional, Tuple
 
 import pytest
+from attr import dataclass
+from cv2 import exp
 
 from darwin.exceptions import DarwinException
 from e2e_tests.objects import E2EDataset
 from e2e_tests.setup_tests import create_random_image
 
 
-def run_cli_command(command: str, working_directory: Optional[str] = None, yes: bool = False) -> Tuple[int, str, str]:
+@dataclass
+class CLIResult:
+    """Wrapper for the result of a CLI command after decoding the stdout and stderr."""
+
+    return_code: int
+    stdout: str
+    stderr: str
+
+
+SERVER_WAIT_TIME = 5
+
+
+def run_cli_command(
+    command: str, working_directory: Optional[str] = None, yes: bool = False, server_wait: int = SERVER_WAIT_TIME
+) -> CLIResult:
     """
     Run a CLI command and return the return code, stdout, and stderr.
 
@@ -49,9 +66,42 @@ def run_cli_command(command: str, working_directory: Optional[str] = None, yes: 
             capture_output=True,
             shell=True,
         )
-
+    sleep(server_wait)  # wait for server to catch up
     try:
-        return result.returncode, result.stdout.decode("utf-8"), result.stderr.decode("utf-8")
+        return CLIResult(result.returncode, result.stdout.decode("utf-8"), result.stderr.decode("utf-8"))
     except UnicodeDecodeError:
-        return result.returncode, result.stdout.decode("cp437"), result.stderr.decode("cp437")
+        return CLIResult(result.returncode, result.stdout.decode("cp437"), result.stderr.decode("cp437"))
 
+
+def format_cli_output(result: CLIResult) -> str:
+    return f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}\n"
+
+
+def assert_cli(
+    result: CLIResult,
+    expected_return_code: int = 0,
+    in_stdout: Optional[str] = None,
+    in_stderr: Optional[str] = None,
+    expected_stdout: Optional[str] = None,
+    expected_stderr: Optional[str] = None,
+    inverse: bool = False,
+) -> None:
+    assert result.return_code == expected_return_code, format_cli_output(result)
+    if not inverse:
+        if in_stdout:
+            assert in_stdout in result.stdout, format_cli_output(result)
+        if in_stderr:
+            assert in_stderr in result.stderr, format_cli_output(result)
+        if expected_stdout:
+            assert result.stdout == expected_stdout, format_cli_output(result)
+        if expected_stderr:
+            assert result.stderr == expected_stderr, format_cli_output(result)
+    else:
+        if in_stdout:
+            assert in_stdout not in result.stdout, format_cli_output(result)
+        if in_stderr:
+            assert in_stderr not in result.stderr, format_cli_output(result)
+        if expected_stdout:
+            assert result.stdout != expected_stdout, format_cli_output(result)
+        if expected_stderr:
+            assert result.stderr != expected_stderr, format_cli_output(result)

--- a/e2e_tests/test_darwin.py
+++ b/e2e_tests/test_darwin.py
@@ -9,7 +9,7 @@ from typing import Generator
 
 import pytest
 
-from e2e_tests.helpers import run_cli_command
+from e2e_tests.helpers import SERVER_WAIT_TIME, assert_cli, run_cli_command
 from e2e_tests.objects import ConfigValues, E2EDataset, E2EItem
 from e2e_tests.setup_tests import api_call, create_random_image
 
@@ -19,16 +19,15 @@ def new_dataset() -> E2EDataset:
     """Create a new dataset via darwin cli and return the dataset object, complete with teardown"""
     uuid_str = str(uuid.uuid4())
     new_dataset_name = "test_dataset_" + uuid_str
-    exit_level, std_out, _ = run_cli_command(f"darwin dataset create {new_dataset_name}")
-    assert exit_level == 0
-    id_raw = re.findall(r"datasets[/\\+](\d+)", std_out)
+    result = run_cli_command(f"darwin dataset create {new_dataset_name}")
+    assert_cli(result, 0)
+    id_raw = re.findall(r"datasets[/\\+](\d+)", result.stdout)
     assert id_raw is not None and len(id_raw) == 1
     id = int(id_raw[0])
     teardown_dataset = E2EDataset(id, new_dataset_name, None)
 
     # Add the teardown dataset to the pytest object to ensure it gets deleted when pytest is done
     pytest.datasets.append(teardown_dataset)  # type: ignore
-    sleep(2) # wait for dataset to be created on server
     return teardown_dataset
 
 
@@ -47,11 +46,11 @@ def local_dataset_with_images(local_dataset: E2EDataset) -> E2EDataset:
         local_dataset.add_item(
             E2EItem(
                 name=path.name,
-                id=uuid.uuid4(), # random uuid as only need item for annotation later
+                id=uuid.uuid4(),  # random uuid as only need item for annotation later
                 path=str(path),
                 file_name=path.name,
                 slot_name="",
-                annotations=[]
+                annotations=[],
             )
         )
     return local_dataset
@@ -62,6 +61,7 @@ def basic_annotation(name: str) -> dict:
         annotation = json.load(f)
     annotation["item"]["name"] = name
     return annotation
+
 
 @pytest.fixture
 def local_dataset_with_annotations(local_dataset_with_images: E2EDataset) -> E2EDataset:
@@ -75,6 +75,7 @@ def local_dataset_with_annotations(local_dataset_with_images: E2EDataset) -> E2E
             json.dump(annotation, f)
     return local_dataset_with_images
 
+
 def test_darwin_create(local_dataset: E2EDataset) -> None:
     """
     Test creating a dataset via the darwin cli, heavy lifting performed
@@ -83,6 +84,7 @@ def test_darwin_create(local_dataset: E2EDataset) -> None:
     assert local_dataset.id is not None
     assert local_dataset.name is not None
 
+
 def test_darwin_push(local_dataset_with_images: E2EDataset) -> None:
     """
     Test pushing a dataset via the darwin cli, dataset created via fixture with images added to object
@@ -90,11 +92,11 @@ def test_darwin_push(local_dataset_with_images: E2EDataset) -> None:
     assert local_dataset_with_images.id is not None
     assert local_dataset_with_images.name is not None
     assert local_dataset_with_images.directory is not None
-    sleep(2)
-    exit_level, std_out, std_err = run_cli_command(
+    result = run_cli_command(
         f"darwin dataset push {local_dataset_with_images.name} {local_dataset_with_images.directory}"
     )
-    assert exit_level == 0
+    assert_cli(result, 0)
+
 
 def test_darwin_import(local_dataset_with_annotations: E2EDataset) -> None:
     """
@@ -106,13 +108,12 @@ def test_darwin_import(local_dataset_with_annotations: E2EDataset) -> None:
     result = run_cli_command(
         f"darwin dataset push {local_dataset_with_annotations.name} {local_dataset_with_annotations.directory}"
     )
-    assert result[0] == 0
-    sleep(2)
-    exit_level, std_out, std_err = run_cli_command(
+    assert_cli(result, 0)
+    result = run_cli_command(
         f"darwin dataset import {local_dataset_with_annotations.name} darwin {Path(local_dataset_with_annotations.directory) / 'annotations'}",
-        yes=True
+        yes=True,
     )
-    assert exit_level == 0
+    assert_cli(result, 0)
 
 
 def test_darwin_export(local_dataset_with_annotations: E2EDataset, config_values: ConfigValues) -> None:
@@ -122,41 +123,34 @@ def test_darwin_export(local_dataset_with_annotations: E2EDataset, config_values
     assert local_dataset_with_annotations.id is not None
     assert local_dataset_with_annotations.name is not None
     assert local_dataset_with_annotations.directory is not None
-    exit_level, std_out, std_err = run_cli_command(
+    result = run_cli_command(
         f"darwin dataset push {local_dataset_with_annotations.name} {local_dataset_with_annotations.directory}"
     )
-    assert exit_level == 0
-    sleep(2)
-    exit_level, std_out, std_err = run_cli_command(
+    assert_cli(result, 0)
+    result = run_cli_command(
         f"darwin dataset import {local_dataset_with_annotations.name} darwin {Path(local_dataset_with_annotations.directory) / 'annotations'}",
-        yes=True
+        yes=True,
     )
-    assert exit_level == 0
-    
+    assert_cli(result, 0)
+
     # Get class ids as export either needs a workflow and complete annotations or the class ids
     url = f"{config_values.server}/api/teams/{config_values.team_slug}/annotation_classes?include_tags=true"
-    response = api_call('get', url, None, config_values.api_key)
+    response = api_call("get", url, None, config_values.api_key)
     if not response.ok:
         raise Exception(f"Failed to get annotation classes: {response.text}")
-    classes = response.json()['annotation_classes']
+    classes = response.json()["annotation_classes"]
     class_ids = [c["id"] for c in classes]
     class_str = " ".join([str(c) for c in class_ids])
     # Test darwin export
-    sleep(2)
-    exit_level, std_out, std_err = run_cli_command(
+    result = run_cli_command(
         f"darwin dataset export {local_dataset_with_annotations.name} test_darwin_export --class-ids {class_str}"
     )
-    assert exit_level == 0
-    assert "successfully exported" in std_out, std_out
-    sleep(5)
-    exit_level, std_out, std_err = run_cli_command(
-        f"darwin dataset releases {local_dataset_with_annotations.name}"
-    )
-    assert exit_level == 0
+    assert_cli(result, 0, in_stdout="successfully exported")
+    result = run_cli_command(f"darwin dataset releases {local_dataset_with_annotations.name}")
+    assert_cli(result, 0, in_stdout="No available releases, export one first", inverse=True)
     # Check that a release is there via inverse, the CLI will truncate outputs and pass/fail is not clear
     # if we check for release name
-    assert "No available releases, export one first" not in std_out
+
 
 if __name__ == "__main__":
     pytest.main(["-vv", "-s", __file__])
-

--- a/tests/e2e_test_internals/test_run_cli_command.py
+++ b/tests/e2e_test_internals/test_run_cli_command.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from http import server
 from unittest import mock
 
 import pytest
@@ -9,19 +10,19 @@ from e2e_tests.helpers import run_cli_command
 
 def test_does_not_allow_directory_traversal() -> None:
     with pytest.raises(DarwinException) as excinfo:
-        run_cli_command("darwin --help; ls ..")
+        run_cli_command("darwin --help; ls ..", server_wait=0)
 
         assert excinfo.value == "Cannot pass directory traversal to 'run_cli_command'."
 
     with pytest.raises(DarwinException) as excinfo:
-        run_cli_command("darwin --help", working_directory="/usr/bin/../")
+        run_cli_command("darwin --help", working_directory="/usr/bin/../", server_wait=0)
         assert excinfo.value == "Cannot pass directory traversal to 'run_cli_command'."
 
 
 @mock.patch("e2e_tests.helpers.run")
 def test_passes_working_directory_to_run_cli_command(mock_subprocess_run: mock.Mock) -> None:
     mock_subprocess_run.reset_mock()
-    run_cli_command("darwin --help", "/usr/bin")
+    run_cli_command("darwin --help", "/usr/bin", server_wait=0)
 
     mock_subprocess_run.assert_called_once()
     assert mock_subprocess_run.call_args[0][0] == "darwin --help"
@@ -35,19 +36,19 @@ def test_passes_back_returncode_stdout_and_stderr(mock_subprocess_run: mock.Mock
 
     mock_subprocess_run.return_value = mocked_output
 
-    return_code, std_out, std_err = run_cli_command("darwin --help", "/usr/bin")
+    result = run_cli_command("darwin --help", "/usr/bin", server_wait=0)
 
     mock_subprocess_run.assert_called_once()
 
-    assert return_code == 137
-    assert std_out == "stdout"
-    assert std_err == "stderr"
+    assert result.return_code == 137
+    assert result.stdout == "stdout"
+    assert result.stderr == "stderr"
 
 
 @mock.patch("e2e_tests.helpers.run")
 def test_does_not_pass_working_directory_to_run_cli_command(mock_subprocess_run: mock.Mock) -> None:
     mock_subprocess_run.reset_mock()
-    run_cli_command("darwin --help")
+    run_cli_command("darwin --help", server_wait=0)
 
     mock_subprocess_run.assert_called_once()
     assert mock_subprocess_run.call_args[0][0] == "darwin --help"


### PR DESCRIPTION
# Problem
Timing on e2e tests can cause failures based on whether the server has fully executed the commands before running new code that interacts with those datasets/items

# Solution
- Change the timing between tests
- Add unified approach to delay
- Add unified approach to testing cli results

# Changelog
e2e tests should be less timing based
