### PR TITLE
[IO-1746] Introduction of Pagination queries and changes to item_ids endpoint

### DIFF
--- a/darwin/future/core/client.py
+++ b/darwin/future/core/client.py
@@ -135,7 +135,11 @@ class ClientCore:
     team: Team, team to make requests to
     """
 
-    def __init__(self, config: DarwinConfig, retries: Optional[Retry] = None) -> None:
+    def __init__(
+        self,
+        config: DarwinConfig = DarwinConfig.local(),
+        retries: Optional[Retry] = None,
+    ) -> None:
         self.config = config
         self.session = requests.Session()
         if not retries:

--- a/darwin/future/core/client.py
+++ b/darwin/future/core/client.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Callable, Dict, Optional, overload
+from typing import Callable, Dict, Optional
 from urllib.parse import urlparse
 
 import requests
@@ -165,21 +165,6 @@ class ClientCore:
         if self.config.api_key:
             http_headers["Authorization"] = f"ApiKey {self.config.api_key}"
         return http_headers
-
-    @overload
-    def _generic_call(
-        self, method: Callable[[str], requests.Response], endpoint: str
-    ) -> dict:
-        ...
-
-    @overload
-    def _generic_call(
-        self,
-        method: Callable[[str, dict], requests.Response],
-        endpoint: str,
-        payload: dict,
-    ) -> dict:
-        ...
 
     def _generic_call(
         self, method: Callable, endpoint: str, payload: Optional[dict] = None

--- a/darwin/future/core/client.py
+++ b/darwin/future/core/client.py
@@ -227,7 +227,7 @@ class ClientCore:
         return self._generic_call(
             self.session.delete,
             self._contain_qs_and_endpoint(endpoint, query_string),
-            data if data is not None else {},
+            data,
         )
 
     def patch(self, endpoint: str, data: dict) -> JSONType:

--- a/darwin/future/core/items/get.py
+++ b/darwin/future/core/items/get.py
@@ -9,7 +9,10 @@ from darwin.future.data_objects.item import Folder, Item
 
 
 def get_item_ids(
-    api_client: ClientCore, team_slug: str, dataset_id: Union[str, int], params: QueryString = QueryString({})
+    api_client: ClientCore,
+    team_slug: str,
+    dataset_id: Union[str, int],
+    params: QueryString = QueryString({}),
 ) -> List[UUID]:
     """
     Returns a list of item ids for the dataset
@@ -34,7 +37,8 @@ def get_item_ids(
             {
                 "dataset_ids": str(dataset_id),
             }
-        ) + params,
+        )
+        + params,
     )
     assert isinstance(response, dict)
     uuids = [UUID(uuid) for uuid in response["item_ids"]]

--- a/darwin/future/core/items/get.py
+++ b/darwin/future/core/items/get.py
@@ -9,7 +9,7 @@ from darwin.future.data_objects.item import Folder, Item
 
 
 def get_item_ids(
-    api_client: ClientCore, team_slug: str, dataset_id: Union[str, int]
+    api_client: ClientCore, team_slug: str, dataset_id: Union[str, int], params: QueryString = QueryString({})
 ) -> List[UUID]:
     """
     Returns a list of item ids for the dataset
@@ -28,16 +28,13 @@ def get_item_ids(
     List[UUID]
         A list of item ids
     """
-
     response = api_client.get(
-        f"/v2/teams/{team_slug}/items/ids",
+        f"/v2/teams/{team_slug}/items/list_ids",
         QueryString(
             {
-                "not_statuses": "archived,error",
-                "sort[id]": "desc",
                 "dataset_ids": str(dataset_id),
             }
-        ),
+        ) + params,
     )
     assert isinstance(response, dict)
     uuids = [UUID(uuid) for uuid in response["item_ids"]]

--- a/darwin/future/core/types/common.py
+++ b/darwin/future/core/types/common.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Union
 
-from darwin.future.core.types.query import Query, QueryFilter
 from darwin.future.data_objects import validators as darwin_validators
 from darwin.future.data_objects.typing import UnknownType
 
@@ -76,9 +75,6 @@ class QueryString:
 
     value: Dict[str, str]
 
-    def from_filter(self, filter: QueryFilter) -> QueryString:
-        return QueryString({filter.name: filter.param}) 
-
     def dict_check(self, value: UnknownType) -> Dict[str, str]:
         assert isinstance(value, dict)
         assert all(isinstance(k, str) and isinstance(v, str) for k, v in value.items())
@@ -89,6 +85,6 @@ class QueryString:
 
     def __str__(self) -> str:
         return "?" + "&".join(f"{k}={v}" for k, v in self.value.items())
-    
+
     def __add__(self, other: QueryString) -> QueryString:
         return QueryString({**self.value, **other.value})

--- a/darwin/future/core/types/common.py
+++ b/darwin/future/core/types/common.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Dict, List, Union
 
 from darwin.future.data_objects import validators as darwin_validators
@@ -83,3 +85,6 @@ class QueryString:
 
     def __str__(self) -> str:
         return "?" + "&".join(f"{k}={v}" for k, v in self.value.items())
+    
+    def __add__(self, other: QueryString) -> QueryString:
+        return QueryString({**self.value, **other.value})

--- a/darwin/future/core/types/common.py
+++ b/darwin/future/core/types/common.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Union
 
+from darwin.future.core.types.query import Query, QueryFilter
 from darwin.future.data_objects import validators as darwin_validators
 from darwin.future.data_objects.typing import UnknownType
 
@@ -74,6 +75,9 @@ class QueryString:
     """
 
     value: Dict[str, str]
+
+    def from_filter(self, filter: QueryFilter) -> QueryString:
+        return QueryString({filter.name: filter.param}) 
 
     def dict_check(self, value: UnknownType) -> Dict[str, str]:
         assert isinstance(value, dict)

--- a/darwin/future/core/types/query.py
+++ b/darwin/future/core/types/query.py
@@ -29,8 +29,9 @@ class Modifier(Enum):
 
 
 class QueryFilter(DefaultDarwin):
-    """Basic query filter with a name and a parameter
-
+    """
+    Basic query filter with a name and a parameter
+    Modifiers are for client side filtering only, and are not passed to the API
     Attributes
     ----------
     name: str
@@ -104,6 +105,7 @@ class QueryFilter(DefaultDarwin):
             modifier = None
         return QueryFilter(name=key, param=value, modifier=modifier)
 
+    
 
 class Query(Generic[T], ABC):
     """

--- a/darwin/future/core/types/query.py
+++ b/darwin/future/core/types/query.py
@@ -319,5 +319,5 @@ class PaginatedQuery(Query[T]):
 
     def __len__(self) -> int:
         if not self.completed:
-            raise QueryNotCompletedError
+            self.collect_all()
         return len(self.results.keys())

--- a/darwin/future/core/types/query.py
+++ b/darwin/future/core/types/query.py
@@ -10,6 +10,7 @@ from darwin.future.exceptions import (
     InvalidQueryFilter,
     InvalidQueryModifier,
     MoreThanOneResultFound,
+    QueryNotCompletedError,
     ResultsNotFound,
 )
 from darwin.future.meta.objects.base import MetaBase
@@ -315,3 +316,8 @@ class PaginatedQuery(Query[T]):
         result = self.results[self.n]
         self.n += 1
         return result
+
+    def __len__(self) -> int:
+        if not self.completed:
+            raise QueryNotCompletedError
+        return len(self.results.keys())

--- a/darwin/future/data_objects/item.py
+++ b/darwin/future/data_objects/item.py
@@ -62,7 +62,7 @@ class ItemSlot(DefaultDarwin):
         return v
 
     @classmethod
-    def validate_fps(cls, values: dict):
+    def validate_fps(cls, values: dict) -> dict:
         value = values.get("fps")
 
         if value is None:

--- a/darwin/future/data_objects/page.py
+++ b/darwin/future/data_objects/page.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Optional
+from uuid import UUID
+
+from darwin.future.core.types.common import QueryString
+from darwin.future.data_objects.pydantic_base import DefaultDarwin
+
+
+class Page(DefaultDarwin):
+    offset: Optional[int] = None
+    size: Optional[int] = None
+    count: Optional[int] = None 
+    next: Optional[UUID] = None
+    previous: Optional[UUID] = None
+
+    @classmethod
+    def default(cls) -> Page:
+        return Page(offset=0, size=500, count=0, next=None, previous=None)
+
+    def to_query_string(self) -> QueryString:
+        """
+        Generate a query string from the page object, some fields are not included if they are None,
+        and certain fields are renamed. Outgoing and incoming query strings are different and require
+        dropping certain fields
+        
+        Returns:
+            QueryString: Outgoing query string
+        """
+        if self.offset is None and self.size is None:
+            return QueryString({})
+        elif self.offset is None:
+            raise ValueError("Offset must be specified if size is specified")
+        elif self.size is None:
+            raise ValueError("Size must be specified if offset is specified")
+        qs_dict = {
+            "page[offset]": str(self.offset),
+            "page[size]": str(self.size)
+        }
+        return QueryString(qs_dict)
+        
+    def increment(self) -> None:
+        """
+        Increment the page offset by the page size
+        """
+        if self.offset is None or self.size is None:
+            self.offset = 0
+            self.size = 500 # Default for darwin api
+            return
+        assert self.size is not None, "Size must be specified if offset is specified"
+        self.offset += self.size

--- a/darwin/future/data_objects/page.py
+++ b/darwin/future/data_objects/page.py
@@ -1,22 +1,42 @@
 from __future__ import annotations
 
+from math import floor
 from typing import Optional
-from uuid import UUID
+
+from pydantic import NonNegativeInt, PositiveInt
 
 from darwin.future.core.types.common import QueryString
 from darwin.future.data_objects.pydantic_base import DefaultDarwin
 
 
+def must_be_positive(v: int) -> int:
+    if v is not None and v < 0:
+        raise ValueError("Value must be positive")
+    return v
+
+
 class Page(DefaultDarwin):
-    offset: Optional[int] = None
-    size: Optional[int] = None
-    count: Optional[int] = None
-    next: Optional[UUID] = None
-    previous: Optional[UUID] = None
+    offset: Optional[NonNegativeInt] = None
+    size: Optional[PositiveInt] = None
+    count: Optional[NonNegativeInt] = None
 
     @classmethod
     def default(cls) -> Page:
-        return Page(offset=0, size=500, count=0, next=None, previous=None)
+        return Page(offset=0, size=500, count=0)
+
+    def get_required_page(self, item_index: int) -> Page:
+        """
+        Get the page that contains the item at the specified index
+
+        Args:
+            item_index (int): The index of the item
+
+        Returns:
+            Page: The page that contains the item
+        """
+        assert self.size is not None
+        required_offset = floor(item_index / self.size)
+        return Page(offset=required_offset, size=self.size)
 
     def to_query_string(self) -> QueryString:
         """

--- a/darwin/future/data_objects/page.py
+++ b/darwin/future/data_objects/page.py
@@ -10,7 +10,7 @@ from darwin.future.data_objects.pydantic_base import DefaultDarwin
 class Page(DefaultDarwin):
     offset: Optional[int] = None
     size: Optional[int] = None
-    count: Optional[int] = None 
+    count: Optional[int] = None
     next: Optional[UUID] = None
     previous: Optional[UUID] = None
 
@@ -23,7 +23,7 @@ class Page(DefaultDarwin):
         Generate a query string from the page object, some fields are not included if they are None,
         and certain fields are renamed. Outgoing and incoming query strings are different and require
         dropping certain fields
-        
+
         Returns:
             QueryString: Outgoing query string
         """
@@ -33,19 +33,16 @@ class Page(DefaultDarwin):
             raise ValueError("Offset must be specified if size is specified")
         elif self.size is None:
             raise ValueError("Size must be specified if offset is specified")
-        qs_dict = {
-            "page[offset]": str(self.offset),
-            "page[size]": str(self.size)
-        }
+        qs_dict = {"page[offset]": str(self.offset), "page[size]": str(self.size)}
         return QueryString(qs_dict)
-        
+
     def increment(self) -> None:
         """
         Increment the page offset by the page size
         """
         if self.offset is None or self.size is None:
             self.offset = 0
-            self.size = 500 # Default for darwin api
+            self.size = 500  # Default for darwin api
             return
         assert self.size is not None, "Size must be specified if offset is specified"
         self.offset += self.size

--- a/darwin/future/data_objects/page.py
+++ b/darwin/future/data_objects/page.py
@@ -29,7 +29,7 @@ class Page(DefaultDarwin):
             Page: The page that contains the item
         """
         assert self.size is not None
-        required_offset = floor(item_index / self.size)
+        required_offset = floor(item_index / self.size) * self.size
         return Page(offset=required_offset, size=self.size)
 
     def to_query_string(self) -> QueryString:

--- a/darwin/future/data_objects/page.py
+++ b/darwin/future/data_objects/page.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from math import floor
-from typing import Optional
 
 from pydantic import NonNegativeInt, PositiveInt
 
@@ -16,13 +15,8 @@ def must_be_positive(v: int) -> int:
 
 
 class Page(DefaultDarwin):
-    offset: Optional[NonNegativeInt] = None
-    size: Optional[PositiveInt] = None
-    count: Optional[NonNegativeInt] = None
-
-    @classmethod
-    def default(cls) -> Page:
-        return Page(offset=0, size=500, count=0)
+    offset: NonNegativeInt = 0
+    size: PositiveInt = 500
 
     def get_required_page(self, item_index: int) -> Page:
         """
@@ -47,12 +41,6 @@ class Page(DefaultDarwin):
         Returns:
             QueryString: Outgoing query string
         """
-        if self.offset is None and self.size is None:
-            return QueryString({})
-        elif self.offset is None:
-            raise ValueError("Offset must be specified if size is specified")
-        elif self.size is None:
-            raise ValueError("Size must be specified if offset is specified")
         qs_dict = {"page[offset]": str(self.offset), "page[size]": str(self.size)}
         return QueryString(qs_dict)
 
@@ -60,9 +48,4 @@ class Page(DefaultDarwin):
         """
         Increment the page offset by the page size
         """
-        if self.offset is None or self.size is None:
-            self.offset = 0
-            self.size = 500  # Default for darwin api
-            return
-        assert self.size is not None, "Size must be specified if offset is specified"
         self.offset += self.size

--- a/darwin/future/exceptions.py
+++ b/darwin/future/exceptions.py
@@ -83,6 +83,11 @@ class DarwinException(Exception):
         return super().__repr__()
 
 
+class QueryNotCompletedError(DarwinException):
+    def __str__(self) -> str:
+        return "This query has not been completely collected and thus it's length is ambigious, to force completion run `.collect_all()` or otherwise collect all results"
+
+
 class ValidationError(DarwinException):
     pass
 

--- a/darwin/future/meta/objects/base.py
+++ b/darwin/future/meta/objects/base.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Dict, Generic, Optional, TypeVar
 
 from darwin.future.core.client import ClientCore
-from darwin.future.pydantic_base import DefaultDarwin
 
 R = TypeVar("R")
 Param = Dict[str, object]

--- a/darwin/future/meta/objects/base.py
+++ b/darwin/future/meta/objects/base.py
@@ -37,7 +37,10 @@ class MetaBase(Generic[R]):
     client: ClientCore
 
     def __init__(
-        self, client: ClientCore, element: R, meta_params: Optional[Param] = None
+        self,
+        element: R,
+        client: ClientCore = ClientCore(),
+        meta_params: Optional[Param] = None,
     ) -> None:
         self.client = client
         self._element = element

--- a/darwin/future/meta/objects/base.py
+++ b/darwin/future/meta/objects/base.py
@@ -5,7 +5,7 @@ from typing import Dict, Generic, Optional, TypeVar
 from darwin.future.core.client import ClientCore
 from darwin.future.pydantic_base import DefaultDarwin
 
-R = TypeVar("R", bound=DefaultDarwin)
+R = TypeVar("R")
 Param = Dict[str, object]
 
 

--- a/darwin/future/meta/objects/dataset.py
+++ b/darwin/future/meta/objects/dataset.py
@@ -71,7 +71,8 @@ class Dataset(MetaBase[DatasetCore]):
         assert self.meta_params["team_slug"] is not None and isinstance(
             self.meta_params["team_slug"], str
         )
-        return ItemIDQuery(self.client, meta_params=self.meta_params)
+        meta_params = {"dataset_ids": self.id, **self.meta_params}
+        return ItemIDQuery(self.client, meta_params=meta_params)
 
     @classmethod
     def create_dataset(cls, client: ClientCore, slug: str) -> DatasetCore:

--- a/darwin/future/meta/objects/dataset.py
+++ b/darwin/future/meta/objects/dataset.py
@@ -1,17 +1,16 @@
 from __future__ import annotations
 
 from typing import List, Optional, Sequence, Union
-from uuid import UUID
 
 from darwin.cli_functions import upload_data
 from darwin.dataset.upload_manager import LocalFile
 from darwin.datatypes import PathLike
 from darwin.future.core.client import ClientCore
 from darwin.future.core.datasets import create_dataset, remove_dataset
-from darwin.future.core.items import get_item_ids
 from darwin.future.data_objects.dataset import DatasetCore
 from darwin.future.helpers.assertion import assert_is
 from darwin.future.meta.objects.base import MetaBase
+from darwin.future.meta.queries.item_id import ItemIDQuery
 
 
 class Dataset(MetaBase[DatasetCore]):
@@ -62,7 +61,7 @@ class Dataset(MetaBase[DatasetCore]):
         return self._element.id
 
     @property
-    def item_ids(self) -> List[UUID]:
+    def item_ids(self) -> ItemIDQuery:
         """Returns a list of item ids for the dataset
 
         Returns:
@@ -72,9 +71,7 @@ class Dataset(MetaBase[DatasetCore]):
         assert self.meta_params["team_slug"] is not None and isinstance(
             self.meta_params["team_slug"], str
         )
-        return get_item_ids(
-            self.client, self.meta_params["team_slug"], str(self._element.id)
-        )
+        return ItemIDQuery(self.client, meta_params=self.meta_params)
 
     @classmethod
     def create_dataset(cls, client: ClientCore, slug: str) -> DatasetCore:

--- a/darwin/future/meta/objects/team.py
+++ b/darwin/future/meta/objects/team.py
@@ -68,7 +68,7 @@ class Team(MetaBase[TeamCore]):
 
     def __init__(self, client: ClientCore, team: Optional[TeamCore] = None) -> None:
         team = team or get_team(client)
-        super().__init__(client, team)
+        super().__init__(client=client, element=team)
 
     @property
     def name(self) -> str:
@@ -172,7 +172,9 @@ class Team(MetaBase[TeamCore]):
 
     def create_dataset(self, slug: str) -> Dataset:
         core = Dataset.create_dataset(self.client, slug)
-        return Dataset(self.client, core, meta_params={"team_slug": self.slug})
+        return Dataset(
+            client=self.client, element=core, meta_params={"team_slug": self.slug}
+        )
 
     def __str__(self) -> str:
         return f"Team\n\

--- a/darwin/future/meta/objects/v7_id.py
+++ b/darwin/future/meta/objects/v7_id.py
@@ -6,6 +6,6 @@ from darwin.future.meta.objects.base import MetaBase
 class V7ID(MetaBase[UUID]):
     def __str__(self) -> str:
         return str(self._element)
-    
+
     def __repr__(self) -> str:
         return str(self)

--- a/darwin/future/meta/objects/v7_id.py
+++ b/darwin/future/meta/objects/v7_id.py
@@ -4,6 +4,10 @@ from darwin.future.meta.objects.base import MetaBase
 
 
 class V7ID(MetaBase[UUID]):
+    @property
+    def id(self) -> UUID:
+        return self._element
+
     def __str__(self) -> str:
         return str(self._element)
 

--- a/darwin/future/meta/objects/v7_id.py
+++ b/darwin/future/meta/objects/v7_id.py
@@ -1,0 +1,11 @@
+from uuid import UUID
+
+from darwin.future.meta.objects.base import MetaBase
+
+
+class V7ID(MetaBase[UUID]):
+    def __str__(self) -> str:
+        return str(self._element)
+    
+    def __repr__(self) -> str:
+        return str(self)

--- a/darwin/future/meta/queries/dataset.py
+++ b/darwin/future/meta/queries/dataset.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List
+from typing import Dict, List
 
 from darwin.future.core.datasets import list_datasets
 from darwin.future.core.types.query import Query, QueryFilter
@@ -18,7 +18,7 @@ class DatasetQuery(Query[Dataset]):
     collect: Executes the query and returns the filtered data
     """
 
-    def _collect(self) -> List[Dataset]:
+    def _collect(self) -> Dict[int, Dataset]:
         datasets, exceptions = list_datasets(self.client)
         if exceptions:
             # TODO: print and or raise exceptions, tbd how we want to handle this
@@ -32,7 +32,7 @@ class DatasetQuery(Query[Dataset]):
         for filter in self.filters:
             datasets_meta = self._execute_filters(datasets_meta, filter)
 
-        return datasets_meta
+        return dict(enumerate(datasets_meta))
 
     def _execute_filters(
         self, datasets: List[Dataset], filter: QueryFilter

--- a/darwin/future/meta/queries/dataset.py
+++ b/darwin/future/meta/queries/dataset.py
@@ -24,7 +24,8 @@ class DatasetQuery(Query[Dataset]):
             # TODO: print and or raise exceptions, tbd how we want to handle this
             pass
         datasets_meta = [
-            Dataset(self.client, dataset, self.meta_params) for dataset in datasets
+            Dataset(client=self.client, element=dataset, meta_params=self.meta_params)
+            for dataset in datasets
         ]
         if not self.filters:
             self.filters = []

--- a/darwin/future/meta/queries/item_id.py
+++ b/darwin/future/meta/queries/item_id.py
@@ -1,7 +1,10 @@
-from typing import List, Optional
+from functools import reduce
+from typing import Dict, List, Optional
 from uuid import UUID
 
 from darwin.future.core.client import ClientCore
+from darwin.future.core.items.get import get_item_ids
+from darwin.future.core.types.common import QueryString
 from darwin.future.core.types.query import Param, Query, QueryFilter
 from darwin.future.data_objects.page import Page
 from darwin.future.meta.objects.v7_id import V7ID
@@ -13,11 +16,25 @@ class ItemIDQuery(Query[V7ID]):
         client: ClientCore,
         filters: Optional[List[QueryFilter]] = None,
         meta_params: Optional[Param] = None,
-        page: Optional[Page] = None,
+        page: Page = Page.default(),
     ):
         super().__init__(client, filters, meta_params)
-        self.page = page or Page.default()
+        self.page = page
         
 
-    def _collect(self) -> List[UUID]:
-        return []
+    def _collect(self) -> Dict[int, UUID]:
+        if "team_slug" not in self.meta_params:
+            raise ValueError("Must specify team_slug to query item ids")
+        if "dataset_id" not in self.meta_params:
+            raise ValueError("Must specify dataset_id to query item ids")
+        assert self.page.offset is not None
+        assert self.page.size is not None
+        team_slug: str = self.meta_params["team_slug"]
+        dataset_id: int = self.meta_params["dataset_id"]
+        params: QueryString = reduce(lambda s1, s2: s1 + s2, [self.page.to_query_string(), *self.filters])
+        uuids = get_item_ids(self.client, team_slug, dataset_id, params)
+        
+        results = {x: uuids[i] for i, x in enumerate(range(self.page.offset, self.page.offset + self.page.size))}
+        self.page.increment()
+        return results
+    

--- a/darwin/future/meta/queries/item_id.py
+++ b/darwin/future/meta/queries/item_id.py
@@ -1,0 +1,23 @@
+from typing import List, Optional
+from uuid import UUID
+
+from darwin.future.core.client import ClientCore
+from darwin.future.core.types.query import Param, Query, QueryFilter
+from darwin.future.data_objects.page import Page
+from darwin.future.meta.objects.v7_id import V7ID
+
+
+class ItemIDQuery(Query[V7ID]):
+    def __init__(
+        self,
+        client: ClientCore,
+        filters: Optional[List[QueryFilter]] = None,
+        meta_params: Optional[Param] = None,
+        page: Optional[Page] = None,
+    ):
+        super().__init__(client, filters, meta_params)
+        self.page = page or Page.default()
+        
+
+    def _collect(self) -> List[UUID]:
+        return []

--- a/darwin/future/meta/queries/item_id.py
+++ b/darwin/future/meta/queries/item_id.py
@@ -4,22 +4,12 @@ from typing import Dict, List, Optional
 from darwin.future.core.client import ClientCore
 from darwin.future.core.items.get import get_item_ids
 from darwin.future.core.types.common import QueryString
-from darwin.future.core.types.query import Param, Query, QueryFilter
+from darwin.future.core.types.query import PaginatedQuery, Param, QueryFilter
 from darwin.future.data_objects.page import Page
 from darwin.future.meta.objects.v7_id import V7ID
 
 
-class ItemIDQuery(Query[V7ID]):
-    def __init__(
-        self,
-        client: ClientCore,
-        filters: Optional[List[QueryFilter]] = None,
-        meta_params: Optional[Param] = None,
-        page: Page = Page.default(),
-    ):
-        super().__init__(client, filters, meta_params)
-        self.page = page
-        self.completed = False
+class ItemIDQuery(PaginatedQuery[V7ID]):
 
     def _collect(self) -> Dict[int, V7ID]:
         if "team_slug" not in self.meta_params:

--- a/darwin/future/meta/queries/item_id.py
+++ b/darwin/future/meta/queries/item_id.py
@@ -32,7 +32,10 @@ class ItemIDQuery(PaginatedQuery[V7ID]):
         uuids = get_item_ids(self.client, team_slug, dataset_ids, params)
 
         results = {
-            i + self.page.offset: V7ID(self.client, uuid, self.meta_params)
+            i
+            + self.page.offset: V7ID(
+                client=self.client, element=uuid, meta_params=self.meta_params
+            )
             for i, uuid in enumerate(uuids)
         }
         return results

--- a/darwin/future/meta/queries/stage.py
+++ b/darwin/future/meta/queries/stage.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List
+from typing import Dict, List
 from uuid import UUID
 
 from darwin.future.core.types.query import Query, QueryFilter
@@ -9,7 +9,7 @@ from darwin.future.meta.objects.stage import Stage
 
 
 class StageQuery(Query[Stage]):
-    def _collect(self) -> List[Stage]:
+    def _collect(self) -> Dict[int, Stage]:
         if "workflow_id" not in self.meta_params:
             raise ValueError("Must specify workflow_id to query stages")
         workflow_id: UUID = self.meta_params["workflow_id"]
@@ -23,7 +23,7 @@ class StageQuery(Query[Stage]):
             self.filters = []
         for filter in self.filters:
             stages = self._execute_filter(stages, filter)
-        return stages
+        return dict(enumerate(stages))
 
     def _execute_filter(self, stages: List[Stage], filter: QueryFilter) -> List[Stage]:
         """Executes filtering on the local list of stages

--- a/darwin/future/meta/queries/stage.py
+++ b/darwin/future/meta/queries/stage.py
@@ -17,7 +17,8 @@ class StageQuery(Query[Stage]):
         workflow = get_workflow(self.client, str(workflow_id))
         assert workflow is not None
         stages = [
-            Stage(self.client, s, meta_params=meta_params) for s in workflow.stages
+            Stage(client=self.client, element=s, meta_params=meta_params)
+            for s in workflow.stages
         ]
         if not self.filters:
             self.filters = []

--- a/darwin/future/meta/queries/team_member.py
+++ b/darwin/future/meta/queries/team_member.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List
+from typing import Dict, List
 
 from darwin.future.core.team.get_team import get_team_members
 from darwin.future.core.types.query import Query, QueryFilter
@@ -16,7 +16,7 @@ class TeamMemberQuery(Query[TeamMember]):
     _execute_filter: Executes a filter on a list of objects
     """
 
-    def _collect(self) -> List[TeamMember]:
+    def _collect(self) -> Dict[int, TeamMember]:
         members, exceptions = get_team_members(self.client)
         members_meta = [TeamMember(self.client, member) for member in members]
         if exceptions:
@@ -27,7 +27,7 @@ class TeamMemberQuery(Query[TeamMember]):
         for filter in self.filters:
             members_meta = self._execute_filter(members_meta, filter)
 
-        return members_meta
+        return dict(enumerate(members_meta))
 
     def _execute_filter(
         self, members: List[TeamMember], filter: QueryFilter

--- a/darwin/future/meta/queries/team_member.py
+++ b/darwin/future/meta/queries/team_member.py
@@ -18,7 +18,9 @@ class TeamMemberQuery(Query[TeamMember]):
 
     def _collect(self) -> Dict[int, TeamMember]:
         members, exceptions = get_team_members(self.client)
-        members_meta = [TeamMember(self.client, member) for member in members]
+        members_meta = [
+            TeamMember(client=self.client, element=member) for member in members
+        ]
         if exceptions:
             # TODO: print and or raise exceptions, tbd how we want to handle this
             pass

--- a/darwin/future/meta/queries/workflow.py
+++ b/darwin/future/meta/queries/workflow.py
@@ -27,7 +27,7 @@ class WorkflowQuery(Query[Workflow]):
             handle_exception(exceptions)
             raise DarwinException from exceptions[0]
         workflows = [
-            Workflow(self.client, workflow, self.meta_params)
+            Workflow(client=self.client, element=workflow, meta_params=self.meta_params)
             for workflow in workflows_core
         ]
         if not self.filters:

--- a/darwin/future/meta/queries/workflow.py
+++ b/darwin/future/meta/queries/workflow.py
@@ -32,7 +32,7 @@ class WorkflowQuery(Query[Workflow]):
         ]
         if not self.filters:
             self.filters = []
-        
+
         for filter in self.filters:
             workflows = self._execute_filters(workflows, filter)
 

--- a/darwin/future/meta/queries/workflow.py
+++ b/darwin/future/meta/queries/workflow.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from typing import List
+from typing import Dict, List
 from uuid import UUID
 
 from darwin.exceptions import DarwinException
@@ -21,7 +21,7 @@ class WorkflowQuery(Query[Workflow]):
     collect: Executes the query and returns the filtered data
     """
 
-    def _collect(self) -> List[Workflow]:
+    def _collect(self) -> Dict[int, Workflow]:
         workflows_core, exceptions = list_workflows(self.client)
         if exceptions:
             handle_exception(exceptions)
@@ -31,12 +31,12 @@ class WorkflowQuery(Query[Workflow]):
             for workflow in workflows_core
         ]
         if not self.filters:
-            return workflows
-
+            self.filters = []
+        
         for filter in self.filters:
             workflows = self._execute_filters(workflows, filter)
 
-        return workflows
+        return dict(enumerate(workflows))
 
     def _execute_filters(
         self, workflows: List[Workflow], filter: QueryFilter

--- a/darwin/future/tests/core/items/test_get_items.py
+++ b/darwin/future/tests/core/items/test_get_items.py
@@ -19,8 +19,8 @@ def test_get_item_ids(
     with responses.RequestsMock() as rsps:
         rsps.add(
             rsps.GET,
-            base_client.config.api_endpoint + "v2/teams/default-team/items/ids"
-            "?not_statuses=archived,error&sort[id]=desc&dataset_ids=1337",
+            base_client.config.api_endpoint + "v2/teams/default-team/items/list_ids"
+            "?dataset_ids=1337",
             json={"item_ids": UUIDs_str},
             status=200,
         )

--- a/darwin/future/tests/core/items/test_set_priority.py
+++ b/darwin/future/tests/core/items/test_set_priority.py
@@ -11,7 +11,7 @@ from darwin.future.tests.core.fixtures import *
 
 
 @responses.activate
-def test_set_item_priority(base_client) -> None:
+def test_set_item_priority(base_client: ClientCore) -> None:
     responses.add(
         responses.POST,
         base_client.config.api_endpoint + "v2/teams/test-team/items/priority",

--- a/darwin/future/tests/core/test_query.py
+++ b/darwin/future/tests/core/test_query.py
@@ -135,7 +135,7 @@ def test_QF_from_asteriks() -> None:
 
 def test_query_first(non_abc_query: Type[Query.Query], base_client: ClientCore) -> None:
     query = non_abc_query(base_client)
-    query.results = [1, 2, 3]
+    query.results = {0: 1, 1: 2, 2: 3}
     first = query.first()
     assert first == 1
 
@@ -144,9 +144,9 @@ def test_query_collect_one(
     non_abc_query: Type[Query.Query], base_client: ClientCore
 ) -> None:
     query = non_abc_query(base_client)
-    query.results = [1, 2, 3]
+    query.results = {0: 1, 1: 2, 2: 3}
     with pytest.raises(MoreThanOneResultFound):
         query.collect_one()
 
-    query.results = [1]
+    query.results = {0: 1}
     assert query.collect_one() == 1

--- a/darwin/future/tests/data_objects/test_page.py
+++ b/darwin/future/tests/data_objects/test_page.py
@@ -1,0 +1,33 @@
+import pytest
+
+from darwin.future.data_objects.page import Page
+
+
+def test_default_page() -> None:
+    page = Page.default()
+    assert page.offset == 0
+    assert page.size == 500
+    assert page.count == 0
+
+
+def test_to_query_string() -> None:
+    page = Page(offset=0, size=10, count=100)
+    qs = page.to_query_string()
+    assert qs.value == {"page[offset]": "0", "page[size]": "10"}
+
+
+def test_increment() -> None:
+    page = Page(offset=0, size=10, count=100)
+    page.increment()
+    assert page.offset == 10
+    assert page.size == 10
+
+
+@pytest.mark.parametrize(
+    "size, index, expected_offset", [(10, 0, 0), (10, 9, 0), (10, 10, 1)]
+)
+def test_get_required_page(size: int, index: int, expected_offset: int) -> None:
+    page = Page(size=size)
+    required_page = page.get_required_page(index)
+    assert required_page.offset == expected_offset
+    assert required_page.size == size

--- a/darwin/future/tests/data_objects/test_page.py
+++ b/darwin/future/tests/data_objects/test_page.py
@@ -4,20 +4,19 @@ from darwin.future.data_objects.page import Page
 
 
 def test_default_page() -> None:
-    page = Page.default()
+    page = Page()
     assert page.offset == 0
     assert page.size == 500
-    assert page.count == 0
 
 
 def test_to_query_string() -> None:
-    page = Page(offset=0, size=10, count=100)
+    page = Page(offset=0, size=10)
     qs = page.to_query_string()
     assert qs.value == {"page[offset]": "0", "page[size]": "10"}
 
 
 def test_increment() -> None:
-    page = Page(offset=0, size=10, count=100)
+    page = Page(offset=0, size=10)
     page.increment()
     assert page.offset == 10
     assert page.size == 10
@@ -27,7 +26,7 @@ def test_increment() -> None:
     "size, index, expected_offset", [(10, 0, 0), (10, 9, 0), (10, 10, 1)]
 )
 def test_get_required_page(size: int, index: int, expected_offset: int) -> None:
-    page = Page(size=size)
+    page = Page(size=size, offset=0)
     required_page = page.get_required_page(index)
     assert required_page.offset == expected_offset
     assert required_page.size == size

--- a/darwin/future/tests/data_objects/test_page.py
+++ b/darwin/future/tests/data_objects/test_page.py
@@ -23,7 +23,7 @@ def test_increment() -> None:
 
 
 @pytest.mark.parametrize(
-    "size, index, expected_offset", [(10, 0, 0), (10, 9, 0), (10, 10, 1)]
+    "size, index, expected_offset", [(10, 0, 0), (10, 9, 0), (10, 10, 10), (10, 11, 10)]
 )
 def test_get_required_page(size: int, index: int, expected_offset: int) -> None:
     page = Page(size=size, offset=0)

--- a/darwin/future/tests/meta/objects/fixtures.py
+++ b/darwin/future/tests/meta/objects/fixtures.py
@@ -21,21 +21,21 @@ def base_UUID() -> UUID:
 
 @fixture
 def base_meta_team(base_client: ClientCore, base_team: TeamCore) -> Team:
-    return Team(base_client, base_team)
+    return Team(client=base_client, team=base_team)
 
 
 @fixture
 def base_meta_workflow(
     base_client: ClientCore, base_workflow: WorkflowCore
 ) -> Workflow:
-    return Workflow(base_client, base_workflow)
+    return Workflow(client=base_client, element=base_workflow)
 
 
 @fixture
 def base_meta_stage(
     base_client: ClientCore, base_stage: WFStageCore, base_UUID: UUID
 ) -> Stage:
-    return Stage(base_client, base_stage)
+    return Stage(client=base_client, element=base_stage)
 
 
 @fixture
@@ -45,4 +45,6 @@ def base_meta_stage_list(base_meta_stage: Stage, base_UUID: UUID) -> List[Stage]
 
 @fixture
 def base_meta_dataset(base_client: ClientCore, base_dataset: DatasetCore) -> Dataset:
-    return Dataset(base_client, base_dataset, meta_params={"team_slug": "test_team"})
+    return Dataset(
+        client=base_client, element=base_dataset, meta_params={"team_slug": "test_team"}
+    )

--- a/darwin/future/tests/meta/objects/test_stagemeta.py
+++ b/darwin/future/tests/meta/objects/test_stagemeta.py
@@ -34,9 +34,13 @@ def stage_meta(
     base_meta_client: Client, base_WFStage: WFStageCore, workflow_id: UUID
 ) -> Stage:
     return Stage(
-        base_meta_client,
-        base_WFStage,
-        {"team_slug": "default-team", "dataset_id": 1337, "workflow_id": workflow_id},
+        client=base_meta_client,
+        element=base_WFStage,
+        meta_params={
+            "team_slug": "default-team",
+            "dataset_id": 1337,
+            "workflow_id": workflow_id,
+        },
     )
 
 
@@ -123,15 +127,15 @@ def test_get_stage_edges(stage_meta: Stage) -> None:
         ),
     ]
     test_stage = Stage(
-        stage_meta.client,
-        WFStageCore(
+        client=stage_meta.client,
+        element=WFStageCore(
             id=UUID("00000000-0000-0000-0000-000000000000"),
             name="test-stage",
             type=WFTypeCore.ANNOTATE,
             assignable_users=[],
             edges=edges,
         ),
-        {
+        meta_params={
             "team_slug": "default-team",
             "dataset_id": 000000,
             "workflow_id": UUID("00000000-0000-0000-0000-000000000000"),

--- a/darwin/future/tests/meta/objects/test_v7_id.py
+++ b/darwin/future/tests/meta/objects/test_v7_id.py
@@ -1,0 +1,17 @@
+from uuid import UUID
+
+
+from darwin.future.meta.objects.v7_id import V7ID
+
+
+def test_v7_id() -> None:
+    # Test creating a V7ID object
+    uuid = UUID("123e4567-e89b-12d3-a456-426655440000")
+    v7_id = V7ID(uuid)
+    assert v7_id.id == uuid
+
+    # Test __str__ method
+    assert str(v7_id) == str(uuid)
+
+    # Test __repr__ method
+    assert repr(v7_id) == str(uuid)

--- a/darwin/future/tests/meta/queries/test_dataset.py
+++ b/darwin/future/tests/meta/queries/test_dataset.py
@@ -13,7 +13,7 @@ def test_dataset_collects_basic(
     with responses.RequestsMock() as rsps:
         endpoint = base_client.config.api_endpoint + "datasets"
         rsps.add(responses.GET, endpoint, json=base_datasets_json)
-        datasets = query._collect()
+        datasets = query._collect().values()
         assert len(datasets) == 2
         assert all(isinstance(dataset, Dataset) for dataset in datasets)
 

--- a/darwin/future/tests/meta/queries/test_stage.py
+++ b/darwin/future/tests/meta/queries/test_stage.py
@@ -94,5 +94,5 @@ def test_stage_filters_WFType(
         stages = filled_query.where({"name": "type", "param": wf_type.value})._collect()
         assert len(stages) == 3
         assert isinstance(stages[0], Stage)
-        for stage in stages:
+        for key, stage in stages.items():
             assert stage._element.type == wf_type

--- a/darwin/future/tests/meta/queries/test_stage.py
+++ b/darwin/future/tests/meta/queries/test_stage.py
@@ -20,7 +20,9 @@ def filled_query(base_client: ClientCore, base_workflow_meta: Workflow) -> Stage
 def base_workflow_meta(
     base_client: ClientCore, base_single_workflow_object: dict
 ) -> Workflow:
-    return Workflow(base_client, WorkflowCore.parse_obj(base_single_workflow_object))
+    return Workflow(
+        client=base_client, element=WorkflowCore.parse_obj(base_single_workflow_object)
+    )
 
 
 @pytest.fixture

--- a/darwin/future/tests/meta/queries/test_team_id.py
+++ b/darwin/future/tests/meta/queries/test_team_id.py
@@ -1,0 +1,83 @@
+from uuid import UUID, uuid4
+
+import responses
+from responses.matchers import query_param_matcher
+
+from darwin.future.core.client import ClientCore
+from darwin.future.data_objects.page import Page
+from darwin.future.meta.objects.v7_id import V7ID
+from darwin.future.meta.queries.item_id import ItemIDQuery
+from darwin.future.tests.core.fixtures import *
+
+
+@pytest.fixture
+def base_ItemIDQuery(base_client: ClientCore) -> ItemIDQuery:
+    return ItemIDQuery(
+        base_client, meta_params={"dataset_id": 0000, "team_slug": "test_team"}
+    )
+
+
+@pytest.fixture
+def list_of_uuids() -> List[UUID]:
+    return [uuid4() for _ in range(10)]
+
+
+def test_pagination_collects_all(
+    base_client: ClientCore, base_ItemIDQuery: ItemIDQuery, list_of_uuids: List[UUID]
+) -> None:
+    base_ItemIDQuery.page = Page(size=5)
+    team_slug = base_ItemIDQuery.meta_params["team_slug"]
+    dataset_id = base_ItemIDQuery.meta_params["dataset_id"]
+    str_ids = [str(uuid) for uuid in list_of_uuids]
+    with responses.RequestsMock() as rsps:
+        endpoint = (
+            base_client.config.api_endpoint + f"v2/teams/{team_slug}/items/list_ids"
+        )
+        rsps.add(
+            responses.GET,
+            endpoint,
+            match=[
+                query_param_matcher(
+                    {
+                        "page[offset]": "0",
+                        "page[size]": "5",
+                        "dataset_ids": str(dataset_id),
+                    }
+                )
+            ],
+            json={"item_ids": [str(uuid) for uuid in str_ids[:5]]},
+        )
+        rsps.add(
+            responses.GET,
+            endpoint,
+            match=[
+                query_param_matcher(
+                    {
+                        "page[offset]": "5",
+                        "page[size]": "5",
+                        "dataset_ids": str(dataset_id),
+                    }
+                )
+            ],
+            json={"item_ids": [str(uuid) for uuid in str_ids[5:]]},
+        )
+        rsps.add(
+            responses.GET,
+            endpoint,
+            match=[
+                query_param_matcher(
+                    {
+                        "page[offset]": "10",
+                        "page[size]": "5",
+                        "dataset_ids": str(dataset_id),
+                    }
+                )
+            ],
+            json={"item_ids": []},
+        )
+
+        ids = base_ItemIDQuery.collect_all()
+        raw_ids = [x.id for x in ids]
+        assert len(rsps.calls) == 3
+        assert len(ids) == 10
+        assert raw_ids == list_of_uuids

--- a/darwin/future/tests/meta/queries/test_team_member.py
+++ b/darwin/future/tests/meta/queries/test_team_member.py
@@ -57,7 +57,7 @@ def test_team_member_filters_role(
         rsps.add(responses.GET, endpoint, json=base_team_members_json)
         members = query._collect()
         assert len(members) == len(TeamMemberRole) - 1
-        for member in members:
+        for member in members.values():
             assert member._element.role != role
 
 

--- a/darwin/future/tests/meta/queries/test_workflow.py
+++ b/darwin/future/tests/meta/queries/test_workflow.py
@@ -30,7 +30,7 @@ def test_workflowquery_collects_basic(
     workflows = query._collect()
 
     assert len(workflows) == 3
-    assert all(isinstance(workflow, Workflow) for workflow in workflows)
+    assert all(isinstance(workflow, Workflow) for workflow in workflows.values())
 
 
 @responses.activate
@@ -84,7 +84,7 @@ def test_workflowquery_filters_inserted_at(
     workflows = query._collect()
 
     assert len(workflows) == 2
-    ids = [str(workflow.id) for workflow in workflows]
+    ids = [str(workflow.id) for workflow in workflows.values()]
     assert WORKFLOW_1 in ids
     assert WORKFLOW_2 in ids
 
@@ -119,7 +119,7 @@ def test_workflowquery_filters_updated_at(
     workflows = query._collect()
 
     assert len(workflows) == 2
-    ids = [str(workflow.id) for workflow in workflows]
+    ids = [str(workflow.id) for workflow in workflows.values()]
     assert WORKFLOW_1 in ids
     assert WORKFLOW_2 in ids
 
@@ -249,7 +249,7 @@ def test_workflowquery_filters_stages_multiple(
     workflows = query._collect()
 
     assert len(workflows) == 2
-    workflow_names = [workflow.name for workflow in workflows]
+    workflow_names = [workflow.name for workflow in workflows.values()]
 
     assert "test-workflow-3" in workflow_names
     assert "test-workflow-1" in workflow_names


### PR DESCRIPTION
# Problem
item ids collection uses an older endpoint, need to swap it over to the newer list_item_ids endpoint, which then needs to filter into changes on the meta objects that implement these. This however necessitates the creation of a solution to pagination on both the Core/Meta levels. 

# Solution
Introduce some major changes to accomodate Pagination, including
- Core data object for keeping track of pages, `darwin.future.data_objects.page.Page` which has defaults that we use on the API
- PaginatedQuery extension, which sets up pagination and changes relevant dunders to allow for pagination
  - paginated objects are lazy loading, iterable and will remember the current page, only collecting when needed
  - includes some new helper functions like collect_all to force total collection
  - still allows for indexing, `PaginatedQuery[76]` will detect the required page to send and collect results if not stored
  - `len(PaginatedQuery)` will collect_all and is something to note behaviour wise, this is a requirement to allow list(PaginatedQuery) to work, otherwise I would have made it Raise on an uncollected object
  - Changes to underlying Query object required to allow mapping, reflected in changes to dunder functions (but not behaviour, which remains the same). Results now stored as a dictionary map of {index: result} indicating the offset location of the item
- V7ID object now a wrapper for UUID
  - Required to interact with Query objects, despite being overkill on UUID list.
  - This approach will allow for other interaction later, like deletion of objects via IDs and any extensions we want to add 
- Anything that uses item_ids prior now uses ItemIDQuery, the first PaginatedQuery object

# Changelog
New Item_ids behaviour and introduction of PaginatedQuery Objects inheritable for default pagination behaviour.