### PR TITLE
[PY-646][external] Resolved precision bug

### DIFF
--- a/darwin/client.py
+++ b/darwin/client.py
@@ -1503,7 +1503,9 @@ class Client:
             team_slug=team_slug or self.default_team,
         )
 
-    def create_property(self, team_slug: Optional[str], params: Union[FullProperty, JSONDict]) -> FullProperty:
+    def create_property(
+        self, team_slug: Optional[str], params: Union[FullProperty, JSONDict]
+    ) -> FullProperty:
         darwin_config = DarwinConfig.from_old(self.config)
         future_client = ClientCore(darwin_config)
 
@@ -1513,7 +1515,9 @@ class Client:
             params=params,
         )
 
-    def update_property(self, team_slug: Optional[str], params: Union[FullProperty, JSONDict]) -> FullProperty:
+    def update_property(
+        self, team_slug: Optional[str], params: Union[FullProperty, JSONDict]
+    ) -> FullProperty:
         darwin_config = DarwinConfig.from_old(self.config)
         future_client = ClientCore(darwin_config)
 

--- a/darwin/torch/dataset.py
+++ b/darwin/torch/dataset.py
@@ -342,6 +342,7 @@ class InstanceSegmentationDataset(LocalDataset):
                 annotation.data[path_key],
                 height=target["height"],
                 width=target["width"],
+                rounding=False,
             )
             # Compute the bbox of the polygon
             x_coords = [s[0::2] for s in sequences]

--- a/darwin/utils/utils.py
+++ b/darwin/utils/utils.py
@@ -1027,7 +1027,9 @@ def _parse_annotators(annotators: List[Dict[str, Any]]) -> List[dt.AnnotationAut
     ]
 
 
-def _parse_properties(properties: List[Dict[str, Any]]) -> Optional[List[SelectedProperty]]:
+def _parse_properties(
+    properties: List[Dict[str, Any]]
+) -> Optional[List[SelectedProperty]]:
     selected_properties = []
     for property in properties:
         selected_properties.append(


### PR DESCRIPTION
# Problem
As described in PY-646, sufficiently small polygons can result in an assertion error due to rounding 4 decimal place floats to integers. This can cause the minimum & maximum x or y coordinates of the enclosing bounding box to be equal, resulting in a "flat" bbox with no area that is therefore invalid

# Solution
Pass the `rounding` arg as `False` to prevent this

# Changelog
Resolved rounding error for very small polygons in Pytorch dataloaders
