### PR TITLE
Intro git hooks for typechecking

### DIFF
--- a/.hooks/typechecking_installer.sh
+++ b/.hooks/typechecking_installer.sh
@@ -22,7 +22,7 @@ HOOK_SCRIPT="#!/bin/bash
 FILES=\$(git diff --diff-filter=MA --name-only master | grep 'darwin/future/.*\.py$')
 RED='\033[0;31m'
 GREEN='\033[0;32m'
-echo Pre-Commit Hook: Typecheck
+echo Typechecking Hook
 echo ----------------------------------------
 echo checking \$FILES
 # Run the linters on each changed file

--- a/.hooks/typechecking_installer.sh
+++ b/.hooks/typechecking_installer.sh
@@ -54,7 +54,7 @@ if [ \$MYPY_FAILED -eq 1 ]; then
     echo -e \"${RED}Mypy failed.\"
 fi
 if [ \$BLACK_FAILED -eq 0 ] && [ \$RUFF_FAILED -eq 0 ] && [ \$MYPY_FAILED -eq 0 ]; then
-    echo -e \"${GREEN}All linters passed.\"
+    echo -e \"${GREEN}All checks passed.\"
 fi
 "
 

--- a/.hooks/typechecking_installer.sh
+++ b/.hooks/typechecking_installer.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# Usage
+# To install the typechecking linters, simply run the script in your terminal:
+
+# sh
+# This will install the linters and set up the pre-commit hook to run them on each changed Python file.
+# -o, --post-commit, -p, --pre-commit, default -p
+
+# Requirements
+# This script requires the following tools to be installed:
+
+# Git
+# Black
+# Ruff
+# Mypy
+# Make sure these tools are installed and available in your system's PATH before running the script.
+
+# Define the hook script
+HOOK_SCRIPT="#!/bin/bash
+# Get the list of changed Python files
+FILES=\$(git diff --name-only HEAD | grep '\.py$')
+
+# Run the linters on each changed file
+for FILE in \$FILES
+do
+    black \$FILE
+    ruff \$FILE
+    mypy \$FILE
+done
+"
+
+# Define the hook name
+HOOK_NAME="linters"
+
+# Define the hook directory
+HOOK_DIR="$(git rev-parse --show-toplevel)/.git/hooks"
+
+# Define the hook file names
+PRE_COMMIT_FILE="$HOOK_DIR/pre-commit"
+POST_COMMIT_FILE="$HOOK_DIR/post-commit"
+
+# Define the hook file names with the hook name
+PRE_COMMIT_HOOK_FILE="$HOOK_DIR/pre-commit-$HOOK_NAME"
+POST_COMMIT_HOOK_FILE="$HOOK_DIR/post-commit-$HOOK_NAME"
+
+# Define the default hook file name
+DEFAULT_HOOK_FILE="$POST_COMMIT_FILE"
+
+# Define the default hook type
+DEFAULT_HOOK_TYPE="post-commit"
+
+# Parse the command line arguments
+while [[ $# -gt 0 ]]
+do
+    key="$1"
+
+    case $key in
+        -p|--pre-commit)
+        DEFAULT_HOOK_FILE="$PRE_COMMIT_FILE"
+        DEFAULT_HOOK_TYPE="pre-commit"
+        shift
+        ;;
+        -o|--post-commit)
+        DEFAULT_HOOK_FILE="$POST_COMMIT_FILE"
+        DEFAULT_HOOK_TYPE="post-commit"
+        shift
+        ;;
+        *)
+        echo "Unknown option: $key"
+        exit 1
+        ;;
+    esac
+done
+
+# Create the hook file
+echo "$HOOK_SCRIPT" > "$PRE_COMMIT_HOOK_FILE"
+echo "$HOOK_SCRIPT" > "$POST_COMMIT_HOOK_FILE"
+
+# Make the hook file executable
+chmod +x "$PRE_COMMIT_HOOK_FILE"
+chmod +x "$POST_COMMIT_HOOK_FILE"
+
+# Install the hook file
+if [ -f "$DEFAULT_HOOK_FILE" ]; then
+    mv "$DEFAULT_HOOK_FILE" "$HOOK_DIR/$DEFAULT_HOOK_TYPE-$(date +%s)-$HOOK_NAME"
+fi
+ln -s "$PRE_COMMIT_HOOK_FILE" "$DEFAULT_HOOK_FILE"

--- a/.hooks/typechecking_installer.sh
+++ b/.hooks/typechecking_installer.sh
@@ -20,6 +20,9 @@
 HOOK_SCRIPT="#!/bin/bash
 # Get the list of changed Python files in the darwin/future folder
 FILES=\$(git diff --diff-filter=MA --name-only master | grep 'darwin/future/.*\.py$')
+if [ -z \"\$FILES\" ]; then
+    exit 0
+fi
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 echo Typechecking Hook
@@ -106,9 +109,3 @@ echo "$HOOK_SCRIPT" > "$DEFAULT_HOOK_FILE"
 
 # Make the hook file executable
 chmod +x "$DEFAULT_HOOK_FILE"
-
-# # Install the hook file
-# if [ -f "$DEFAULT_HOOK_FILE" ]; then
-#     mv "$DEFAULT_HOOK_FILE" "$HOOK_DIR/$DEFAULT_HOOK_TYPE-$(date +%s)-$HOOK_NAME"
-# fi
-# ln -s "$PRE_COMMIT_HOOK_FILE" "$DEFAULT_HOOK_FILE"

--- a/.hooks/typechecking_installer.sh
+++ b/.hooks/typechecking_installer.sh
@@ -20,28 +20,42 @@
 HOOK_SCRIPT="#!/bin/bash
 # Get the list of changed Python files in the darwin/future folder
 FILES=\$(git diff --diff-filter=MA --name-only master | grep 'darwin/future/.*\.py$')
+RED='\033[0;31m'
+GREEN='\033[0;32m'
 echo Pre-Commit Hook: Typecheck
 echo ----------------------------------------
 echo checking \$FILES
 # Run the linters on each changed file
 echo Running Black
 echo ----------------------------------------
-for FILE in \$FILES
-do
-    black \$FILE
-done
+BLACK_FAILED=0
+black --check \$FILES || BLACK_FAILED=1
+
 echo Running Ruff
 echo ----------------------------------------
-for FILE in \$FILES
-do
-    ruff \$FILE
-done
+RUFF_FAILED=0
+ruff check \$FILES || RUFF_FAILED=1
+
 echo Running Mypy
 echo ----------------------------------------
-for FILE in \$FILES
-do
-    mypy \$FILE
-done
+MYPY_FAILED=0
+mypy \$FILES || MYPY_FAILED=1
+
+# Check if any linter failed
+echo Summary
+echo ----------------------------------------
+if [ \$BLACK_FAILED -eq 1 ]; then
+    echo \"${RED}Black failed.\"
+fi
+if [ \$RUFF_FAILED -eq 1 ]; then
+    echo \"${RED}Ruff failed.\"
+fi
+if [ \$MYPY_FAILED -eq 1 ]; then
+    echo \"${RED}Mypy failed.\"
+fi
+if [ \$BLACK_FAILED -eq 0 ] && [ \$RUFF_FAILED -eq 0 ] && [ \$MYPY_FAILED -eq 0 ]; then
+    echo \"${GREEN}All linters passed.\"
+fi
 "
 
 # Define the hook name

--- a/.hooks/typechecking_installer.sh
+++ b/.hooks/typechecking_installer.sh
@@ -45,16 +45,16 @@ mypy \$FILES || MYPY_FAILED=1
 echo Summary
 echo ----------------------------------------
 if [ \$BLACK_FAILED -eq 1 ]; then
-    echo -e \"${RED}Black failed.\"
+    echo -e \"\${RED}Black failed.\"
 fi
 if [ \$RUFF_FAILED -eq 1 ]; then
-    echo -e \"${RED}Ruff failed.\"
+    echo -e \"\${RED}Ruff failed.\"
 fi
 if [ \$MYPY_FAILED -eq 1 ]; then
-    echo -e \"${RED}Mypy failed.\"
+    echo -e \"\${RED}Mypy failed.\"
 fi
 if [ \$BLACK_FAILED -eq 0 ] && [ \$RUFF_FAILED -eq 0 ] && [ \$MYPY_FAILED -eq 0 ]; then
-    echo -e \"${GREEN}All checks passed.\"
+    echo -e \"\${GREEN}All checks passed.\"
 fi
 "
 

--- a/.hooks/typechecking_installer.sh
+++ b/.hooks/typechecking_installer.sh
@@ -26,23 +26,23 @@ echo Pre-Commit Hook: Typecheck
 echo ----------------------------------------
 echo checking \$FILES
 # Run the linters on each changed file
-echo Running Black
+echo -e '\nRunning Black'
 echo ----------------------------------------
 BLACK_FAILED=0
 black --check \$FILES || BLACK_FAILED=1
 
-echo Running Ruff
+echo -e '\nRunning Ruff'
 echo ----------------------------------------
 RUFF_FAILED=0
 ruff check \$FILES || RUFF_FAILED=1
 
-echo Running Mypy
+echo -e '\nRunning Mypy'
 echo ----------------------------------------
 MYPY_FAILED=0
 mypy \$FILES || MYPY_FAILED=1
 
 # Check if any linter failed
-echo \nSummary
+echo Summary
 echo ----------------------------------------
 if [ \$BLACK_FAILED -eq 1 ]; then
     echo -e \"${RED}Black failed.\"

--- a/.hooks/typechecking_installer.sh
+++ b/.hooks/typechecking_installer.sh
@@ -26,17 +26,17 @@ echo Pre-Commit Hook: Typecheck
 echo ----------------------------------------
 echo checking \$FILES
 # Run the linters on each changed file
-echo \nRunning Black
+echo Running Black
 echo ----------------------------------------
 BLACK_FAILED=0
 black --check \$FILES || BLACK_FAILED=1
 
-echo \nRunning Ruff
+echo Running Ruff
 echo ----------------------------------------
 RUFF_FAILED=0
 ruff check \$FILES || RUFF_FAILED=1
 
-echo \nRunning Mypy
+echo Running Mypy
 echo ----------------------------------------
 MYPY_FAILED=0
 mypy \$FILES || MYPY_FAILED=1
@@ -45,16 +45,16 @@ mypy \$FILES || MYPY_FAILED=1
 echo \nSummary
 echo ----------------------------------------
 if [ \$BLACK_FAILED -eq 1 ]; then
-    echo \"${RED}Black failed.\"
+    echo -e \"${RED}Black failed.\"
 fi
 if [ \$RUFF_FAILED -eq 1 ]; then
-    echo \"${RED}Ruff failed.\"
+    echo -e \"${RED}Ruff failed.\"
 fi
 if [ \$MYPY_FAILED -eq 1 ]; then
-    echo \"${RED}Mypy failed.\"
+    echo -e \"${RED}Mypy failed.\"
 fi
 if [ \$BLACK_FAILED -eq 0 ] && [ \$RUFF_FAILED -eq 0 ] && [ \$MYPY_FAILED -eq 0 ]; then
-    echo \"${GREEN}All linters passed.\"
+    echo -e \"${GREEN}All linters passed.\"
 fi
 "
 

--- a/.hooks/typechecking_installer.sh
+++ b/.hooks/typechecking_installer.sh
@@ -19,7 +19,9 @@
 # Define the hook script
 HOOK_SCRIPT="#!/bin/bash
 # Get the list of changed Python files in the darwin/future folder
-FILES=\$(git diff --name-only HEAD | grep 'darwin/future/.*\.py$')
+FILES=\$(git diff --diff-filter=MA --name-only master | grep 'darwin/future/.*\.py$')
+echo Pre-Commit Hook: Typecheck
+echo ----------------------------------------
 echo checking \$FILES
 # Run the linters on each changed file
 for FILE in \$FILES

--- a/.hooks/typechecking_installer.sh
+++ b/.hooks/typechecking_installer.sh
@@ -24,10 +24,22 @@ echo Pre-Commit Hook: Typecheck
 echo ----------------------------------------
 echo checking \$FILES
 # Run the linters on each changed file
+echo Running Black
+echo ----------------------------------------
 for FILE in \$FILES
 do
     black \$FILE
+done
+echo Running Ruff
+echo ----------------------------------------
+for FILE in \$FILES
+do
     ruff \$FILE
+done
+echo Running Mypy
+echo ----------------------------------------
+for FILE in \$FILES
+do
     mypy \$FILE
 done
 "

--- a/.hooks/typechecking_installer.sh
+++ b/.hooks/typechecking_installer.sh
@@ -26,23 +26,23 @@ echo Pre-Commit Hook: Typecheck
 echo ----------------------------------------
 echo checking \$FILES
 # Run the linters on each changed file
-echo Running Black
+echo \nRunning Black
 echo ----------------------------------------
 BLACK_FAILED=0
 black --check \$FILES || BLACK_FAILED=1
 
-echo Running Ruff
+echo \nRunning Ruff
 echo ----------------------------------------
 RUFF_FAILED=0
 ruff check \$FILES || RUFF_FAILED=1
 
-echo Running Mypy
+echo \nRunning Mypy
 echo ----------------------------------------
 MYPY_FAILED=0
 mypy \$FILES || MYPY_FAILED=1
 
 # Check if any linter failed
-echo Summary
+echo \nSummary
 echo ----------------------------------------
 if [ \$BLACK_FAILED -eq 1 ]; then
     echo \"${RED}Black failed.\"

--- a/.hooks/typechecking_installer.sh
+++ b/.hooks/typechecking_installer.sh
@@ -5,7 +5,7 @@
 
 # sh
 # This will install the linters and set up the pre-commit hook to run them on each changed Python file.
-# -o, --post-commit, -p, --pre-commit, default -p
+# -o, --post-commit, -p, --pre-commit, default -o post commit install
 
 # Requirements
 # This script requires the following tools to be installed:

--- a/.hooks/typechecking_installer.sh
+++ b/.hooks/typechecking_installer.sh
@@ -20,7 +20,7 @@
 HOOK_SCRIPT="#!/bin/bash
 # Get the list of changed Python files in the darwin/future folder
 FILES=\$(git diff --name-only HEAD | grep 'darwin/future/.*\.py$')
-
+echo checking \$FILES
 # Run the linters on each changed file
 for FILE in \$FILES
 do
@@ -74,12 +74,10 @@ do
 done
 
 # Create the hook file
-echo "$HOOK_SCRIPT" > "$PRE_COMMIT_HOOK_FILE"
-echo "$HOOK_SCRIPT" > "$POST_COMMIT_HOOK_FILE"
+echo "$HOOK_SCRIPT" > "$DEFAULT_HOOK_FILE"
 
 # Make the hook file executable
-chmod +x "$PRE_COMMIT_HOOK_FILE"
-chmod +x "$POST_COMMIT_HOOK_FILE"
+chmod +x "$DEFAULT_HOOK_FILE"
 
 # # Install the hook file
 # if [ -f "$DEFAULT_HOOK_FILE" ]; then

--- a/.hooks/typechecking_installer.sh
+++ b/.hooks/typechecking_installer.sh
@@ -18,8 +18,8 @@
 
 # Define the hook script
 HOOK_SCRIPT="#!/bin/bash
-# Get the list of changed Python files
-FILES=\$(git diff --name-only HEAD | grep '\.py$')
+# Get the list of changed Python files in the darwin/future folder
+FILES=\$(git diff --name-only HEAD | grep 'darwin/future/.*\.py$')
 
 # Run the linters on each changed file
 for FILE in \$FILES
@@ -41,8 +41,8 @@ PRE_COMMIT_FILE="$HOOK_DIR/pre-commit"
 POST_COMMIT_FILE="$HOOK_DIR/post-commit"
 
 # Define the hook file names with the hook name
-PRE_COMMIT_HOOK_FILE="$HOOK_DIR/pre-commit-$HOOK_NAME"
-POST_COMMIT_HOOK_FILE="$HOOK_DIR/post-commit-$HOOK_NAME"
+PRE_COMMIT_HOOK_FILE="$HOOK_DIR/pre-commit"
+POST_COMMIT_HOOK_FILE="$HOOK_DIR/post-commit"
 
 # Define the default hook file name
 DEFAULT_HOOK_FILE="$POST_COMMIT_FILE"
@@ -81,8 +81,8 @@ echo "$HOOK_SCRIPT" > "$POST_COMMIT_HOOK_FILE"
 chmod +x "$PRE_COMMIT_HOOK_FILE"
 chmod +x "$POST_COMMIT_HOOK_FILE"
 
-# Install the hook file
-if [ -f "$DEFAULT_HOOK_FILE" ]; then
-    mv "$DEFAULT_HOOK_FILE" "$HOOK_DIR/$DEFAULT_HOOK_TYPE-$(date +%s)-$HOOK_NAME"
-fi
-ln -s "$PRE_COMMIT_HOOK_FILE" "$DEFAULT_HOOK_FILE"
+# # Install the hook file
+# if [ -f "$DEFAULT_HOOK_FILE" ]; then
+#     mv "$DEFAULT_HOOK_FILE" "$HOOK_DIR/$DEFAULT_HOOK_TYPE-$(date +%s)-$HOOK_NAME"
+# fi
+# ln -s "$PRE_COMMIT_HOOK_FILE" "$DEFAULT_HOOK_FILE"

--- a/darwin/future/core/items/move_items.py
+++ b/darwin/future/core/items/move_items.py
@@ -31,7 +31,7 @@ def move_items_to_stage(
 
     Returns
     -------
-    None
+    JSONType
     """
 
     return api_client.post(

--- a/darwin/future/meta/objects/base.py
+++ b/darwin/future/meta/objects/base.py
@@ -13,11 +13,9 @@ class MetaBase(Generic[R]):
     _element: R
     client: ClientCore
 
-    def __init__(
-        self, client: ClientCore, element: R, meta_params: Optional[Param] = None
-    ) -> None:
+    def __init__(self, client: ClientCore, element: R, meta_params: Optional[Param] = None) -> None:
         self.client = client
-        self._element = element
+        self._element = R
         self.meta_params = meta_params or {}
 
     def __str__(self) -> str:

--- a/darwin/future/meta/objects/base.py
+++ b/darwin/future/meta/objects/base.py
@@ -15,7 +15,7 @@ class MetaBase(Generic[R]):
 
     def __init__(self, client: ClientCore, element: R, meta_params: Optional[Param] = None) -> None:
         self.client = client
-        self._element = R
+        self._element = element
         self.meta_params = meta_params or {}
 
     def __str__(self) -> str:

--- a/darwin/future/meta/objects/base.py
+++ b/darwin/future/meta/objects/base.py
@@ -13,7 +13,9 @@ class MetaBase(Generic[R]):
     _element: R
     client: ClientCore
 
-    def __init__(self, client: ClientCore, element: R, meta_params: Optional[Param] = None) -> None:
+    def __init__(
+        self, client: ClientCore, element: R, meta_params: Optional[Param] = None
+    ) -> None:
         self.client = client
         self._element = element
         self.meta_params = meta_params or {}

--- a/darwin/importer/formats/coco.py
+++ b/darwin/importer/formats/coco.py
@@ -7,7 +7,6 @@ import orjson as json
 from upolygon import find_contours, rle_decode
 
 import darwin.datatypes as dt
-from darwin.exceptions import UnrecognizableFileEncoding
 from darwin.path_utils import deconstruct_full_path
 from darwin.utils import attempt_decode
 from darwin.version import __version__


### PR DESCRIPTION
# Problem
We now have linting and typechecking on the darwin-py future code but no non-manual way to ensure this code is up to scratch before creating a PR

# Solution
Add in a typechecking optional pre/post commit hook script
install via `./.hooks/typechecking_installer.sh -o/-p` -o default for post-commit (non-blocking warning) vs -p pre-commit (strictly enforced), 

# Changelog
Optional developer installable git hooks
