### PR TITLE
Fix `RecursionError` in `Item` class

### DIFF
--- a/darwin/future/meta/objects/base.py
+++ b/darwin/future/meta/objects/base.py
@@ -48,3 +48,6 @@ class MetaBase(Generic[R]):
 
     def __repr__(self) -> str:
         return str(self)
+
+    def __str__(self) -> str:
+        return f"{self.__class__.__name__}({self._element})"

--- a/darwin/future/meta/objects/item.py
+++ b/darwin/future/meta/objects/item.py
@@ -6,8 +6,8 @@ from uuid import UUID
 from darwin.future.core.items.archive_items import archive_list_of_items
 from darwin.future.core.items.delete_items import delete_list_of_items
 from darwin.future.core.items.move_items_to_folder import move_list_of_items_to_folder
-from darwin.future.core.items.set_item_priority import set_item_priority
 from darwin.future.core.items.restore_items import restore_list_of_items
+from darwin.future.core.items.set_item_priority import set_item_priority
 from darwin.future.data_objects.item import ItemCore, ItemLayout, ItemSlot
 from darwin.future.meta.objects.base import MetaBase
 
@@ -144,3 +144,9 @@ class Item(MetaBase[ItemCore]):
     @property
     def layout(self) -> Optional[ItemLayout]:
         return self._element.layout
+
+    def __str__(self) -> str:
+        return f"Item\n\
+- Item Name: {self._element.name}\n\
+- Item Processing Status: {self._element.processing_status}\n\
+- Item ID: {self._element.id}"


### PR DESCRIPTION
# Problem
Printing the `Item` class raises RecursionError

```python
from darwin.future.meta.client import Client

dataset = client.team.datasets.collect()[-1]
print(dataset.items.where().collect())
```
```console
Traceback (most recent call last):
  File "t4.py", line 15, in <module>
    raise SystemExit(main())
  File "t4.py", line 8, in main
    print(dataset.items.where().collect())
  File "/Users/saurabhchopra/github/v7labs/darwin-py/darwin/future/meta/objects/base.py", line 50, in __repr__
    return str(self)
  File "/Users/saurabhchopra/github/v7labs/darwin-py/darwin/future/meta/objects/base.py", line 50, in __repr__
    return str(self)
  File "/Users/saurabhchopra/github/v7labs/darwin-py/darwin/future/meta/objects/base.py", line 50, in __repr__
    return str(self)
  [Previous line repeated 329 more times]
RecursionError: maximum recursion depth exceeded while getting the str of an object
```

# Solution
Implement the missing `__str__` method in `Item` class, which solves the issue.

# Changelog
Fix `RecursionError` while printing an `Item` class.
