### PR TITLE
[PY-613] BUG: Unable to export Nifti files without file extension.

### DIFF
--- a/darwin/exporter/formats/nifti.py
+++ b/darwin/exporter/formats/nifti.py
@@ -137,35 +137,56 @@ def check_for_error_and_return_imageid(
     image_id : str
 
     """
-    filename = Path(video_annotation.slots[0].source_files[0]["file_name"])
+    # check if all item slots have the correct file-extension
+    for slot in video_annotation.slots:
+        for source_file in slot.source_files:
+            filename = Path(source_file["file_name"])
+
+            try:
+                suffixes = filename.suffixes[-2:]
+            except IndexError:
+                suffixes = filename.suffixes
+            if len(suffixes) == 2:
+                if suffixes[0] == ".nii" and suffixes[1] == ".gz":
+                    image_id = str(filename).rstrip("".join(suffixes))
+                else:
+                    return create_error_message_json(
+                        "Two suffixes found but not ending in .nii.gz",
+                        output_dir,
+                        str(filename),
+                    )
+            elif len(suffixes) == 1:
+                if suffixes[0] == ".nii" or suffixes[0] == ".dcm":
+                    image_id = filename.stem
+                else:
+                    return create_error_message_json(
+                        "Misconfigured filename, not ending in .nii or .dcm. Are you sure this is medical data?",
+                        output_dir,
+                        str(filename),
+                    )
+            else:
+                return create_error_message_json(
+                    "You are trying to export to nifti. Filename should contain either .nii, .nii.gz or .dcm extension."
+                    "Are you sure this is medical data?",
+                    output_dir,
+                    str(filename),
+                )
+
+    filename = Path(video_annotation.filename)
     try:
         suffixes = filename.suffixes[-2:]
     except IndexError:
         suffixes = filename.suffixes
     if len(suffixes) == 2:
-        if suffixes[0] == ".nii" and suffixes[1] == ".gz":
-            image_id = str(filename).rstrip("".join(suffixes))
-        else:
-            return create_error_message_json(
-                "Two suffixes found but not ending in .nii.gz",
-                output_dir,
-                str(filename),
-            )
+        image_id = str(filename).rstrip("".join(suffixes))
     elif len(suffixes) == 1:
-        if suffixes[0] == ".nii" or suffixes[0] == ".dcm":
-            image_id = filename.stem
-        else:
-            return create_error_message_json(
-                "Misconfigured filename, not ending in .nii or .dcm. Are you sure this is medical data?",
-                output_dir,
-                str(filename),
-            )
+        image_id = str(filename.stem)
     else:
+        image_id = str(filename)
+
+    if video_annotation is None:
         return create_error_message_json(
-            "You are trying to export to nifti. Filename should contain either .nii, .nii.gz or .dcm extension."
-            "Are you sure this is medical data?",
-            output_dir,
-            str(filename),
+            "video_annotation not found", output_dir, image_id
         )
     if video_annotation is None:
         return create_error_message_json(

--- a/darwin/exporter/formats/nifti.py
+++ b/darwin/exporter/formats/nifti.py
@@ -137,8 +137,7 @@ def check_for_error_and_return_imageid(
     image_id : str
 
     """
-
-    filename = Path(video_annotation.filename)
+    filename = Path(video_annotation.slots[0].source_files[0]["file_name"])
     try:
         suffixes = filename.suffixes[-2:]
     except IndexError:


### PR DESCRIPTION
# Problem
Unable to export Nifti files without file extension.

# Solution
This is a bug, which should be performing checks on slot's `file_name`. 
Updated the `filename` checks to work on slot level.

# Changelog
Fix Nifti file export without a file extension.