### PR TITLE
[IO-1802][external] Added core item method to restore items + tests

### DIFF
--- a/darwin/future/core/items/restore_items.py
+++ b/darwin/future/core/items/restore_items.py
@@ -1,0 +1,44 @@
+from typing import Dict, List
+from uuid import UUID
+
+from darwin.future.core.client import ClientCore
+from darwin.future.core.types.common import JSONType
+from darwin.future.data_objects.typing import UnknownType
+
+
+def restore_list_of_items(
+    api_client: ClientCore,
+    team_slug: str,
+    dataset_id: int,
+    item_ids: List[UUID],
+    filters: Dict[str, UnknownType] = {},
+) -> JSONType:
+    """
+    Archive specified items
+
+    Parameters
+    ----------
+    client: Client
+        The client to use for the request
+    team_slug: str
+        The slug of the team containing the items
+    dataset_id: int
+        The ID of the dataset containing the items
+    item_ids: List[UUID]
+        The IDs of the items to be restored
+    filters: Dict[str, UnknownType]
+        Dataset filter parameters
+
+    Returns
+    -------
+    JSONType
+    """
+    payload = {
+        "filters": {
+            "dataset_ids": [dataset_id],
+            "item_ids": [str(item_id) for item_id in item_ids],
+            **filters,
+        }
+    }
+
+    return api_client.post(f"/v2/teams/{team_slug}/items/restore", data=payload)

--- a/darwin/future/core/items/restore_items.py
+++ b/darwin/future/core/items/restore_items.py
@@ -14,7 +14,7 @@ def restore_list_of_items(
     filters: Dict[str, UnknownType] = {},
 ) -> JSONType:
     """
-    Archive specified items
+    Restore specified items
 
     Parameters
     ----------

--- a/darwin/future/tests/core/items/test_restore_items.py
+++ b/darwin/future/tests/core/items/test_restore_items.py
@@ -1,0 +1,54 @@
+from unittest.mock import Mock
+from uuid import UUID
+
+import pytest
+import responses
+
+from darwin.exceptions import DarwinException
+from darwin.future.core.client import ClientCore
+from darwin.future.core.items.restore_items import restore_list_of_items
+from darwin.future.tests.core.fixtures import *
+
+
+@responses.activate
+def test_restore_items_including_filters(base_client: ClientCore) -> None:
+    # Define the expected response
+    responses.add(
+        responses.POST,
+        base_client.config.api_endpoint + "v2/teams/test-team/items/restore",
+        json={"affected_item_count": 2},
+    )
+
+    # Call the function
+    response = restore_list_of_items(
+        api_client=base_client,
+        team_slug="test-team",
+        dataset_id=000000,
+        item_ids=[
+            UUID("00000000-0000-0000-0000-000000000000"),
+            UUID("00000000-0000-0000-0000-000000000000"),
+        ],
+        filters={
+            "not_statuses": ["uploading", "annotate"],
+            "not_assignees": [123, 456, 789],
+        },
+    )
+
+    # Check that the response mathces what we expect
+    assert response == {"affected_item_count": 2}
+
+
+def test_restore_items_with_error_response() -> None:
+    api_client = Mock(spec=ClientCore)
+    api_client.post.side_effect = DarwinException("Something went wrong")
+
+    with pytest.raises(DarwinException):
+        restore_list_of_items(
+            api_client=api_client,
+            team_slug="test-team",
+            dataset_id=000000,
+            item_ids=[
+                UUID("00000000-0000-0000-0000-000000000000"),
+                UUID("00000000-0000-0000-0000-000000000000"),
+            ],
+        )


### PR DESCRIPTION
# Problem
Currently no way to restore items in `darwin.future`

# Solution
Define the core method to restore a list of items by their UUIDs by using the restore endpoint

# Changelog
Added core item restore method & tests