### PR TITLE
[IO-1805][external] Core delete item method & tests

### DIFF
--- a/darwin/future/core/client.py
+++ b/darwin/future/core/client.py
@@ -219,10 +219,15 @@ class ClientCore:
         return self._generic_call(self.session.post, endpoint, data)
 
     def delete(
-        self, endpoint: str, query_string: Optional[QueryString] = None
+        self,
+        endpoint: str,
+        query_string: Optional[QueryString] = None,
+        data: Optional[dict] = None,
     ) -> JSONType:
         return self._generic_call(
-            self.session.delete, self._contain_qs_and_endpoint(endpoint, query_string)
+            self.session.delete,
+            self._contain_qs_and_endpoint(endpoint, query_string),
+            data if data is not None else {},
         )
 
     def patch(self, endpoint: str, data: dict) -> JSONType:

--- a/darwin/future/core/items/delete_items.py
+++ b/darwin/future/core/items/delete_items.py
@@ -1,0 +1,44 @@
+from typing import Dict, List
+from uuid import UUID
+
+from darwin.future.core.client import ClientCore
+from darwin.future.core.types.common import JSONType
+from darwin.future.data_objects.typing import UnknownType
+
+
+def delete_list_of_items(
+    api_client: ClientCore,
+    team_slug: str,
+    dataset_id: int,
+    item_ids: List[UUID],
+    filters: Dict[str, UnknownType] = {},
+) -> JSONType:
+    """
+    Delete specified items
+
+    Parameters
+    ----------
+    client: Client
+        The client to use for the request
+    team_slug: str
+        The slug of the team containing the items
+    dataset_id: int
+        The ID of the dataset containing the items
+    item_ids: List[UUID]
+        The IDs of the items to be deleted
+    filters: Dict[str, UnknownType]
+        Dataset filter parameters
+
+    Returns
+    -------
+    JSONType
+    """
+    payload = {
+        "filters": {
+            "dataset_ids": [dataset_id],
+            "item_ids": [str(item_id) for item_id in item_ids],
+            **filters,
+        }
+    }
+
+    return api_client.delete(f"/v2/teams/{team_slug}/items", data=payload)

--- a/darwin/future/tests/core/items/test_delete_items.py
+++ b/darwin/future/tests/core/items/test_delete_items.py
@@ -1,0 +1,54 @@
+from unittest.mock import Mock
+from uuid import UUID
+
+import pytest
+import responses
+
+from darwin.exceptions import DarwinException
+from darwin.future.core.client import ClientCore
+from darwin.future.core.items.delete_items import delete_list_of_items
+from darwin.future.tests.core.fixtures import *
+
+
+@responses.activate
+def test_delete_items_including_filters(base_client: ClientCore) -> None:
+    # Define the expected response
+    responses.add(
+        responses.DELETE,
+        base_client.config.api_endpoint + "v2/teams/test-team/items",
+        json={"affected_item_count": 2},
+    )
+
+    # Call the function
+    response = delete_list_of_items(
+        api_client=base_client,
+        team_slug="test-team",
+        dataset_id=000000,
+        item_ids=[
+            UUID("00000000-0000-0000-0000-000000000000"),
+            UUID("00000000-0000-0000-0000-000000000000"),
+        ],
+        filters={
+            "not_statuses": ["uploading", "annotate"],
+            "not_assignees": [123, 456, 789],
+        },
+    )
+
+    # Check that the response mathces what we expect
+    assert response == {"affected_item_count": 2}
+
+
+def test_delete_items_with_error_response() -> None:
+    api_client = Mock(spec=ClientCore)
+    api_client.delete.side_effect = DarwinException("Something went wrong")
+
+    with pytest.raises(DarwinException):
+        delete_list_of_items(
+            api_client=api_client,
+            team_slug="test-team",
+            dataset_id=000000,
+            item_ids=[
+                UUID("00000000-0000-0000-0000-000000000000"),
+                UUID("00000000-0000-0000-0000-000000000000"),
+            ],
+        )


### PR DESCRIPTION
# Problem
Currently no way to delete items in `darwin.future`

# Solution
Define the core method to delete a list of items by their UUIDs by using the delete endpoint

# Changelog
Added core item delete methods & tests