### PR TITLE
[Bug] Property import fixed, `options` -> `property_values`

### DIFF
--- a/darwin/datatypes.py
+++ b/darwin/datatypes.py
@@ -410,11 +410,11 @@ class Property:
     # Whether the property is required or not
     required: bool
 
-    # Description of the property
-    description: Optional[str]
-
     # Property options
-    options: list[dict[str, Any]]
+    property_values: list[dict[str, Any]]
+
+    # Description of the property
+    description: Optional[str] = None
 
 
 @dataclass

--- a/darwin/future/data_objects/properties.py
+++ b/darwin/future/data_objects/properties.py
@@ -34,7 +34,7 @@ class PropertyValue(DefaultDarwin):
 
     id: Optional[str] = None
     type: Literal["string"] = "string"
-    value: str
+    value: Optional[str] = None
     color: str = "auto"
 
     @field_validator("color")
@@ -150,4 +150,4 @@ class SelectedProperty(DefaultDarwin):
     frame_index: int
     name: str
     type: Optional[str] = None
-    value: str
+    value: Optional[str] = None

--- a/darwin/future/data_objects/properties.py
+++ b/darwin/future/data_objects/properties.py
@@ -143,11 +143,11 @@ class SelectedProperty(DefaultDarwin):
     Attributes:
         frame_index (int): Frame index of the annotation
         name (str): Name of the property
-        type (str): Type of the property
+        type (str | None): Type of the property (if it exists)
         value (str): Value of the property
     """
 
     frame_index: int
     name: str
-    type: Literal["string"] = "string"
+    type: Optional[str] = None
     value: str

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -418,15 +418,21 @@ def _import_properties(
                         # find property value in m_prop (.v7/metadata.json) options
                         for m_prop_option in m_prop_options:
                             if m_prop_option.get("value") == a_prop.value:
-                                # update property_values with new value
-                                full_property.property_values.append(
-                                    PropertyValue(
-                                        value=m_prop_option.get("value"),  # type: ignore
-                                        color=m_prop_option.get("color"),  # type: ignore
+                                # check if property value exists in property_values
+                                for prop_val in property_values:
+                                    if prop_val.value == a_prop.value:
+                                        break
+                                else:
+                                    # update property_values with new value
+                                    full_property.property_values.append(
+                                        PropertyValue(
+                                            value=m_prop_option.get("value"),  # type: ignore
+                                            color=m_prop_option.get("color"),  # type: ignore
+                                        )
                                     )
-                                )
-                                break
-                        break
+                                    break
+                        else:
+                            break
                 else:
                     property_values = []
                     # find property value in m_prop (.v7/metadata.json) options

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -363,6 +363,8 @@ def _import_properties(
             or annotation.annotation_class.annotation_type
         )
         annotation_name_type = (annotation_name, annotation_type)
+        if annotation_name_type not in annotation_class_ids_map:
+            continue
         annotation_class_id = int(annotation_class_ids_map[annotation_name_type])
         if not annotation.id:
             continue

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -521,7 +521,9 @@ def _import_properties(
     # update annotation_property_map with property ids from created_properties & updated_properties
     for annotation_id, annotation_props in annotation_property_map.items():
         if not annotation_props:
-            annotation = annotation_id_map[annotation_id]
+            annotation = annotation_id_map.get(annotation_id)
+            if not annotation:
+                continue
             frame_index = str(annotation.frame_index)
 
             for prop in (created_properties + updated_properties):

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -432,9 +432,8 @@ def _import_properties(
                                             color=m_prop_option.get("color"),  # type: ignore
                                         )
                                     )
-                                    break
-                        else:
-                            break
+                                break
+                        break
                 else:
                     property_values = []
                     # find property value in m_prop (.v7/metadata.json) options

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -377,7 +377,7 @@ def _import_properties(
             m_prop_type: PropertyType = m_prop.type
 
             # get metadata property options
-            m_prop_options: List[Dict[str, str]] = m_prop.options or []
+            m_prop_options: List[Dict[str, str]] = m_prop.property_values or []
 
             # check if property value is missing for a property that requires a value
             if m_prop.required and not a_prop.value:
@@ -435,13 +435,13 @@ def _import_properties(
                     create_properties.append(full_property)
                 continue
 
-            # check if property value/type is different in m_prop (.v7/metadata.json) options
+            # check if property value is different in m_prop (.v7/metadata.json) options
             for m_prop_option in m_prop_options:
-                if m_prop_option.get("value") == a_prop.value and m_prop_option.get("type") == a_prop.type:
+                if m_prop_option.get("value") == a_prop.value:
                     break
             else:
                 raise ValueError(
-                    f"Annotation: '{annotation_name}' -> Property '{a_prop.value}' ({a_prop.type}) not found in .v7/metadata.json, found: {m_prop.options}"
+                    f"Annotation: '{annotation_name}' -> Property '{a_prop.value}' not found in .v7/metadata.json, found: {m_prop.property_values}"
                 )
 
             # get team property
@@ -449,9 +449,9 @@ def _import_properties(
                 (a_prop.name, annotation_class_id)
             ]
 
-            # check if property value/type is different in t_prop (team) options
+            # check if property value is different in t_prop (team) options
             for t_prop_val in t_prop.property_values or []:
-                if t_prop_val.value == a_prop.value and t_prop_val.type == a_prop.type:
+                if t_prop_val.value == a_prop.value:
                     break
             else:
                 # if it is, update it

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -417,6 +417,9 @@ def _import_properties(
                             full_property.property_values = []
 
                         property_values = full_property.property_values
+                        if a_prop.value is None:
+                            # skip creating property if property value is None
+                            continue
                         # find property value in m_prop (.v7/metadata.json) options
                         for m_prop_option in m_prop_options:
                             if m_prop_option.get("value") == a_prop.value:
@@ -436,6 +439,9 @@ def _import_properties(
                         break
                 else:
                     property_values = []
+                    if a_prop.value is None:
+                        # skip creating property if property value is None
+                        continue
                     # find property value in m_prop (.v7/metadata.json) options
                     for m_prop_option in m_prop_options:
                         if m_prop_option.get("value") == a_prop.value:
@@ -496,7 +502,7 @@ def _import_properties(
                     annotation_class_id=int(annotation_class_id),
                     property_values=[
                         PropertyValue(
-                            value=m_prop_option.get("value"),  # type: ignore
+                            value=a_prop.value,
                             color=m_prop_option.get("color"),  # type: ignore
                         )
                     ],

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -474,6 +474,12 @@ def _import_properties(
                 (a_prop.name, annotation_class_id)
             ]
 
+            if a_prop.value is None:
+                # if property value is None, update annotation_property_map with empty set
+                assert t_prop.id is not None
+                annotation_property_map[annotation_id][str(a_prop.frame_index)][t_prop.id] = set()
+                continue
+
             # check if property value is different in t_prop (team) options
             for t_prop_val in t_prop.property_values or []:
                 if t_prop_val.value == a_prop.value:

--- a/darwin/utils/utils.py
+++ b/darwin/utils/utils.py
@@ -1036,7 +1036,6 @@ def _parse_properties(
             SelectedProperty(
                 frame_index=property.get("frame_index", None),
                 name=property.get("name", None),
-                type=property.get("type", None),
                 value=property.get("value", None),
             )
         )

--- a/tests/darwin/data/metadata.json
+++ b/tests/darwin/data/metadata.json
@@ -14,7 +14,7 @@
                     "name": "Colors",
                     "type": "multi-select",
                     "description": "Some additional description",
-                    "options": [
+                    "property_values": [
                         {
                             "value": "red",
                             "color": "rgba(255, 0, 0, 0)"
@@ -34,7 +34,7 @@
                     "name": "Shape (expanded format)",
                     "description": "Some additional description",
                     "type": "single-select",
-                    "options": [
+                    "property_values": [
                         {
                             "value": "Star",
                             "color": "rgba(0, 0, 0, 0)"

--- a/tests/darwin/data/metadata_nested_properties.json
+++ b/tests/darwin/data/metadata_nested_properties.json
@@ -36,7 +36,7 @@
                     "name": "Colors",
                     "type": "multi-select",
                     "description": "Some additional description",
-                    "options": [
+                    "property_values": [
                         {
                             "value": "red",
                             "color": "rgba(255, 0, 0, 0)",

--- a/tests/darwin/datatypes_test.py
+++ b/tests/darwin/datatypes_test.py
@@ -88,12 +88,12 @@ def assert_annotation_class(annotation, name, type, internal_type=None) -> None:
     ),
 )
 def test_parse_properties(filename, property_class_n, properties_n):
-    manifest_path = Path(__file__).parent / f"data/{filename}"
+    metadata_path = Path(__file__).parent / f"data/{filename}"
 
-    with open(manifest_path) as f:
-        manifest = json.load(f)
+    with open(metadata_path) as f:
+        metadata = json.load(f)
 
-    property_classes = parse_property_classes(manifest)
+    property_classes = parse_property_classes(metadata)
     assert len(property_classes) == property_class_n
     assert [
         len(property_class.properties or []) for property_class in property_classes


### PR DESCRIPTION
# Problem
Import breaks with properties, when parsing 'options' from Property in .v7/metadata.json

# Solution
- `options` is moved to `property_values`
- `type` field is Optional[str] now.

Additional Changes:
- `frame_index` for Video Annotation is fixed (per-annotation)
- fix the annotation-import payload in case of null property-values

# Changelog
[Bug] Property import fixed, `options` -> `property_values`, `frame_index` fixes
