### PR TITLE
add poetry config file `poetry.toml`

### DIFF
--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -12,14 +12,6 @@ If the command `pyenv` isn't recognized, it hasn't installed to your shell envir
 ## Poetry
 Poetry manages project level dependencies and local python versions. Install instructions [here](https://python-poetry.org/docs/). Make sure to follow the printed instructions and add the path to your shell environment, if running the command `poetry --version` after installation doesn't work, it means your path hasn't been updated
 
-Set 2 config settings for poetry once you have it setup and recognized as a command
-1. Set poetry to use the local version of python, to be used in conjuction with pyenv later
-
-    - `poetry config virtualenvs.prefer-active-python true`
-
-2. Tell poetry to create a local folder copy of python inside .venv directory when it's called to manage a project
-
-    - `poetry config virtualenvs.in-project true` 
 ## New Folder Setup
 To Start from scratch and get a development/QA environemnt setup. This process means you will have a fresh python version with only the dependencies required by darwin-py that is uncorrupted by other packages installed on the system python
 - clone darwin py repo

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,3 @@
+[virtualenvs]
+in-project = true
+prefer-active-python = true


### PR DESCRIPTION
# Problem
Setting up poetry config is a manual process - Instructions here: https://github.com/v7labs/darwin-py/blob/master/docs/DEV.md#poetry

# Solution
Adding poetry configurations in a [Local configuration](https://python-poetry.org/docs/configuration/#local-configuration) file poetry.toml to make our life easier :)

Configuration Docs:
- [virtualenvs.in-project](https://python-poetry.org/docs/configuration/#virtualenvsin-project)
- [virtualenvs.prefer-active-python](https://python-poetry.org/docs/configuration/#virtualenvsprefer-active-python-experimental)

# Changelog
[dev] Move Poetry Configuration to `poetry.toml` 
