### PR TITLE
[DAR-5][internal] Remove CODEOWNERS from darwin-py

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,0 @@
-@owencjones
-@nathanjp91
-@simedw
-@andreaazzini


### PR DESCRIPTION
# Problem
We don't need the CODEOWNERS logic any more.

# Solution
Remove CODEOWNERS file.