### PR TITLE
`tag`, `untag` an Item / ItemQuery object

### DIFF
--- a/darwin/future/core/items/tag_items.py
+++ b/darwin/future/core/items/tag_items.py
@@ -9,7 +9,7 @@ def tag_items(
     client: ClientCore,
     team_slug: str,
     dataset_ids: int | list[int],
-    tag_id: str,
+    tag_id: int,
     filters: dict[str, UnknownType],
 ) -> JSONType:
     """
@@ -19,7 +19,7 @@ def tag_items(
         client (ClientCore): The Darwin Core client.
         team_slug (str): The team slug.
         dataset_ids (int | list[int]): The dataset ids.
-        tag_id (str): The tag id.
+        tag_id (int): The tag id.
         filters Dict[str, UnknownType]: The parameters of the filter.
 
     Returns:

--- a/darwin/future/core/items/untag_items.py
+++ b/darwin/future/core/items/untag_items.py
@@ -9,7 +9,7 @@ def untag_items(
     client: ClientCore,
     team_slug: str,
     dataset_ids: int | list[int],
-    tag_id: str,
+    tag_id: int,
     filters: dict[str, UnknownType],
 ) -> JSONType:
     """
@@ -19,8 +19,8 @@ def untag_items(
         client (ClientCore): The Darwin Core client.
         team_slug (str): The team slug.
         dataset_ids (int | list[int]): The dataset ids.
-        tag_id (str): The tag id.
-        
+        tag_id (int): The tag id.
+
         filters Dict[str, UnknownType]: The parameters of the filter.
 
     Returns:

--- a/darwin/future/meta/objects/item.py
+++ b/darwin/future/meta/objects/item.py
@@ -11,6 +11,7 @@ from darwin.future.core.items.set_item_priority import set_item_priority
 from darwin.future.core.items.tag_items import tag_items
 from darwin.future.core.items.untag_items import untag_items
 from darwin.future.data_objects.item import ItemCore, ItemLayout, ItemSlot
+from darwin.future.exceptions import BadRequest
 from darwin.future.meta.objects.base import MetaBase
 
 
@@ -107,7 +108,7 @@ class Item(MetaBase[ItemCore]):
         filters = {"item_ids": [str(self.id)]}
         archive_list_of_items(self.client, team_slug, dataset_id, filters)
 
-    def tag(self, tag_id: str) -> None:
+    def tag(self, tag_id: int) -> None:
         team_slug, dataset_id = (
             self.meta_params["team_slug"],
             self.meta_params["dataset_id"]
@@ -115,11 +116,13 @@ class Item(MetaBase[ItemCore]):
             else self.meta_params["dataset_ids"],
         )
         assert isinstance(team_slug, str)
+        if not isinstance(tag_id, int):
+            raise BadRequest(f"tag_id must be an integer, got {type(tag_id)}")
         dataset_id = cast(Union[int, List[int]], dataset_id)
         filters = {"item_ids": [str(self.id)]}
         tag_items(self.client, team_slug, dataset_id, tag_id, filters)
 
-    def untag(self, tag_id: str) -> None:
+    def untag(self, tag_id: int) -> None:
         team_slug, dataset_id = (
             self.meta_params["team_slug"],
             self.meta_params["dataset_id"]
@@ -127,6 +130,8 @@ class Item(MetaBase[ItemCore]):
             else self.meta_params["dataset_ids"],
         )
         assert isinstance(team_slug, str)
+        if not isinstance(tag_id, int):
+            raise BadRequest(f"tag_id must be an integer, got {type(tag_id)}")
         dataset_id = cast(Union[int, List[int]], dataset_id)
         filters = {"item_ids": [str(self.id)]}
         untag_items(self.client, team_slug, dataset_id, tag_id, filters)

--- a/darwin/future/meta/queries/item.py
+++ b/darwin/future/meta/queries/item.py
@@ -11,6 +11,7 @@ from darwin.future.core.items.tag_items import tag_items
 from darwin.future.core.items.untag_items import untag_items
 from darwin.future.core.types.common import QueryString
 from darwin.future.core.types.query import PaginatedQuery
+from darwin.future.exceptions import BadRequest
 from darwin.future.meta.objects.item import Item
 
 
@@ -146,7 +147,7 @@ class ItemQuery(PaginatedQuery[Item]):
         filters = {"item_ids": [str(item) for item in ids]}
         archive_list_of_items(self.client, team_slug, dataset_ids, filters)
 
-    def tag(self, tag_id: str) -> None:
+    def tag(self, tag_id: int) -> None:
         if "team_slug" not in self.meta_params:
             raise ValueError("Must specify team_slug to query items")
         if (
@@ -156,6 +157,8 @@ class ItemQuery(PaginatedQuery[Item]):
             raise ValueError("Must specify dataset_ids to query items")
         if not tag_id:
             raise ValueError("Must specify tag_id to tag items with")
+        if not isinstance(tag_id, int):
+            raise BadRequest(f"tag_id must be an integer, got {type(tag_id)}")
         dataset_ids = (
             self.meta_params["dataset_ids"]
             if "dataset_ids" in self.meta_params
@@ -167,7 +170,7 @@ class ItemQuery(PaginatedQuery[Item]):
         filters = {"item_ids": [str(item) for item in ids]}
         tag_items(self.client, team_slug, dataset_ids, tag_id, filters)
 
-    def untag(self, tag_id: str) -> None:
+    def untag(self, tag_id: int) -> None:
         if "team_slug" not in self.meta_params:
             raise ValueError("Must specify team_slug to query items")
         if (
@@ -177,6 +180,8 @@ class ItemQuery(PaginatedQuery[Item]):
             raise ValueError("Must specify dataset_ids to query items")
         if not tag_id:
             raise ValueError("Must specify tag_id to untag items with")
+        if not isinstance(tag_id, int):
+            raise BadRequest(f"tag_id must be an integer, got {type(tag_id)}")
         dataset_ids = (
             self.meta_params["dataset_ids"]
             if "dataset_ids" in self.meta_params

--- a/darwin/future/tests/core/items/test_tag_items.py
+++ b/darwin/future/tests/core/items/test_tag_items.py
@@ -1,7 +1,9 @@
+import pytest
 import responses
 
 from darwin.future.core.client import ClientCore
 from darwin.future.core.items.tag_items import tag_items
+from darwin.future.exceptions import BadRequest
 from darwin.future.tests.core.fixtures import *
 
 
@@ -9,7 +11,7 @@ from darwin.future.tests.core.fixtures import *
 def test_tag_items(base_client: ClientCore) -> None:
     team_slug = "test-team"
     dataset_ids = [1, 2, 3]
-    tag_id = "123456"
+    tag_id = 123456
     item_ids = [
         "00000000-0000-0000-0000-000000000001",
         "00000000-0000-0000-0000-000000000002",
@@ -32,3 +34,61 @@ def test_tag_items(base_client: ClientCore) -> None:
     )
 
     assert response == {"created_commands": 2}
+
+
+@responses.activate
+def test_tag_items_empty_filters_error(base_client: ClientCore) -> None:
+    team_slug = "test-team"
+    dataset_ids = [1, 2, 3]
+    tag_id = 123456
+    # this should raise an error as no filters are provided
+    filters = {}
+
+    responses.add(
+        responses.POST,
+        base_client.config.api_endpoint + "v2/teams/test-team/items/slots/tags",
+        json={"created_commands": 2},
+        status=200,
+    )
+
+    with pytest.raises(AssertionError) as excinfo:
+        tag_items(
+            client=base_client,
+            team_slug=team_slug,
+            dataset_ids=dataset_ids,
+            tag_id=tag_id,
+            filters=filters,
+        )
+    (msg,) = excinfo.value.args
+    assert (
+        msg
+        == "No parameters provided, please provide at least one non-dataset id filter"
+    )
+
+
+@responses.activate
+def test_tag_items_bad_request_error(base_client: ClientCore) -> None:
+    team_slug = "test-team"
+    dataset_ids = [1, 2, 3]
+    tag_id = "123456"
+    item_ids = [
+        "00000000-0000-0000-0000-000000000001",
+        "00000000-0000-0000-0000-000000000002",
+    ]
+    filters = {"item_ids": item_ids}
+
+    responses.add(
+        responses.POST,
+        base_client.config.api_endpoint + "v2/teams/test-team/items/slots/tags",
+        json={"error": "Bad Request"},
+        status=400,
+    )
+
+    with pytest.raises(BadRequest):
+        tag_items(
+            client=base_client,
+            team_slug=team_slug,
+            dataset_ids=dataset_ids,
+            tag_id=tag_id,
+            filters=filters,
+        )

--- a/darwin/future/tests/core/items/test_untag_items.py
+++ b/darwin/future/tests/core/items/test_untag_items.py
@@ -1,7 +1,9 @@
+import pytest
 import responses
 
 from darwin.future.core.client import ClientCore
 from darwin.future.core.items.untag_items import untag_items
+from darwin.future.exceptions import BadRequest
 from darwin.future.tests.core.fixtures import *
 
 
@@ -9,7 +11,7 @@ from darwin.future.tests.core.fixtures import *
 def test_untag_items(base_client: ClientCore) -> None:
     team_slug = "test-team"
     dataset_ids = [1, 2, 3]
-    tag_id = "123456"
+    tag_id = 123456
     item_ids = [
         "00000000-0000-0000-0000-000000000001",
         "00000000-0000-0000-0000-000000000002",
@@ -32,3 +34,61 @@ def test_untag_items(base_client: ClientCore) -> None:
     )
 
     assert response == {"created_commands": 2}
+
+
+@responses.activate
+def test_untag_items_empty_filters_error(base_client: ClientCore) -> None:
+    team_slug = "test-team"
+    dataset_ids = [1, 2, 3]
+    tag_id = 123456
+    # this should raise an error as no filters are provided
+    filters = {}
+
+    responses.add(
+        responses.DELETE,
+        base_client.config.api_endpoint + "v2/teams/test-team/items/slots/tags",
+        json={"created_commands": 2},
+        status=200,
+    )
+
+    with pytest.raises(AssertionError) as excinfo:
+        untag_items(
+            client=base_client,
+            team_slug=team_slug,
+            dataset_ids=dataset_ids,
+            tag_id=tag_id,
+            filters=filters,
+        )
+        (msg,) = excinfo.value.args
+        assert (
+            msg
+            == "No parameters provided, please provide at least one non-dataset id filter"
+        )
+
+
+@responses.activate
+def test_untag_items_bad_request_error(base_client: ClientCore) -> None:
+    team_slug = "test-team"
+    dataset_ids = [1, 2, 3]
+    tag_id = "123456"
+    item_ids = [
+        "00000000-0000-0000-0000-000000000001",
+        "00000000-0000-0000-0000-000000000002",
+    ]
+    filters = {"item_ids": item_ids}
+
+    responses.add(
+        responses.DELETE,
+        base_client.config.api_endpoint + "v2/teams/test-team/items/slots/tags",
+        json={"error": "Bad Request"},
+        status=400,
+    )
+
+    with pytest.raises(BadRequest):
+        untag_items(
+            client=base_client,
+            team_slug=team_slug,
+            dataset_ids=dataset_ids,
+            tag_id=tag_id,
+            filters=filters,
+        )

--- a/darwin/future/tests/meta/objects/test_itemmeta.py
+++ b/darwin/future/tests/meta/objects/test_itemmeta.py
@@ -232,7 +232,7 @@ def test_tag(item: Item) -> None:
     with responses.RequestsMock() as rsps:
         team_slug = item.meta_params["team_slug"]
         dataset_id = item.meta_params["dataset_id"]
-        tag_id = "123456"
+        tag_id = 123456
         rsps.add(
             rsps.POST,
             item.client.config.api_endpoint + f"v2/teams/{team_slug}/items/slots/tags",
@@ -253,11 +253,20 @@ def test_tag(item: Item) -> None:
         item.tag(tag_id)
 
 
+def test_tag_bad_input(item: Item) -> None:
+    with responses.RequestsMock():
+        tag_id = "123456"
+        with pytest.raises(BadRequest) as excinfo:
+            item.tag(tag_id)
+        (msg,) = excinfo.value.args
+        assert msg == "tag_id must be an integer, got <class 'str'>"
+
+
 def test_untag(item: Item) -> None:
     with responses.RequestsMock() as rsps:
         team_slug = item.meta_params["team_slug"]
         dataset_id = item.meta_params["dataset_id"]
-        tag_id = "123456"
+        tag_id = 123456
         rsps.add(
             rsps.DELETE,
             item.client.config.api_endpoint + f"v2/teams/{team_slug}/items/slots/tags",
@@ -276,3 +285,12 @@ def test_untag(item: Item) -> None:
             json={},
         )
         item.untag(tag_id)
+
+
+def test_untag_bad_input(item: Item) -> None:
+    with responses.RequestsMock():
+        tag_id = "123456"
+        with pytest.raises(BadRequest) as excinfo:
+            item.untag(tag_id)
+        (msg,) = excinfo.value.args
+        assert msg == "tag_id must be an integer, got <class 'str'>"

--- a/darwin/future/tests/meta/queries/test_item.py
+++ b/darwin/future/tests/meta/queries/test_item.py
@@ -295,6 +295,53 @@ def test_archive(
         item_query.archive()
 
 
+def test_tag(item_query: ItemQuery, items_json: List[dict], items: List[Item]) -> None:
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            rsps.GET,
+            item_query.client.config.api_endpoint + "v2/teams/test/items",
+            match=[
+                query_param_matcher(
+                    {"page[offset]": "0", "page[size]": "500", "dataset_ids": "1"}
+                )
+            ],
+            json={"items": items_json, "errors": []},
+        )
+        team_slug = items[0].meta_params["team_slug"]
+        dataset_id = items[0].meta_params["dataset_id"]
+        tag_id = 123456
+        rsps.add(
+            rsps.POST,
+            items[0].client.config.api_endpoint
+            + f"v2/teams/{team_slug}/items/slots/tags",
+            status=200,
+            match=[
+                json_params_matcher(
+                    {
+                        "filters": {
+                            "item_ids": [str(item.id) for item in items],
+                            "dataset_ids": [dataset_id],
+                        },
+                        "annotation_class_id": tag_id,
+                    }
+                )
+            ],
+            json={},
+        )
+        item_query.tag(tag_id)
+
+
+def test_tag_bad_request(
+    item_query: ItemQuery, items_json: List[dict], items: List[Item]
+) -> None:
+    with responses.RequestsMock():
+        tag_id = "123456"
+        with pytest.raises(BadRequest) as excinfo:
+            item_query.tag(tag_id)
+        (msg,) = excinfo.value.args
+        assert msg == "tag_id must be an integer, got <class 'str'>"
+
+
 def test_untag(
     item_query: ItemQuery, items_json: List[dict], items: List[Item]
 ) -> None:
@@ -311,7 +358,7 @@ def test_untag(
         )
         team_slug = items[0].meta_params["team_slug"]
         dataset_id = items[0].meta_params["dataset_id"]
-        tag_id = "123456"
+        tag_id = 123456
         rsps.add(
             rsps.DELETE,
             items[0].client.config.api_endpoint
@@ -333,37 +380,12 @@ def test_untag(
         item_query.untag(tag_id)
 
 
-def test_tag(item_query: ItemQuery, items_json: List[dict], items: List[Item]) -> None:
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            rsps.GET,
-            item_query.client.config.api_endpoint + "v2/teams/test/items",
-            match=[
-                query_param_matcher(
-                    {"page[offset]": "0", "page[size]": "500", "dataset_ids": "1"}
-                )
-            ],
-            json={"items": items_json, "errors": []},
-        )
-        team_slug = items[0].meta_params["team_slug"]
-        dataset_id = items[0].meta_params["dataset_id"]
+def test_untag_bad_request(
+    item_query: ItemQuery, items_json: List[dict], items: List[Item]
+) -> None:
+    with responses.RequestsMock():
         tag_id = "123456"
-        rsps.add(
-            rsps.POST,
-            items[0].client.config.api_endpoint
-            + f"v2/teams/{team_slug}/items/slots/tags",
-            status=200,
-            match=[
-                json_params_matcher(
-                    {
-                        "filters": {
-                            "item_ids": [str(item.id) for item in items],
-                            "dataset_ids": [dataset_id],
-                        },
-                        "annotation_class_id": tag_id,
-                    }
-                )
-            ],
-            json={},
-        )
-        item_query.tag(tag_id)
+        with pytest.raises(BadRequest) as excinfo:
+            item_query.untag(tag_id)
+        (msg,) = excinfo.value.args
+        assert msg == "tag_id must be an integer, got <class 'str'>"


### PR DESCRIPTION
# Problem
Feature request of tagging/untagging an Item

# Solution
Add `tag`, `untag` methods in both `Item` and `ItemQuery` objects.

# Changelog
Ability to tag, untag an Item via `Item` or `ItemQuery` objects.