### PR TITLE
[PY-605][external]Added support for folder structures when importing CSV video tags

### DIFF
--- a/darwin/importer/formats/csv_tags_video.py
+++ b/darwin/importer/formats/csv_tags_video.py
@@ -54,7 +54,6 @@ def parse_path(path: Path) -> Optional[List[dt.AnnotationFile]]:
         annotation_classes = set(
             [annotation.annotation_class for annotation in annotations]
         )
-
         filename_path = Path(filename)
         remote_path = str(filename_path.parent)
         if not remote_path.startswith("/"):

--- a/darwin/importer/formats/csv_tags_video.py
+++ b/darwin/importer/formats/csv_tags_video.py
@@ -54,6 +54,8 @@ def parse_path(path: Path) -> Optional[List[dt.AnnotationFile]]:
         annotation_classes = set(
             [annotation.annotation_class for annotation in annotations]
         )
+        remote_path = "/" + "/".join(filename.split("/")[:-1])
+        filename = filename.split("/")[-1]
         files.append(
             dt.AnnotationFile(
                 path,
@@ -61,7 +63,7 @@ def parse_path(path: Path) -> Optional[List[dt.AnnotationFile]]:
                 annotation_classes,
                 annotations,
                 is_video=True,
-                remote_path="/",
+                remote_path=remote_path,
             )
         )
     return files

--- a/darwin/importer/formats/csv_tags_video.py
+++ b/darwin/importer/formats/csv_tags_video.py
@@ -54,7 +54,10 @@ def parse_path(path: Path) -> Optional[List[dt.AnnotationFile]]:
         annotation_classes = set(
             [annotation.annotation_class for annotation in annotations]
         )
-        remote_path = "/" + "/".join(filename.split("/")[:-1])
+        split_filename = filename.split("/")
+        remote_path = "/".join(split_filename[:-1])
+        if not remote_path.startswith("/"):
+            remote_path = "/" + remote_path
         filename = filename.split("/")[-1]
         files.append(
             dt.AnnotationFile(

--- a/darwin/importer/formats/csv_tags_video.py
+++ b/darwin/importer/formats/csv_tags_video.py
@@ -54,11 +54,12 @@ def parse_path(path: Path) -> Optional[List[dt.AnnotationFile]]:
         annotation_classes = set(
             [annotation.annotation_class for annotation in annotations]
         )
-        split_filename = filename.split("/")
-        remote_path = "/".join(split_filename[:-1])
+
+        filename_path = Path(filename)
+        remote_path = str(filename_path.parent)
         if not remote_path.startswith("/"):
             remote_path = "/" + remote_path
-        filename = filename.split("/")[-1]
+        filename = filename_path.name
         files.append(
             dt.AnnotationFile(
                 path,

--- a/darwin/importer/formats/csv_tags_video.py
+++ b/darwin/importer/formats/csv_tags_video.py
@@ -52,7 +52,7 @@ def parse_path(path: Path) -> Optional[List[dt.AnnotationFile]]:
     for filename in file_annotation_map:
         annotations = file_annotation_map[filename]
         annotation_classes = set(
-            [annotation.annotation_class for annotation in annotations]
+            annotation.annotation_class for annotation in annotations
         )
         filename_path = Path(filename)
         remote_path = str(filename_path.parent)


### PR DESCRIPTION
# Problem
Currently, CSV video tag imports assume items are in a flat folder structure, meaning the importer ignores files in folder structures.

# Solution
Added logic to pull out and consider the remote path when importing

# Changelog
Added support for folder structures when importing CSV video tags