### PR TITLE
[PY-641][external] Small typing change to stage_id

### DIFF
--- a/darwin/client.py
+++ b/darwin/client.py
@@ -908,7 +908,7 @@ class Client:
         dataset_slug: str,
         team_slug: str,
         filters: Dict[str, UnknownType],
-        stage_id: int,
+        stage_id: str,
     ) -> None:
         """
         Moves the given items to the specified stage
@@ -921,7 +921,7 @@ class Client:
             The slug of the team.
         filters: Dict[str, UnknownType]
             A filter Dictionary that defines the items to have the new, selected stage.
-        stage_id: int
+        stage_id: str
             ID of the stage to set.
         """
         payload: Dict[str, UnknownType] = {


### PR DESCRIPTION
# Problem
`stage_id` was mistakenly typed as `int` in `darwin/client.py`

# Solution
Type as `str`

# Changelog
Small typing fix for `stage_id`
