### PR TITLE
[PY-626] Updates to import endpoint - `annotation_properties`

### DIFF
--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -299,7 +299,7 @@ def _import_properties(
     annotation_id_property_map: Dict[int, Dict[str, List[str]]] = {}
     if not isinstance(metadata_path, Path):
         # No properties to import
-        return
+        return {}
 
     # parse metadata.json file -> list[PropertyClass]
     metadata = parse_metadata(metadata_path)

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -430,7 +430,6 @@ def _import_properties(
             assert t_prop.id is not None
             assert t_prop_val.id is not None
             annotation_id_property_map[annotation_class_id][t_prop.id].append(t_prop_val.id)
-            print(f"adding {t_prop_val.id} to {t_prop.id} for {annotation_class_id}, annotation prop is: {a_prop}")
 
     console = Console(theme=_console_theme())
     if create_properties:
@@ -870,24 +869,6 @@ def _handle_complex_polygon(
     return data
 
 
-def _handle_properties(
-        annotation: dt.Annotation, data: dt.DictFreeForm
-    ) -> dt.DictFreeForm:
-    data["properties"] = [
-        p.model_dump()
-        for p in annotation.properties or []
-    ]
-    return data
-
-
-def _handle_annotation_data(
-        annotation: dt.Annotation, data: dt.DictFreeForm
-    ) -> dt.DictFreeForm:
-    data = _handle_complex_polygon(annotation, data)
-    # data = _handle_properties(annotation, data)
-    return data
-
-
 def _annotators_or_reviewers_to_payload(
     actors: List[dt.AnnotationAuthor], role: dt.AnnotationAuthorRole
 ) -> List[dt.DictFreeForm]:
@@ -926,14 +907,14 @@ def _get_annotation_data(
             post_processing=lambda annotation, data: \
                 _handle_subs(
                     annotation,
-                    _handle_annotation_data(annotation, data),
+                    _handle_complex_polygon(annotation, data),
                     annotation_class_id,
                     attributes,
                 ),
         )
     else:
         data = {annotation_class.annotation_type: annotation.data}
-        data = _handle_annotation_data(annotation, data)
+        data = _handle_complex_polygon(annotation, data)
         data = _handle_subs(annotation, data, annotation_class_id, attributes)
 
     return data

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -282,6 +282,9 @@ def _update_payload_with_properties(
     """
     Updates the annotations with the properties that were created/updated during the import.
     """
+    if not annotation_id_property_map:
+        return
+
     for annotation in annotations:
         annotation_id = annotation["annotation_class_id"]
         if annotation_id_property_map.get(annotation_id):

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -907,13 +907,12 @@ def _get_annotation_data(
     if isinstance(annotation, dt.VideoAnnotation):
         data = annotation.get_data(
             only_keyframes=True,
-            post_processing=lambda annotation, data: \
-                _handle_subs(
-                    annotation,
-                    _handle_complex_polygon(annotation, data),
-                    annotation_class_id,
-                    attributes,
-                ),
+            post_processing=lambda annotation, data: _handle_subs(
+                annotation,
+                _handle_complex_polygon(annotation, data),
+                annotation_class_id,
+                attributes,
+            ),
         )
     else:
         data = {annotation_class.annotation_type: annotation.data}

--- a/tests/darwin/importer/importer_test.py
+++ b/tests/darwin/importer/importer_test.py
@@ -189,9 +189,7 @@ def test__get_annotation_data() -> None:
     with patch_factory("_handle_complex_polygon") as mock_hcp, patch_factory(
         "_handle_subs"
     ) as mock_hs, patch.object(
-        dt.VideoAnnotation,
-        "get_data",
-        return_value="TEST VIDEO DATA"
+        dt.VideoAnnotation, "get_data", return_value="TEST VIDEO DATA"
     ):
         from darwin.importer.importer import _get_annotation_data
 

--- a/tests/darwin/importer/importer_test.py
+++ b/tests/darwin/importer/importer_test.py
@@ -188,8 +188,7 @@ def test__get_annotation_data() -> None:
 
     with patch_factory("_handle_complex_polygon") as mock_hcp, patch_factory(
         "_handle_subs"
-    ) as mock_hs, patch_factory("_handle_annotation_data"
-    ) as mock_ad, patch.object(
+    ) as mock_hs, patch.object(
         dt.VideoAnnotation,
         "get_data",
         return_value="TEST VIDEO DATA"

--- a/tests/darwin/importer/importer_test.py
+++ b/tests/darwin/importer/importer_test.py
@@ -188,8 +188,7 @@ def test__get_annotation_data() -> None:
 
     with patch_factory("_handle_complex_polygon") as mock_hcp, patch_factory(
         "_handle_subs"
-    ) as mock_hs, patch_factory("_handle_properties"
-    ) as mock_hp, patch_factory("_handle_annotation_data"
+    ) as mock_hs, patch_factory("_handle_annotation_data"
     ) as mock_ad, patch.object(
         dt.VideoAnnotation,
         "get_data",
@@ -197,7 +196,7 @@ def test__get_annotation_data() -> None:
     ):
         from darwin.importer.importer import _get_annotation_data
 
-        mock_ad.return_value = "TEST DATA_AD"
+        mock_hcp.return_value = "TEST DATA_HCP"
         mock_hs.return_value = "TEST DATA_HS"
 
         assert (
@@ -206,7 +205,7 @@ def test__get_annotation_data() -> None:
         )
         assert _get_annotation_data(annotation, "class_id", {}) == "TEST DATA_HS"
 
-        assert mock_ad.call_count == 1
+        assert mock_hcp.call_count == 1
         assert mock_hs.call_count == 1
 
     with patch_factory("_handle_complex_polygon") as mock_hcp, patch_factory(

--- a/tests/darwin/importer/importer_test.py
+++ b/tests/darwin/importer/importer_test.py
@@ -188,12 +188,16 @@ def test__get_annotation_data() -> None:
 
     with patch_factory("_handle_complex_polygon") as mock_hcp, patch_factory(
         "_handle_subs"
-    ) as mock_hs, patch.object(
-        dt.VideoAnnotation, "get_data", return_value="TEST VIDEO DATA"
+    ) as mock_hs, patch_factory("_handle_properties"
+    ) as mock_hp, patch_factory("_handle_annotation_data"
+    ) as mock_ad, patch.object(
+        dt.VideoAnnotation,
+        "get_data",
+        return_value="TEST VIDEO DATA"
     ):
         from darwin.importer.importer import _get_annotation_data
 
-        mock_hcp.return_value = "TEST DATA_HCP"
+        mock_ad.return_value = "TEST DATA_AD"
         mock_hs.return_value = "TEST DATA_HS"
 
         assert (
@@ -202,7 +206,7 @@ def test__get_annotation_data() -> None:
         )
         assert _get_annotation_data(annotation, "class_id", {}) == "TEST DATA_HS"
 
-        assert mock_hcp.call_count == 1
+        assert mock_ad.call_count == 1
         assert mock_hs.call_count == 1
 
     with patch_factory("_handle_complex_polygon") as mock_hcp, patch_factory(


### PR DESCRIPTION
# Problem
No support for handling properties data in import_annotation endpoint

# Solution
add another function `_handle_properties` which adds `properties` as list of property data (as required by backend)

TODO:
* [ ] Merge #759 to master before merging this PR.

# Changelog
Updates to import endpoint - Handle Properties data