### PR TITLE
Config changes required for pydantic model updates

### DIFF
--- a/darwin/future/core/client.py
+++ b/darwin/future/core/client.py
@@ -72,8 +72,8 @@ class DarwinConfig(BaseModel):
             return values
         assert values["default_team"] in values["teams"]
         team = values["default_team"]
-        values["api_key"] = values["teams"][team]['api_key']
-        values["datasets_dir"] = values["teams"][team]['datasets_dir']
+        values["api_key"] = values["teams"][team]["api_key"]
+        values["datasets_dir"] = values["teams"][team]["datasets_dir"]
         return values
 
     @staticmethod

--- a/darwin/future/core/client.py
+++ b/darwin/future/core/client.py
@@ -55,9 +55,8 @@ class DarwinConfig(BaseModel):
         assert check.netloc, "base_url must contain a domain"
         return v
 
-    @model_validator(mode="before")
     @classmethod
-    def remove_global(cls, values: dict) -> dict:
+    def _remove_global(cls, values: dict) -> dict:
         if "global" not in values:
             return values
         global_conf = values["global"]
@@ -68,12 +67,13 @@ class DarwinConfig(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def validate_defaults(cls, values: Any) -> Any:
-        if values["api_key"]:
+        values = cls._remove_global(values)
+        if "api_key" in values:
             return values
         assert values["default_team"] in values["teams"]
         team = values["default_team"]
-        values["api_key"] = values["teams"][team].api_key
-        values["datasets_dir"] = values["teams"][team].datasets_dir
+        values["api_key"] = values["teams"][team]['api_key']
+        values["datasets_dir"] = values["teams"][team]['datasets_dir']
         return values
 
     @staticmethod

--- a/darwin/future/core/datasets/create_dataset.py
+++ b/darwin/future/core/datasets/create_dataset.py
@@ -31,4 +31,4 @@ def create_dataset(api_client: ClientCore, name: str) -> DatasetCore:
         },
     )
     assert isinstance(response, dict)
-    return DatasetCore(**response)
+    return DatasetCore.model_validate(response)

--- a/darwin/future/pydantic_base.py
+++ b/darwin/future/pydantic_base.py
@@ -9,4 +9,4 @@ class DefaultDarwin(BaseModel):
         - objects are passed by reference to prevent unnecesary data copying
     """
 
-    model_config = ConfigDict(validate_assignment=True)
+    model_config = ConfigDict(validate_assignment=True, protected_namespaces=())


### PR DESCRIPTION
# Problem
Some latent issues exists regarding recent pydantic 1.x -> 2.x changes

# Solution
Change the root validator for config, and protected namespaces of default darwin object

# Changelog
Fixed a bug stopping client from instantiating with recent pydantic changes
