### PR TITLE
fixed the siutation when a user pass only a image

### DIFF
--- a/darwin/torch/transforms.py
+++ b/darwin/torch/transforms.py
@@ -332,7 +332,7 @@ class AlbumentationsTransform:
         transformed_data = self.transform(**albu_data)
         image, transformed_annotation = self._post_process(transformed_data, annotation)
 
-        if list(albu_data.keys()) == ["image"]:
+        if len(annotation) < 1:
             return image
 
         return image, transformed_annotation

--- a/darwin/torch/transforms.py
+++ b/darwin/torch/transforms.py
@@ -332,6 +332,9 @@ class AlbumentationsTransform:
         transformed_data = self.transform(**albu_data)
         image, transformed_annotation = self._post_process(transformed_data, annotation)
 
+        if list(albu_data.keys()) == ["image"]:
+            return image
+
         return image, transformed_annotation
 
     def _pre_process(self, image: np.ndarray, annotation: dict) -> dict:

--- a/darwin/torch/transforms.py
+++ b/darwin/torch/transforms.py
@@ -143,7 +143,9 @@ class ColorJitter(transforms.ColorJitter):
     def __call__(
         self, image: PILImage.Image, target: Optional[TargetType] = None
     ) -> Union[PILImage.Image, Tuple[PILImage.Image, TargetType]]:
-        transform = self.get_params(self.brightness, self.contrast, self.saturation, self.hue)
+        transform = self.get_params(
+            self.brightness, self.contrast, self.saturation, self.hue
+        )
         image = transform(image)
         if target is None:
             return image
@@ -198,7 +200,9 @@ class ConvertPolygonsToInstanceMasks(object):
     Converts given polygon to an ``InstanceMask``.
     """
 
-    def __call__(self, image: PILImage.Image, target: TargetType) -> Tuple[PILImage.Image, TargetType]:
+    def __call__(
+        self, image: PILImage.Image, target: TargetType
+    ) -> Tuple[PILImage.Image, TargetType]:
         w, h = image.size
 
         image_id = target["image_id"]
@@ -255,7 +259,9 @@ class ConvertPolygonsToSemanticMask(object):
     Converts given polygon to an ``SemanticMask``.
     """
 
-    def __call__(self, image: PILImage.Image, target: TargetType) -> Tuple[PILImage.Image, TargetType]:
+    def __call__(
+        self, image: PILImage.Image, target: TargetType
+    ) -> Tuple[PILImage.Image, TargetType]:
         w, h = image.size
         image_id = target["image_id"]
         image_id = torch.tensor([image_id])
@@ -282,7 +288,9 @@ class ConvertPolygonToMask(object):
     Converts given polygon to a ``Mask``.
     """
 
-    def __call__(self, image: PILImage.Image, annotation: Dict[str, Any]) -> Tuple[PILImage.Image, PILImage.Image]:
+    def __call__(
+        self, image: PILImage.Image, annotation: Dict[str, Any]
+    ) -> Tuple[PILImage.Image, PILImage.Image]:
         w, h = image.size
         segmentations = [obj["segmentation"] for obj in annotation]
         cats = [obj["category_id"] for obj in annotation]
@@ -368,7 +376,9 @@ class AlbumentationsTransform:
         if bboxes is not None:
             output_annotation["boxes"] = torch.tensor(bboxes)
             if "area" in annotation and "masks" not in albumentation_output:
-                output_annotation["area"] = output_annotation["boxes"][:, 2] * output_annotation["boxes"][:, 3]
+                output_annotation["area"] = (
+                    output_annotation["boxes"][:, 2] * output_annotation["boxes"][:, 3]
+                )
 
         labels = albumentation_output.get("labels")
         if labels is not None:
@@ -381,7 +391,9 @@ class AlbumentationsTransform:
             else:
                 output_annotation["masks"] = torch.stack(masks)
             if "area" in annotation:
-                output_annotation["area"] = torch.sum(output_annotation["masks"], dim=[1, 2])
+                output_annotation["area"] = torch.sum(
+                    output_annotation["masks"], dim=[1, 2]
+                )
 
         # Copy other metadata from original annotation
         for key, value in annotation.items():

--- a/tests/darwin/exporter/formats/export_darwin_1_0_test.py
+++ b/tests/darwin/exporter/formats/export_darwin_1_0_test.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 import darwin.datatypes as dt
 from darwin.exporter.formats.darwin_1_0 import _build_json
 
@@ -56,9 +55,15 @@ class TestBuildJson:
             {"x": 531.6440000000002, "y": 428.4196},
             {"x": 529.8140000000002, "y": 426.5896},
         ]
-
+        bounding_box = {"x": 557.66,
+            "y": 428.98,
+            "w": 160.76,
+            "h": 315.3
+            }
         annotation_class = dt.AnnotationClass(name="test", annotation_type="polygon")
-        annotation = dt.Annotation(annotation_class=annotation_class, data={"path": polygon_path}, subs=[])
+        annotation = dt.Annotation(annotation_class=annotation_class, data={"path": polygon_path, "bounding_box":bounding_box}, subs=[])
+
+
 
         annotation_file = dt.AnnotationFile(
             path=Path("test.json"),


### PR DESCRIPTION
# Problem
One should be able to user the albumentations transform in this way:
```

transform = AlbumentationsTransform(transform_compse())
img_tensor = transform(img)

```

Right now the transform output's a (img, target) tuple even when only an image is passed.

# Solution

Add a check if there is only an image as input, and return only image if that is the case.


# Changelog
- albumentation transform now returns only img and not (img, target) when only an image is present as input
