### PR TITLE
added instance_id read from coco json if no segmentation

### DIFF
--- a/darwin/importer/formats/coco.py
+++ b/darwin/importer/formats/coco.py
@@ -136,14 +136,22 @@ def parse_annotation(
 
     if len(segmentation) == 0 and len(annotation["bbox"]) == 4:
         x, y, w, h = map(int, annotation["bbox"])
-        return dt.make_bounding_box(category["name"], x, y, w, h)
+        if 'extra' in annotation and 'instance_id' in annotation['extra']:
+            track_id = int(annotation["extra"]["instance_id"])
+            return dt.make_bounding_box(category["name"], x, y, w, h, subs=[dt.make_instance_id(track_id)])
+        else:
+            dt.make_bounding_box(category["name"], x, y, w, h)
     elif (
         len(segmentation) == 0
         and len(annotation["bbox"]) == 1
         and len(annotation["bbox"][0]) == 4
     ):
         x, y, w, h = map(int, annotation["bbox"][0])
-        return dt.make_bounding_box(category["name"], x, y, w, h)
+        if 'extra' in annotation and 'instance_id' in annotation['extra']:
+            track_id = int(annotation["extra"]["instance_id"])
+            return dt.make_bounding_box(category["name"], x, y, w, h, subs=[dt.make_instance_id(track_id)])
+        else:
+            dt.make_bounding_box(category["name"], x, y, w, h)
     elif isinstance(segmentation, dict):
         logger.warn(
             "warning, converting complex coco rle mask to polygon, could take some time"


### PR DESCRIPTION
I added an way to read instance_id from a coco json file only if there's no segmentation. I guess it can be extended to segmentation classes as well.

I tested it and it works, however the visualization of the IDs in the web interface depends on the browser somehow. It's no visible if I open a image to label in firefox under linux. Interestingly, if I use firefox under windows or chrome under linux then I can see the tracking IDs with the bounding boxes. Somehow firefox under linux is not loading them. 

This image is taken from firefox under linux:
![Screenshot from 2023-11-21 21-16-57](https://github.com/v7labs/darwin-py/assets/45577687/99ab4fa9-39db-4bcf-9825-03c7501fb98c)

while this other is from chromium under linux:
![Screenshot from 2023-11-21 21-17-05](https://github.com/v7labs/darwin-py/assets/45577687/66743801-1760-47cf-aea1-89aaa86e65e2)
