### PR TITLE
[PY-627] Long Video support for split video annotations

### DIFF
--- a/darwin/datatypes.py
+++ b/darwin/datatypes.py
@@ -453,6 +453,9 @@ class AnnotationFile:
     # The darwin ID of the item that these annotations belong to.
     item_id: Optional[str] = None
 
+    # The Frame Count if this is a video annotation
+    frame_count: Optional[int] = None
+
     @property
     def full_path(self) -> str:
         """

--- a/darwin/utils/utils.py
+++ b/darwin/utils/utils.py
@@ -999,7 +999,7 @@ def split_video_annotation(annotation: dt.AnnotationFile) -> List[dt.AnnotationF
     if not annotation.frame_count and not annotation.frame_urls:
         raise AttributeError("This Annotation has no frames")
     
-    urls = annotation.frame_urls if annotation.frame_urls else [''] * (annotation.frame_count or 1)
+    urls = annotation.frame_urls if annotation.frame_urls else [None] * (annotation.frame_count or 1)
     frame_annotations = []
     for i, frame_url in enumerate(urls):
         annotations = [

--- a/darwin/utils/utils.py
+++ b/darwin/utils/utils.py
@@ -996,10 +996,12 @@ def split_video_annotation(annotation: dt.AnnotationFile) -> List[dt.AnnotationF
     if not annotation.is_video:
         raise AttributeError("This is not a video annotation")
 
+    # changes here from annotation.frame_urls to annotation.frame_count with frame_urls as backup
+    # due to addition of long videos feature, where frame_urls is no longer available.
+    # frame_count should be available for both, however existing annotations will not have this
     if not annotation.frame_count and not annotation.frame_urls:
         raise AttributeError("This Annotation has no frames")
     urls = annotation.frame_urls or [None] * (annotation.frame_count or 1)
-    )
     frame_annotations = []
     for i, frame_url in enumerate(urls):
         annotations = [

--- a/darwin/utils/utils.py
+++ b/darwin/utils/utils.py
@@ -585,7 +585,7 @@ def _parse_darwin_v2(path: Path, data: Dict[str, Any]) -> dt.AnnotationFile:
             frame_urls=slot.frame_urls,
             remote_path=item["path"],
             slots=slots,
-            frame_count=slot.frame_count
+            frame_count=slot.frame_count,
         )
 
     return annotation_file
@@ -998,8 +998,11 @@ def split_video_annotation(annotation: dt.AnnotationFile) -> List[dt.AnnotationF
 
     if not annotation.frame_count and not annotation.frame_urls:
         raise AttributeError("This Annotation has no frames")
-    
-    urls = annotation.frame_urls if annotation.frame_urls else [None] * (annotation.frame_count or 1)
+    urls = (
+        annotation.frame_urls
+        if annotation.frame_urls
+        else [None] * (annotation.frame_count or 1)
+    )
     frame_annotations = []
     for i, frame_url in enumerate(urls):
         annotations = [

--- a/darwin/utils/utils.py
+++ b/darwin/utils/utils.py
@@ -998,10 +998,7 @@ def split_video_annotation(annotation: dt.AnnotationFile) -> List[dt.AnnotationF
 
     if not annotation.frame_count and not annotation.frame_urls:
         raise AttributeError("This Annotation has no frames")
-    urls = (
-        annotation.frame_urls
-        if annotation.frame_urls
-        else [None] * (annotation.frame_count or 1)
+    urls = annotation.frame_urls or [None] * (annotation.frame_count or 1)
     )
     frame_annotations = []
     for i, frame_url in enumerate(urls):


### PR DESCRIPTION
# Problem
Long videos currently does not get split correctly for formats like coco that require treating each image seperately. 

# Solution
Added in logic for generation of split video annotations if frame_urls is not present, relying instead on frame_count, which is a field to be added in conjunction with changes to slots

# Changelog
split video annotations should now work correctly with long video files
