### PR TITLE
[PLA-591][external] Fix for pushing subfolder structures on Windows

### DIFF
--- a/darwin/dataset/remote_dataset_v2.py
+++ b/darwin/dataset/remote_dataset_v2.py
@@ -213,7 +213,9 @@ class RemoteDatasetV2(RemoteDataset):
                     if is_relative_to(found_file, source_file)
                 ]
                 if source_files:
-                    local_path = str(found_file.relative_to(source_files[0]).parent)
+                    local_path = str(
+                        found_file.relative_to(source_files[0]).parent.as_posix()
+                    )
             uploading_files.append(
                 LocalFile(
                     found_file,


### PR DESCRIPTION
# Problem
When uploading subfolder structures on Windows, we were partly using local paths involving backslashes, causing situations like these:
![06868fc877461b009f6df2b5f71dc66b](https://github.com/v7labs/darwin-py/assets/124276291/5224594d-e091-47a6-92c0-6785ad1556fb)

This was happening because we were converting `WindowsPath` objects with `str()`

# Solution
Make sure that all local paths are converted to `PosixPath` objects before `str()` conversion. This allows subfolder structures to be uploaded on Windows

# Changelog
Fixed bug preventing the upload of subfolder structures using darwin-py on Windows
