### PR TITLE
[AI-1486] fix darwin py 0835 bug loading version in videos

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
     "editor.formatOnSave": true,
     "editor.tabSize": 4,
     "editor.codeActionsOnSave": {
-      "source.organizeImports": true,
+      "source.organizeImports": "explicit"
     },
     "editor.defaultFormatter": "ms-python.black-formatter"
   },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
     "editor.formatOnSave": true,
     "editor.tabSize": 4,
     "editor.codeActionsOnSave": {
-      "source.organizeImports": "explicit"
+      "source.organizeImports": true,
     },
     "editor.defaultFormatter": "ms-python.black-formatter"
   },

--- a/darwin/dataset/utils.py
+++ b/darwin/dataset/utils.py
@@ -102,10 +102,7 @@ def extract_classes(
             continue
 
         for annotation in annotation_file.annotations:
-            if (
-                annotation.annotation_class.annotation_type
-                not in annotation_types_to_load
-            ):
+            if annotation.annotation_class.annotation_type not in annotation_types_to_load:
                 continue
 
             class_name = annotation.annotation_class.name
@@ -194,11 +191,7 @@ def get_classes(
         classes_file_path = release_path / f"lists/classes_{atype}.txt"
 
         class_per_annotations = get_classes_from_file(classes_file_path)
-        if (
-            remove_background
-            and class_per_annotations
-            and class_per_annotations[0] == "__background__"
-        ):
+        if remove_background and class_per_annotations and class_per_annotations[0] == "__background__":
             class_per_annotations = class_per_annotations[1:]
 
         for cls in class_per_annotations:
@@ -321,9 +314,7 @@ def get_coco_format_record(
     objs = []
     for obj in data.annotations:
         if annotation_type != obj.annotation_class.annotation_type:
-            if (
-                annotation_type not in obj.data
-            ):  # Allows training object detection with bboxes
+            if annotation_type not in obj.data:  # Allows training object detection with bboxes
                 continue
 
         if annotation_type == "polygon":
@@ -366,9 +357,7 @@ def create_polygon_object(obj, box_mode, classes=None):
         "segmentation": segmentation,
         "bbox": [np.min(all_px), np.min(all_py), np.max(all_px), np.max(all_py)],
         "bbox_mode": box_mode,
-        "category_id": classes.index(obj.annotation_class.name)
-        if classes
-        else obj.annotation_class.name,
+        "category_id": classes.index(obj.annotation_class.name) if classes else obj.annotation_class.name,
         "iscrowd": 0,
     }
 
@@ -380,9 +369,7 @@ def create_bbox_object(obj, box_mode, classes=None):
     new_obj = {
         "bbox": [bbox["x"], bbox["y"], bbox["x"] + bbox["w"], bbox["y"] + bbox["h"]],
         "bbox_mode": box_mode,
-        "category_id": classes.index(obj.annotation_class.name)
-        if classes
-        else obj.annotation_class.name,
+        "category_id": classes.index(obj.annotation_class.name) if classes else obj.annotation_class.name,
         "iscrowd": 0,
     }
 
@@ -459,9 +446,7 @@ def get_annotations(
     )
 
     if partition:
-        stems = _get_stems_from_split(
-            release_path, split, split_type, annotation_type, partition
-        )
+        stems = _get_stems_from_split(release_path, split, split_type, annotation_type, partition)
     else:
         stems = (e.stem for e in annotations_dir.glob("**/*.json"))
 
@@ -469,19 +454,14 @@ def get_annotations(
         images_paths,
         annotations_paths,
         invalid_annotation_paths,
-    ) = _map_annotations_to_images(
-        stems, annotations_dir, images_dir, ignore_inconsistent_examples
-    )
+    ) = _map_annotations_to_images(stems, annotations_dir, images_dir, ignore_inconsistent_examples)
 
     print(f"Found {len(invalid_annotation_paths)} invalid annotations")
     for p in invalid_annotation_paths:
         print(p)
 
     if len(images_paths) == 0:
-        raise ValueError(
-            f"Could not find any {SUPPORTED_EXTENSIONS} file"
-            f" in {dataset_path / 'images'}"
-        )
+        raise ValueError(f"Could not find any {SUPPORTED_EXTENSIONS} file" f" in {dataset_path / 'images'}")
 
     assert len(images_paths) == len(annotations_paths)
 
@@ -507,9 +487,7 @@ def _validate_inputs(partition, split_type, annotation_type):
     if split_type not in ["random", "stratified", None]:
         raise ValueError("split_type should be either 'random', 'stratified', or None")
     if annotation_type not in ["tag", "polygon", "bounding_box"]:
-        raise ValueError(
-            "annotation_type should be either 'tag', 'bounding_box', or 'polygon'"
-        )
+        raise ValueError("annotation_type should be either 'tag', 'bounding_box', or 'polygon'")
 
 
 def _get_stems_from_split(release_path, split, split_type, annotation_type, partition):
@@ -550,9 +528,7 @@ def _get_stems_from_split(release_path, split, split_type, annotation_type, part
         )
 
 
-def _map_annotations_to_images(
-    stems, annotations_dir, images_dir, ignore_inconsistent_examples
-):
+def _map_annotations_to_images(stems, annotations_dir, images_dir, ignore_inconsistent_examples):
     """
     Maps annotations to their corresponding images based on the file stems.
 
@@ -583,16 +559,12 @@ def _map_annotations_to_images(
                 invalid_annotation_paths.append(annotation_path)
                 continue
             else:
-                raise ValueError(
-                    f"Annotation ({annotation_path}) does not have a corresponding image"
-                )
+                raise ValueError(f"Annotation ({annotation_path}) does not have a corresponding image")
 
     return images_paths, annotations_paths, invalid_annotation_paths
 
 
-def _load_and_format_annotations(
-    images_paths, annotations_paths, annotation_format, annotation_type, classes
-):
+def _load_and_format_annotations(images_paths, annotations_paths, annotation_format, annotation_type, classes):
     """
     Loads and formats annotations based on the specified format and type.
 
@@ -611,13 +583,9 @@ def _load_and_format_annotations(
     """
     if annotation_format == "coco":
         images_ids = list(range(len(images_paths)))
-        for annotation_path, image_path, image_id in zip(
-            annotations_paths, images_paths, images_ids
-        ):
+        for annotation_path, image_path, image_id in zip(annotations_paths, images_paths, images_ids):
             if image_path.suffix.lower() in SUPPORTED_VIDEO_EXTENSIONS:
-                print(
-                    f"[WARNING] Cannot load video annotation into COCO format. Skipping {image_path}"
-                )
+                print(f"[WARNING] Cannot load video annotation into COCO format. Skipping {image_path}")
                 continue
             yield get_coco_format_record(
                 annotation_path=annotation_path,
@@ -755,34 +723,25 @@ def compute_distributions(
         - instance_distribution: count of all instances of a given class exist for each partition
     """
 
-    class_distribution: AnnotationDistribution = {
-        partition: Counter() for partition in partitions
-    }
-    instance_distribution: AnnotationDistribution = {
-        partition: Counter() for partition in partitions
-    }
+    class_distribution: AnnotationDistribution = {partition: Counter() for partition in partitions}
+    instance_distribution: AnnotationDistribution = {partition: Counter() for partition in partitions}
 
     for partition in partitions:
         for annotation_type in annotation_types:
-            split_file: Path = (
-                split_path / f"stratified_{annotation_type}_{partition}.txt"
-            )
+            split_file: Path = split_path / f"stratified_{annotation_type}_{partition}.txt"
             if not split_file.exists():
                 split_file = split_path / f"random_{partition}.txt"
             stems: List[str] = [e.rstrip("\n\r") for e in split_file.open()]
 
             for stem in stems:
                 annotation_path: Path = annotations_dir / f"{stem}"
-                annotation_file: Optional[dt.AnnotationFile] = parse_path(
-                    annotation_path
-                )
+                annotation_file: Optional[dt.AnnotationFile] = parse_path(annotation_path)
 
                 if annotation_file is None:
                     continue
 
                 annotation_class_names: List[str] = [
-                    annotation.annotation_class.name
-                    for annotation in annotation_file.annotations
+                    annotation.annotation_class.name for annotation in annotation_file.annotations
                 ]
 
                 class_distribution[partition] += Counter(set(annotation_class_names))

--- a/darwin/dataset/utils.py
+++ b/darwin/dataset/utils.py
@@ -102,7 +102,10 @@ def extract_classes(
             continue
 
         for annotation in annotation_file.annotations:
-            if annotation.annotation_class.annotation_type not in annotation_types_to_load:
+            if (
+                annotation.annotation_class.annotation_type
+                not in annotation_types_to_load
+            ):
                 continue
 
             class_name = annotation.annotation_class.name
@@ -191,7 +194,11 @@ def get_classes(
         classes_file_path = release_path / f"lists/classes_{atype}.txt"
 
         class_per_annotations = get_classes_from_file(classes_file_path)
-        if remove_background and class_per_annotations and class_per_annotations[0] == "__background__":
+        if (
+            remove_background
+            and class_per_annotations
+            and class_per_annotations[0] == "__background__"
+        ):
             class_per_annotations = class_per_annotations[1:]
 
         for cls in class_per_annotations:
@@ -314,7 +321,9 @@ def get_coco_format_record(
     objs = []
     for obj in data.annotations:
         if annotation_type != obj.annotation_class.annotation_type:
-            if annotation_type not in obj.data:  # Allows training object detection with bboxes
+            if (
+                annotation_type not in obj.data
+            ):  # Allows training object detection with bboxes
                 continue
 
         if annotation_type == "polygon":
@@ -357,7 +366,9 @@ def create_polygon_object(obj, box_mode, classes=None):
         "segmentation": segmentation,
         "bbox": [np.min(all_px), np.min(all_py), np.max(all_px), np.max(all_py)],
         "bbox_mode": box_mode,
-        "category_id": classes.index(obj.annotation_class.name) if classes else obj.annotation_class.name,
+        "category_id": classes.index(obj.annotation_class.name)
+        if classes
+        else obj.annotation_class.name,
         "iscrowd": 0,
     }
 
@@ -369,7 +380,9 @@ def create_bbox_object(obj, box_mode, classes=None):
     new_obj = {
         "bbox": [bbox["x"], bbox["y"], bbox["x"] + bbox["w"], bbox["y"] + bbox["h"]],
         "bbox_mode": box_mode,
-        "category_id": classes.index(obj.annotation_class.name) if classes else obj.annotation_class.name,
+        "category_id": classes.index(obj.annotation_class.name)
+        if classes
+        else obj.annotation_class.name,
         "iscrowd": 0,
     }
 
@@ -446,7 +459,9 @@ def get_annotations(
     )
 
     if partition:
-        stems = _get_stems_from_split(release_path, split, split_type, annotation_type, partition)
+        stems = _get_stems_from_split(
+            release_path, split, split_type, annotation_type, partition
+        )
     else:
         stems = (e.stem for e in annotations_dir.glob("**/*.json"))
 
@@ -454,14 +469,19 @@ def get_annotations(
         images_paths,
         annotations_paths,
         invalid_annotation_paths,
-    ) = _map_annotations_to_images(stems, annotations_dir, images_dir, ignore_inconsistent_examples)
+    ) = _map_annotations_to_images(
+        stems, annotations_dir, images_dir, ignore_inconsistent_examples
+    )
 
     print(f"Found {len(invalid_annotation_paths)} invalid annotations")
     for p in invalid_annotation_paths:
         print(p)
 
     if len(images_paths) == 0:
-        raise ValueError(f"Could not find any {SUPPORTED_EXTENSIONS} file" f" in {dataset_path / 'images'}")
+        raise ValueError(
+            f"Could not find any {SUPPORTED_EXTENSIONS} file"
+            f" in {dataset_path / 'images'}"
+        )
 
     assert len(images_paths) == len(annotations_paths)
 
@@ -487,7 +507,9 @@ def _validate_inputs(partition, split_type, annotation_type):
     if split_type not in ["random", "stratified", None]:
         raise ValueError("split_type should be either 'random', 'stratified', or None")
     if annotation_type not in ["tag", "polygon", "bounding_box"]:
-        raise ValueError("annotation_type should be either 'tag', 'bounding_box', or 'polygon'")
+        raise ValueError(
+            "annotation_type should be either 'tag', 'bounding_box', or 'polygon'"
+        )
 
 
 def _get_stems_from_split(release_path, split, split_type, annotation_type, partition):
@@ -528,7 +550,9 @@ def _get_stems_from_split(release_path, split, split_type, annotation_type, part
         )
 
 
-def _map_annotations_to_images(stems, annotations_dir, images_dir, ignore_inconsistent_examples):
+def _map_annotations_to_images(
+    stems, annotations_dir, images_dir, ignore_inconsistent_examples
+):
     """
     Maps annotations to their corresponding images based on the file stems.
 
@@ -559,12 +583,16 @@ def _map_annotations_to_images(stems, annotations_dir, images_dir, ignore_incons
                 invalid_annotation_paths.append(annotation_path)
                 continue
             else:
-                raise ValueError(f"Annotation ({annotation_path}) does not have a corresponding image")
+                raise ValueError(
+                    f"Annotation ({annotation_path}) does not have a corresponding image"
+                )
 
     return images_paths, annotations_paths, invalid_annotation_paths
 
 
-def _load_and_format_annotations(images_paths, annotations_paths, annotation_format, annotation_type, classes):
+def _load_and_format_annotations(
+    images_paths, annotations_paths, annotation_format, annotation_type, classes
+):
     """
     Loads and formats annotations based on the specified format and type.
 
@@ -583,9 +611,13 @@ def _load_and_format_annotations(images_paths, annotations_paths, annotation_for
     """
     if annotation_format == "coco":
         images_ids = list(range(len(images_paths)))
-        for annotation_path, image_path, image_id in zip(annotations_paths, images_paths, images_ids):
+        for annotation_path, image_path, image_id in zip(
+            annotations_paths, images_paths, images_ids
+        ):
             if image_path.suffix.lower() in SUPPORTED_VIDEO_EXTENSIONS:
-                print(f"[WARNING] Cannot load video annotation into COCO format. Skipping {image_path}")
+                print(
+                    f"[WARNING] Cannot load video annotation into COCO format. Skipping {image_path}"
+                )
                 continue
             yield get_coco_format_record(
                 annotation_path=annotation_path,
@@ -723,25 +755,34 @@ def compute_distributions(
         - instance_distribution: count of all instances of a given class exist for each partition
     """
 
-    class_distribution: AnnotationDistribution = {partition: Counter() for partition in partitions}
-    instance_distribution: AnnotationDistribution = {partition: Counter() for partition in partitions}
+    class_distribution: AnnotationDistribution = {
+        partition: Counter() for partition in partitions
+    }
+    instance_distribution: AnnotationDistribution = {
+        partition: Counter() for partition in partitions
+    }
 
     for partition in partitions:
         for annotation_type in annotation_types:
-            split_file: Path = split_path / f"stratified_{annotation_type}_{partition}.txt"
+            split_file: Path = (
+                split_path / f"stratified_{annotation_type}_{partition}.txt"
+            )
             if not split_file.exists():
                 split_file = split_path / f"random_{partition}.txt"
             stems: List[str] = [e.rstrip("\n\r") for e in split_file.open()]
 
             for stem in stems:
                 annotation_path: Path = annotations_dir / f"{stem}"
-                annotation_file: Optional[dt.AnnotationFile] = parse_path(annotation_path)
+                annotation_file: Optional[dt.AnnotationFile] = parse_path(
+                    annotation_path
+                )
 
                 if annotation_file is None:
                     continue
 
                 annotation_class_names: List[str] = [
-                    annotation.annotation_class.name for annotation in annotation_file.annotations
+                    annotation.annotation_class.name
+                    for annotation in annotation_file.annotations
                 ]
 
                 class_distribution[partition] += Counter(set(annotation_class_names))

--- a/darwin/dataset/utils.py
+++ b/darwin/dataset/utils.py
@@ -102,10 +102,7 @@ def extract_classes(
             continue
 
         for annotation in annotation_file.annotations:
-            if (
-                annotation.annotation_class.annotation_type
-                not in annotation_types_to_load
-            ):
+            if annotation.annotation_class.annotation_type not in annotation_types_to_load:
                 continue
 
             class_name = annotation.annotation_class.name
@@ -194,11 +191,7 @@ def get_classes(
         classes_file_path = release_path / f"lists/classes_{atype}.txt"
 
         class_per_annotations = get_classes_from_file(classes_file_path)
-        if (
-            remove_background
-            and class_per_annotations
-            and class_per_annotations[0] == "__background__"
-        ):
+        if remove_background and class_per_annotations and class_per_annotations[0] == "__background__":
             class_per_annotations = class_per_annotations[1:]
 
         for cls in class_per_annotations:
@@ -321,9 +314,7 @@ def get_coco_format_record(
     objs = []
     for obj in data.annotations:
         if annotation_type != obj.annotation_class.annotation_type:
-            if (
-                annotation_type not in obj.data
-            ):  # Allows training object detection with bboxes
+            if annotation_type not in obj.data:  # Allows training object detection with bboxes
                 continue
 
         if annotation_type == "polygon":
@@ -366,9 +357,7 @@ def create_polygon_object(obj, box_mode, classes=None):
         "segmentation": segmentation,
         "bbox": [np.min(all_px), np.min(all_py), np.max(all_px), np.max(all_py)],
         "bbox_mode": box_mode,
-        "category_id": classes.index(obj.annotation_class.name)
-        if classes
-        else obj.annotation_class.name,
+        "category_id": classes.index(obj.annotation_class.name) if classes else obj.annotation_class.name,
         "iscrowd": 0,
     }
 
@@ -380,9 +369,7 @@ def create_bbox_object(obj, box_mode, classes=None):
     new_obj = {
         "bbox": [bbox["x"], bbox["y"], bbox["x"] + bbox["w"], bbox["y"] + bbox["h"]],
         "bbox_mode": box_mode,
-        "category_id": classes.index(obj.annotation_class.name)
-        if classes
-        else obj.annotation_class.name,
+        "category_id": classes.index(obj.annotation_class.name) if classes else obj.annotation_class.name,
         "iscrowd": 0,
     }
 
@@ -459,9 +446,7 @@ def get_annotations(
     )
 
     if partition:
-        stems = _get_stems_from_split(
-            release_path, split, split_type, annotation_type, partition
-        )
+        stems = _get_stems_from_split(release_path, split, split_type, annotation_type, partition)
     else:
         stems = (e.stem for e in annotations_dir.glob("**/*.json"))
 
@@ -469,19 +454,14 @@ def get_annotations(
         images_paths,
         annotations_paths,
         invalid_annotation_paths,
-    ) = _map_annotations_to_images(
-        stems, annotations_dir, images_dir, ignore_inconsistent_examples
-    )
+    ) = _map_annotations_to_images(stems, annotations_dir, images_dir, ignore_inconsistent_examples)
 
     print(f"Found {len(invalid_annotation_paths)} invalid annotations")
     for p in invalid_annotation_paths:
         print(p)
 
     if len(images_paths) == 0:
-        raise ValueError(
-            f"Could not find any {SUPPORTED_EXTENSIONS} file"
-            f" in {dataset_path / 'images'}"
-        )
+        raise ValueError(f"Could not find any {SUPPORTED_EXTENSIONS} file" f" in {dataset_path / 'images'}")
 
     assert len(images_paths) == len(annotations_paths)
 
@@ -507,9 +487,7 @@ def _validate_inputs(partition, split_type, annotation_type):
     if split_type not in ["random", "stratified", None]:
         raise ValueError("split_type should be either 'random', 'stratified', or None")
     if annotation_type not in ["tag", "polygon", "bounding_box"]:
-        raise ValueError(
-            "annotation_type should be either 'tag', 'bounding_box', or 'polygon'"
-        )
+        raise ValueError("annotation_type should be either 'tag', 'bounding_box', or 'polygon'")
 
 
 def _get_stems_from_split(release_path, split, split_type, annotation_type, partition):
@@ -550,9 +528,7 @@ def _get_stems_from_split(release_path, split, split_type, annotation_type, part
         )
 
 
-def _map_annotations_to_images(
-    stems, annotations_dir, images_dir, ignore_inconsistent_examples
-):
+def _map_annotations_to_images(stems, annotations_dir, images_dir, ignore_inconsistent_examples):
     """
     Maps annotations to their corresponding images based on the file stems.
 
@@ -583,16 +559,12 @@ def _map_annotations_to_images(
                 invalid_annotation_paths.append(annotation_path)
                 continue
             else:
-                raise ValueError(
-                    f"Annotation ({annotation_path}) does not have a corresponding image"
-                )
+                raise ValueError(f"Annotation ({annotation_path}) does not have a corresponding image")
 
     return images_paths, annotations_paths, invalid_annotation_paths
 
 
-def _load_and_format_annotations(
-    images_paths, annotations_paths, annotation_format, annotation_type, classes
-):
+def _load_and_format_annotations(images_paths, annotations_paths, annotation_format, annotation_type, classes):
     """
     Loads and formats annotations based on the specified format and type.
 
@@ -611,13 +583,9 @@ def _load_and_format_annotations(
     """
     if annotation_format == "coco":
         images_ids = list(range(len(images_paths)))
-        for annotation_path, image_path, image_id in zip(
-            annotations_paths, images_paths, images_ids
-        ):
+        for annotation_path, image_path, image_id in zip(annotations_paths, images_paths, images_ids):
             if image_path.suffix.lower() in SUPPORTED_VIDEO_EXTENSIONS:
-                print(
-                    f"[WARNING] Cannot load video annotation into COCO format. Skipping {image_path}"
-                )
+                print(f"[WARNING] Cannot load video annotation into COCO format. Skipping {image_path}")
                 continue
             yield get_coco_format_record(
                 annotation_path=annotation_path,
@@ -755,34 +723,25 @@ def compute_distributions(
         - instance_distribution: count of all instances of a given class exist for each partition
     """
 
-    class_distribution: AnnotationDistribution = {
-        partition: Counter() for partition in partitions
-    }
-    instance_distribution: AnnotationDistribution = {
-        partition: Counter() for partition in partitions
-    }
+    class_distribution: AnnotationDistribution = {partition: Counter() for partition in partitions}
+    instance_distribution: AnnotationDistribution = {partition: Counter() for partition in partitions}
 
     for partition in partitions:
         for annotation_type in annotation_types:
-            split_file: Path = (
-                split_path / f"stratified_{annotation_type}_{partition}.txt"
-            )
+            split_file: Path = split_path / f"stratified_{annotation_type}_{partition}.txt"
             if not split_file.exists():
                 split_file = split_path / f"random_{partition}.txt"
             stems: List[str] = [e.rstrip("\n\r") for e in split_file.open()]
 
             for stem in stems:
-                annotation_path: Path = annotations_dir / f"{stem}.json"
-                annotation_file: Optional[dt.AnnotationFile] = parse_path(
-                    annotation_path
-                )
+                annotation_path: Path = annotations_dir / f"{stem}"
+                annotation_file: Optional[dt.AnnotationFile] = parse_path(annotation_path)
 
                 if annotation_file is None:
                     continue
 
                 annotation_class_names: List[str] = [
-                    annotation.annotation_class.name
-                    for annotation in annotation_file.annotations
+                    annotation.annotation_class.name for annotation in annotation_file.annotations
                 ]
 
                 class_distribution[partition] += Counter(set(annotation_class_names))

--- a/darwin/utils/utils.py
+++ b/darwin/utils/utils.py
@@ -487,9 +487,9 @@ def stream_darwin_json(path: Path) -> PersistentStreamingJSONObject:
 def get_image_path_from_stream(
     darwin_json: PersistentStreamingJSONObject,
     images_dir: Path,
-    with_folders: bool,
-    annotation_filepath: Path,
+    with_folders: bool = True,
     json_version: str = "2.0",
+    annotation_filepath: Path = None,
 ) -> Path:
     """
     Returns the path to the image file associated with the given darwin json file.

--- a/darwin/utils/utils.py
+++ b/darwin/utils/utils.py
@@ -214,7 +214,9 @@ def is_project_dir(project_path: Path) -> bool:
     return (project_path / "releases").exists() and (project_path / "images").exists()
 
 
-def get_progress_bar(array: List[dt.AnnotationFile], description: Optional[str] = None) -> Iterable[ProgressType]:
+def get_progress_bar(
+    array: List[dt.AnnotationFile], description: Optional[str] = None
+) -> Iterable[ProgressType]:
     """
     Get a rich a progress bar for the given list of annotation files.
 
@@ -358,7 +360,9 @@ def persist_client_configuration(
         api_key=team_config.api_key,
         datasets_dir=team_config.datasets_dir,
     )
-    config.set_global(api_endpoint=client.url, base_url=client.base_url, default_team=default_team)
+    config.set_global(
+        api_endpoint=client.url, base_url=client.base_url, default_team=default_team
+    )
 
     return config
 
@@ -415,7 +419,9 @@ def attempt_decode(path: Path) -> dict:
             return data
         except Exception:
             continue
-    raise UnrecognizableFileEncoding(f"Unable to load file {path} with any encodings: {encodings}")
+    raise UnrecognizableFileEncoding(
+        f"Unable to load file {path} with any encodings: {encodings}"
+    )
 
 
 def load_data_from_file(path: Path) -> Tuple[dict, dt.AnnotationFileVersion]:
@@ -424,7 +430,9 @@ def load_data_from_file(path: Path) -> Tuple[dict, dt.AnnotationFileVersion]:
     return data, version
 
 
-def parse_darwin_json(path: Path, count: Optional[int] = None) -> Optional[dt.AnnotationFile]:
+def parse_darwin_json(
+    path: Path, count: Optional[int] = None
+) -> Optional[dt.AnnotationFile]:
     """
     Parses the given JSON file in v7's darwin proprietary format. Works for images, split frame
     videos (treated as images) and playback videos.
@@ -517,7 +525,9 @@ def get_image_path_from_stream(
                 return images_dir / Path(darwin_json["item"]["name"])
             else:
                 return (
-                    images_dir / (Path(darwin_json["item"]["path"].lstrip("/\\"))) / Path(darwin_json["item"]["name"])
+                    images_dir
+                    / (Path(darwin_json["item"]["path"].lstrip("/\\")))
+                    / Path(darwin_json["item"]["name"])
                 )
         else:
             if not with_folders:
@@ -574,9 +584,15 @@ def is_stream_list_empty(json_list: PersistentStreamingJSONList) -> bool:
 def _parse_darwin_v2(path: Path, data: Dict[str, Any]) -> dt.AnnotationFile:
     item = data["item"]
     item_source = item.get("source_info", {})
-    slots: List[dt.Slot] = list(filter(None, map(_parse_darwin_slot, item.get("slots", []))))
-    annotations: List[Union[dt.Annotation, dt.VideoAnnotation]] = _data_to_annotations(data)
-    annotation_classes: Set[dt.AnnotationClass] = {annotation.annotation_class for annotation in annotations}
+    slots: List[dt.Slot] = list(
+        filter(None, map(_parse_darwin_slot, item.get("slots", [])))
+    )
+    annotations: List[Union[dt.Annotation, dt.VideoAnnotation]] = _data_to_annotations(
+        data
+    )
+    annotation_classes: Set[dt.AnnotationClass] = {
+        annotation.annotation_class for annotation in annotations
+    }
 
     if len(slots) == 0:
         annotation_file = dt.AnnotationFile(
@@ -584,7 +600,9 @@ def _parse_darwin_v2(path: Path, data: Dict[str, Any]) -> dt.AnnotationFile:
             path=path,
             filename=item["name"],
             item_id=item.get("source_info", {}).get("item_id", None),
-            dataset_name=item.get("source_info", {}).get("dataset", {}).get("name", None),
+            dataset_name=item.get("source_info", {})
+            .get("dataset", {})
+            .get("name", None),
             annotation_classes=annotation_classes,
             annotations=annotations,
             is_video=False,
@@ -605,13 +623,17 @@ def _parse_darwin_v2(path: Path, data: Dict[str, Any]) -> dt.AnnotationFile:
             path=path,
             filename=item["name"],
             item_id=item.get("source_info", {}).get("item_id", None),
-            dataset_name=item.get("source_info", {}).get("dataset", {}).get("name", None),
+            dataset_name=item.get("source_info", {})
+            .get("dataset", {})
+            .get("name", None),
             annotation_classes=annotation_classes,
             annotations=annotations,
             is_video=slot.frame_urls is not None or slot.frame_manifest is not None,
             image_width=slot.width,
             image_height=slot.height,
-            image_url=None if len(slot.source_files or []) == 0 else slot.source_files[0]["url"],
+            image_url=None
+            if len(slot.source_files or []) == 0
+            else slot.source_files[0]["url"],
             image_thumbnail_url=slot.thumbnail_url,
             workview_url=item_source.get("workview_url", None),
             seq=0,
@@ -641,9 +663,15 @@ def _parse_darwin_slot(data: Dict[str, Any]) -> dt.Slot:
     )
 
 
-def _parse_darwin_image(path: Path, data: Dict[str, Any], count: Optional[int]) -> dt.AnnotationFile:
-    annotations: List[Union[dt.Annotation, dt.VideoAnnotation]] = _data_to_annotations(data)
-    annotation_classes: Set[dt.AnnotationClass] = {annotation.annotation_class for annotation in annotations}
+def _parse_darwin_image(
+    path: Path, data: Dict[str, Any], count: Optional[int]
+) -> dt.AnnotationFile:
+    annotations: List[Union[dt.Annotation, dt.VideoAnnotation]] = _data_to_annotations(
+        data
+    )
+    annotation_classes: Set[dt.AnnotationClass] = {
+        annotation.annotation_class for annotation in annotations
+    }
 
     slot = dt.Slot(
         name=None,
@@ -680,12 +708,20 @@ def _parse_darwin_image(path: Path, data: Dict[str, Any], count: Optional[int]) 
     return annotation_file
 
 
-def _parse_darwin_video(path: Path, data: Dict[str, Any], count: Optional[int]) -> dt.AnnotationFile:
-    annotations: List[Union[dt.Annotation, dt.VideoAnnotation]] = _data_to_annotations(data)
-    annotation_classes: Set[dt.AnnotationClass] = {annotation.annotation_class for annotation in annotations}
+def _parse_darwin_video(
+    path: Path, data: Dict[str, Any], count: Optional[int]
+) -> dt.AnnotationFile:
+    annotations: List[Union[dt.Annotation, dt.VideoAnnotation]] = _data_to_annotations(
+        data
+    )
+    annotation_classes: Set[dt.AnnotationClass] = {
+        annotation.annotation_class for annotation in annotations
+    }
 
     if "width" not in data["image"] or "height" not in data["image"]:
-        raise OutdatedDarwinJSONFormat("Missing width/height in video, please re-export")
+        raise OutdatedDarwinJSONFormat(
+            "Missing width/height in video, please re-export"
+        )
 
     slot = dt.Slot(
         name=None,
@@ -731,23 +767,41 @@ def _parse_darwin_annotation(annotation: Dict[str, Any]) -> Optional[dt.Annotati
     main_annotation: Optional[dt.Annotation] = None
 
     # Darwin JSON 2.0 representation of complex polygons
-    if "polygon" in annotation and "paths" in annotation["polygon"] and len(annotation["polygon"]["paths"]) > 1:
+    if (
+        "polygon" in annotation
+        and "paths" in annotation["polygon"]
+        and len(annotation["polygon"]["paths"]) > 1
+    ):
         bounding_box = annotation.get("bounding_box")
         paths = annotation["polygon"]["paths"]
-        main_annotation = dt.make_complex_polygon(name, paths, bounding_box, slot_names=slot_names)
+        main_annotation = dt.make_complex_polygon(
+            name, paths, bounding_box, slot_names=slot_names
+        )
     # Darwin JSON 2.0 representation of simple polygons
-    elif "polygon" in annotation and "paths" in annotation["polygon"] and len(annotation["polygon"]["paths"]) == 1:
+    elif (
+        "polygon" in annotation
+        and "paths" in annotation["polygon"]
+        and len(annotation["polygon"]["paths"]) == 1
+    ):
         bounding_box = annotation.get("bounding_box")
         paths = annotation["polygon"]["paths"]
-        main_annotation = dt.make_polygon(name, paths[0], bounding_box, slot_names=slot_names)
+        main_annotation = dt.make_polygon(
+            name, paths[0], bounding_box, slot_names=slot_names
+        )
     # Darwin JSON 1.0 representation of complex and simple polygons
     elif "polygon" in annotation:
         bounding_box = annotation.get("bounding_box")
         if "additional_paths" in annotation["polygon"]:
-            paths = [annotation["polygon"]["path"]] + annotation["polygon"]["additional_paths"]
-            main_annotation = dt.make_complex_polygon(name, paths, bounding_box, slot_names=slot_names)
+            paths = [annotation["polygon"]["path"]] + annotation["polygon"][
+                "additional_paths"
+            ]
+            main_annotation = dt.make_complex_polygon(
+                name, paths, bounding_box, slot_names=slot_names
+            )
         else:
-            main_annotation = dt.make_polygon(name, annotation["polygon"]["path"], bounding_box, slot_names=slot_names)
+            main_annotation = dt.make_polygon(
+                name, annotation["polygon"]["path"], bounding_box, slot_names=slot_names
+            )
     # Darwin JSON 1.0 representation of complex polygons
     elif "complex_polygon" in annotation:
         bounding_box = annotation.get("bounding_box")
@@ -759,7 +813,9 @@ def _parse_darwin_annotation(annotation: Dict[str, Any]) -> Optional[dt.Annotati
         if "additional_paths" in annotation["complex_polygon"]:
             paths.extend(annotation["complex_polygon"]["additional_paths"])
 
-        main_annotation = dt.make_complex_polygon(name, paths, bounding_box, slot_names=slot_names)
+        main_annotation = dt.make_complex_polygon(
+            name, paths, bounding_box, slot_names=slot_names
+        )
     elif "bounding_box" in annotation:
         bounding_box = annotation["bounding_box"]
         main_annotation = dt.make_bounding_box(
@@ -773,7 +829,9 @@ def _parse_darwin_annotation(annotation: Dict[str, Any]) -> Optional[dt.Annotati
     elif "tag" in annotation:
         main_annotation = dt.make_tag(name, slot_names=slot_names)
     elif "line" in annotation:
-        main_annotation = dt.make_line(name, annotation["line"]["path"], slot_names=slot_names)
+        main_annotation = dt.make_line(
+            name, annotation["line"]["path"], slot_names=slot_names
+        )
     elif "keypoint" in annotation:
         main_annotation = dt.make_keypoint(
             name,
@@ -782,11 +840,17 @@ def _parse_darwin_annotation(annotation: Dict[str, Any]) -> Optional[dt.Annotati
             slot_names=slot_names,
         )
     elif "ellipse" in annotation:
-        main_annotation = dt.make_ellipse(name, annotation["ellipse"], slot_names=slot_names)
+        main_annotation = dt.make_ellipse(
+            name, annotation["ellipse"], slot_names=slot_names
+        )
     elif "cuboid" in annotation:
-        main_annotation = dt.make_cuboid(name, annotation["cuboid"], slot_names=slot_names)
+        main_annotation = dt.make_cuboid(
+            name, annotation["cuboid"], slot_names=slot_names
+        )
     elif "skeleton" in annotation:
-        main_annotation = dt.make_skeleton(name, annotation["skeleton"]["nodes"], slot_names=slot_names)
+        main_annotation = dt.make_skeleton(
+            name, annotation["skeleton"]["nodes"], slot_names=slot_names
+        )
     elif "table" in annotation:
         main_annotation = dt.make_table(
             name,
@@ -795,7 +859,9 @@ def _parse_darwin_annotation(annotation: Dict[str, Any]) -> Optional[dt.Annotati
             slot_names=slot_names,
         )
     elif "string" in annotation:
-        main_annotation = dt.make_string(name, annotation["string"]["sources"], slot_names=slot_names)
+        main_annotation = dt.make_string(
+            name, annotation["string"]["sources"], slot_names=slot_names
+        )
     elif "graph" in annotation:
         main_annotation = dt.make_graph(
             name,
@@ -822,19 +888,29 @@ def _parse_darwin_annotation(annotation: Dict[str, Any]) -> Optional[dt.Annotati
     if "id" in annotation:
         main_annotation.id = annotation["id"]
     if "instance_id" in annotation:
-        main_annotation.subs.append(dt.make_instance_id(annotation["instance_id"]["value"]))
+        main_annotation.subs.append(
+            dt.make_instance_id(annotation["instance_id"]["value"])
+        )
     if "attributes" in annotation:
         main_annotation.subs.append(dt.make_attributes(annotation["attributes"]))
     if "text" in annotation:
         main_annotation.subs.append(dt.make_text(annotation["text"]["text"]))
     if "inference" in annotation:
-        main_annotation.subs.append(dt.make_opaque_sub("inference", annotation["inference"]))
+        main_annotation.subs.append(
+            dt.make_opaque_sub("inference", annotation["inference"])
+        )
     if "directional_vector" in annotation:
-        main_annotation.subs.append(dt.make_opaque_sub("directional_vector", annotation["directional_vector"]))
+        main_annotation.subs.append(
+            dt.make_opaque_sub("directional_vector", annotation["directional_vector"])
+        )
     if "measures" in annotation:
-        main_annotation.subs.append(dt.make_opaque_sub("measures", annotation["measures"]))
+        main_annotation.subs.append(
+            dt.make_opaque_sub("measures", annotation["measures"])
+        )
     if "auto_annotate" in annotation:
-        main_annotation.subs.append(dt.make_opaque_sub("auto_annotate", annotation["auto_annotate"]))
+        main_annotation.subs.append(
+            dt.make_opaque_sub("auto_annotate", annotation["auto_annotate"])
+        )
 
     if annotation.get("annotators") is not None:
         main_annotation.annotators = _parse_annotators(annotation["annotators"])
@@ -888,7 +964,9 @@ def _parse_darwin_raster_annotation(annotation: dict) -> Optional[dt.Annotation]
     slot_names: Optional[List[str]] = parse_slot_names(annotation)
 
     if not id or not name or not raster_layer:
-        raise ValueError("Raster annotation must have an 'id', 'name' and 'raster_layer' field")
+        raise ValueError(
+            "Raster annotation must have an 'id', 'name' and 'raster_layer' field"
+        )
 
     dense_rle, mask_annotation_ids_mapping, total_pixels = (
         raster_layer.get("dense_rle", None),
@@ -939,9 +1017,14 @@ def _parse_darwin_mask_annotation(annotation: dict) -> Optional[dt.Annotation]:
 
 def _parse_annotators(annotators: List[Dict[str, Any]]) -> List[dt.AnnotationAuthor]:
     if not (hasattr(annotators, "full_name") or not hasattr(annotators, "email")):
-        raise AttributeError("JSON file must contain annotators with 'full_name' and 'email' fields")
+        raise AttributeError(
+            "JSON file must contain annotators with 'full_name' and 'email' fields"
+        )
 
-    return [dt.AnnotationAuthor(annotator["full_name"], annotator["email"]) for annotator in annotators]
+    return [
+        dt.AnnotationAuthor(annotator["full_name"], annotator["email"])
+        for annotator in annotators
+    ]
 
 
 def split_video_annotation(annotation: dt.AnnotationFile) -> List[dt.AnnotationFile]:
@@ -977,9 +1060,13 @@ def split_video_annotation(annotation: dt.AnnotationFile) -> List[dt.AnnotationF
     frame_annotations = []
     for i, frame_url in enumerate(urls):
         annotations = [
-            a.frames[i] for a in annotation.annotations if isinstance(a, dt.VideoAnnotation) and i in a.frames
+            a.frames[i]
+            for a in annotation.annotations
+            if isinstance(a, dt.VideoAnnotation) and i in a.frames
         ]
-        annotation_classes: Set[dt.AnnotationClass] = {annotation.annotation_class for annotation in annotations}
+        annotation_classes: Set[dt.AnnotationClass] = {
+            annotation.annotation_class for annotation in annotations
+        }
         filename: str = f"{Path(annotation.filename).stem}/{i:07d}.png"
         frame_annotations.append(
             dt.AnnotationFile(
@@ -1065,7 +1152,9 @@ def convert_polygons_to_sequences(
     else:
         list_polygons = cast(List[dt.Polygon], [polygons])
 
-    if not isinstance(list_polygons[0], list) or not isinstance(list_polygons[0][0], dict):
+    if not isinstance(list_polygons[0], list) or not isinstance(
+        list_polygons[0][0], dict
+    ):
         raise ValueError("Unknown input format")
 
     sequences: List[List[Union[int, float]]] = []
@@ -1206,7 +1295,9 @@ def convert_bounding_box_to_xyxy(box: dt.BoundingBox) -> List[float]:
     return [box["x"], box["y"], x2, y2]
 
 
-def convert_polygons_to_mask(polygons: List, height: int, width: int, value: Optional[int] = 1) -> np.ndarray:
+def convert_polygons_to_mask(
+    polygons: List, height: int, width: int, value: Optional[int] = 1
+) -> np.ndarray:
     """
     Converts a list of polygons, encoded as a list of dictionaries into an ``nd.array`` mask.
 
@@ -1300,24 +1391,38 @@ def _parse_version(data: dict) -> dt.AnnotationFileVersion:
     return dt.AnnotationFileVersion(int(major), int(minor), suffix)
 
 
-def _data_to_annotations(data: Dict[str, Any]) -> List[Union[dt.Annotation, dt.VideoAnnotation]]:
+def _data_to_annotations(
+    data: Dict[str, Any]
+) -> List[Union[dt.Annotation, dt.VideoAnnotation]]:
     raw_image_annotations = filter(
         lambda annotation: (
-            ("frames" not in annotation) and ("raster_layer" not in annotation) and ("mask" not in annotation)
+            ("frames" not in annotation)
+            and ("raster_layer" not in annotation)
+            and ("mask" not in annotation)
         ),
         data["annotations"],
     )
-    raw_video_annotations = filter(lambda annotation: "frames" in annotation, data["annotations"])
-    raw_raster_annotations = filter(lambda annotation: "raster_layer" in annotation, data["annotations"])
-    raw_mask_annotations = filter(lambda annotation: "mask" in annotation, data["annotations"])
-    image_annotations: List[dt.Annotation] = list(filter(None, map(_parse_darwin_annotation, raw_image_annotations)))
+    raw_video_annotations = filter(
+        lambda annotation: "frames" in annotation, data["annotations"]
+    )
+    raw_raster_annotations = filter(
+        lambda annotation: "raster_layer" in annotation, data["annotations"]
+    )
+    raw_mask_annotations = filter(
+        lambda annotation: "mask" in annotation, data["annotations"]
+    )
+    image_annotations: List[dt.Annotation] = list(
+        filter(None, map(_parse_darwin_annotation, raw_image_annotations))
+    )
     video_annotations: List[dt.VideoAnnotation] = list(
         filter(None, map(_parse_darwin_video_annotation, raw_video_annotations))
     )
     raster_annotations: List[dt.Annotation] = list(
         filter(None, map(_parse_darwin_raster_annotation, raw_raster_annotations))
     )
-    mask_annotations: List[dt.Annotation] = list(filter(None, map(_parse_darwin_mask_annotation, raw_mask_annotations)))
+    mask_annotations: List[dt.Annotation] = list(
+        filter(None, map(_parse_darwin_mask_annotation, raw_mask_annotations))
+    )
 
     return [
         *image_annotations,
@@ -1338,4 +1443,6 @@ def _supported_schema_versions() -> Dict[Tuple[int, int, str], str]:
 
 
 def _default_schema(version: dt.AnnotationFileVersion) -> Optional[str]:
-    return _supported_schema_versions().get((version.major, version.minor, version.suffix))
+    return _supported_schema_versions().get(
+        (version.major, version.minor, version.suffix)
+    )

--- a/darwin/utils/utils.py
+++ b/darwin/utils/utils.py
@@ -482,7 +482,7 @@ def stream_darwin_json(path: Path) -> PersistentStreamingJSONObject:
 
     with path.open() as infile:
         return json_stream.load(infile, persistent=True)
-      
+
 
 def get_image_path_from_stream(
     darwin_json: PersistentStreamingJSONObject,
@@ -517,9 +517,7 @@ def get_image_path_from_stream(
                 return images_dir / Path(darwin_json["item"]["name"])
             else:
                 return (
-                    images_dir
-                    / (Path(darwin_json["item"]["path"].lstrip("/\\")))
-                    / Path(darwin_json["item"]["name"])
+                    images_dir / (Path(darwin_json["item"]["path"].lstrip("/\\"))) / Path(darwin_json["item"]["name"])
                 )
         else:
             if not with_folders:
@@ -553,11 +551,16 @@ def get_darwin_json_version(annotations_dir: Path) -> str:
     str
         A str representing the Darwin JSON version.
     """
-    with open(next(annotations_dir.glob("*.json")), "r") as file:
+
+    # Search for JSON files both directly in the directory and in subdirectories
+    json_files = list(annotations_dir.glob("**/*.json"))
+
+    anno = json_files[0]
+    with open(anno, "r") as file:
         data_str = file.read()
         data = json.loads(data_str)
         return "2.0" if "version" in data and data["version"] == "2.0" else "1.0"
-      
+
 
 def is_stream_list_empty(json_list: PersistentStreamingJSONList) -> bool:
     try:

--- a/darwin/utils/utils.py
+++ b/darwin/utils/utils.py
@@ -488,8 +488,8 @@ def get_image_path_from_stream(
     darwin_json: PersistentStreamingJSONObject,
     images_dir: Path,
     with_folders: bool,
-    json_version: str,
     annotation_filepath: Path,
+    json_version: str = "2.0",
 ) -> Path:
     """
     Returns the path to the image file associated with the given darwin json file.


### PR DESCRIPTION
# Problem
There are a few updates in latest `darwin-py` that breaks other parts of the code.

First, the [get_darwin_json_version](https://github.com/v7labs/darwin-py/blob/a8d24aa62580382c720d5a2e3263fef48304da98/darwin/utils/utils.py#L542C5-L542C28) method assumes a flat structure of json files. Which is not true when we download with folders and/or video.

`with open(next(annotations_dir.glob("*.json")), "r") as file:`


Secondly, the `compute_distributions` will now add an extra `.json` on top of what is now the fill file path (with suffix).
https://github.com/v7labs/darwin-py/blob/a8d24aa62580382c720d5a2e3263fef48304da98/darwin/dataset/utils.py#L727

Example usage:

```
from darwin.dataset.split_manager import split_dataset
from darwin.dataset.utils import compute_distributions
p = Path(p)
split_path = split_dataset(
    p,
    release_name="example",
    val_percentage=0.2,
    test_percentage=0.2,
    stratified_types=["polygon"],
)

split_name = split_path.name

distributions = compute_distributions(p, split_path)
```

Thirdly, the [get_image_path_from_stream](https://github.com/v7labs/darwin-py/blob/a8d24aa62580382c720d5a2e3263fef48304da98/darwin/utils/utils.py#L487)` has now additional required arguments. This function is being used since before in [_map_annotations_to_images](https://github.com/v7labs/darwin-py/blob/392c228e67bd084b3a56e703b7073e20da1ce765/darwin/dataset/utils.py#L553C5-L553C31) and that one has not been updated to take the new arguments into account.



# Solution
- TBD, this is just a DRAFT

# Changelog
(Will appear in release docs)
