### PR TITLE
[PLA-548][external] Resolved issue with item path filtering

### DIFF
--- a/darwin/dataset/remote_dataset_v2.py
+++ b/darwin/dataset/remote_dataset_v2.py
@@ -272,7 +272,13 @@ class RemoteDatasetV2(RemoteDataset):
                 filters["item_names"] = filters["filenames"]
                 del filters["filenames"]
 
-            for list_type in ["item_names", "statuses", "item_ids", "slot_types"]:
+            for list_type in [
+                "item_names",
+                "statuses",
+                "item_ids",
+                "slot_types",
+                "item_paths",
+            ]:
                 if list_type in filters:
                     if type(filters[list_type]) is list:
                         for value in filters[list_type]:


### PR DESCRIPTION
# Problem
The `fetch_remote_files()` method does not accept `item_paths` as a filter

This led to some confusion as this was shown as being possible as per the following recipe: https://docs.v7labs.com/recipes/list-datasetitems-from-remotedataset-sdk

# Solution
Allow `item_paths` to be passed as a filter to `fetch_remote_files()`

# Changelog
Fixed bug preventing filtering by item path for an SDK function
