### PR TITLE
[PLA-595] Don't create sub-annotation keyframe for every keyframe when importing annotations

### DIFF
--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -277,7 +277,7 @@ def _resolve_annotation_classes(
 
 def _update_payload_with_properties(
     annotations: List[Dict[str, Unknown]],
-    annotation_id_property_map: Dict[str, Dict[str, Dict[str, Set[str]]]]
+    annotation_id_property_map: Dict[str, Dict[str, Dict[str, Set[str]]]],
 ) -> None:
     """
     Updates the annotations with the properties that were created/updated during the import.
@@ -290,13 +290,16 @@ def _update_payload_with_properties(
 
         if annotation_id_property_map.get(annotation_id):
             _map = {}
-            for _frame_index, _property_map in annotation_id_property_map[annotation_id].items():
+            for _frame_index, _property_map in annotation_id_property_map[
+                annotation_id
+            ].items():
                 _map[_frame_index] = {}
                 for prop_id, prop_val_set in dict(_property_map).items():
                     prop_val_list = list(prop_val_set)
                     _map[_frame_index][prop_id] = prop_val_list
 
             annotation["annotation_properties"] = dict(_map)
+
 
 def _import_properties(
     metadata_path: Union[Path, bool],
@@ -336,9 +339,9 @@ def _import_properties(
     # get team properties -> List[FullProperty]
     team_properties = client.get_team_properties()
     # (property-name, annotation_class_id): FullProperty object
-    team_properties_annotation_lookup: Dict[
-        Tuple[str, Optional[int]], FullProperty
-    ] = {}
+    team_properties_annotation_lookup: Dict[Tuple[str, Optional[int]], FullProperty] = (
+        {}
+    )
     for prop in team_properties:
         team_properties_annotation_lookup[(prop.name, prop.annotation_class_id)] = prop
 
@@ -370,7 +373,9 @@ def _import_properties(
             continue
         annotation_id = annotation.id
         if annotation_id not in annotation_property_map:
-            annotation_property_map[annotation_id] = defaultdict(lambda: defaultdict(set))
+            annotation_property_map[annotation_id] = defaultdict(
+                lambda: defaultdict(set)
+            )
         annotation_id_map[annotation_id] = annotation
 
         # raise error if annotation class not present in metadata
@@ -379,7 +384,7 @@ def _import_properties(
                 f"Annotation: '{annotation_name}' not found in {metadata_path}"
             )
 
-        # loop on annotation properties and check if they exist in metadata & team
+        # loop on annotation properties and check if they exist in metadata & team
         for a_prop in annotation.properties or []:
             a_prop: SelectedProperty
 
@@ -405,13 +410,17 @@ def _import_properties(
                 )
 
             # check if property and annotation class exists in team
-            if (a_prop.name, annotation_class_id) \
-                not in team_properties_annotation_lookup:
+            if (
+                a_prop.name,
+                annotation_class_id,
+            ) not in team_properties_annotation_lookup:
 
                 # check if fullproperty exists in create_properties
                 for full_property in create_properties:
-                    if full_property.name == a_prop.name and \
-                        full_property.annotation_class_id == annotation_class_id:
+                    if (
+                        full_property.name == a_prop.name
+                        and full_property.annotation_class_id == annotation_class_id
+                    ):
                         # make sure property_values is not None
                         if full_property.property_values is None:
                             full_property.property_values = []
@@ -457,7 +466,8 @@ def _import_properties(
                         name=a_prop.name,
                         type=m_prop_type,  # type from .v7/metadata.json
                         required=m_prop.required,  # required from .v7/metadata.json
-                        description=m_prop.description or "property-created-during-annotation-import",
+                        description=m_prop.description
+                        or "property-created-during-annotation-import",
                         slug=client.default_team,
                         annotation_class_id=int(annotation_class_id),
                         property_values=property_values,
@@ -483,7 +493,9 @@ def _import_properties(
             if a_prop.value is None:
                 # if property value is None, update annotation_property_map with empty set
                 assert t_prop.id is not None
-                annotation_property_map[annotation_id][str(a_prop.frame_index)][t_prop.id] = set()
+                annotation_property_map[annotation_id][str(a_prop.frame_index)][
+                    t_prop.id
+                ] = set()
                 continue
 
             # check if property value is different in t_prop (team) options
@@ -497,7 +509,8 @@ def _import_properties(
                     name=a_prop.name,
                     type=m_prop_type,
                     required=m_prop.required,
-                    description=m_prop.description or "property-updated-during-annotation-import",
+                    description=m_prop.description
+                    or "property-updated-during-annotation-import",
                     slug=client.default_team,
                     annotation_class_id=int(annotation_class_id),
                     property_values=[
@@ -512,7 +525,9 @@ def _import_properties(
 
             assert t_prop.id is not None
             assert t_prop_val.id is not None
-            annotation_property_map[annotation_id][str(a_prop.frame_index)][t_prop.id].add(t_prop_val.id)
+            annotation_property_map[annotation_id][str(a_prop.frame_index)][
+                t_prop.id
+            ].add(t_prop_val.id)
 
     console = Console(theme=_console_theme())
 
@@ -522,9 +537,11 @@ def _import_properties(
         for full_property in create_properties:
             console.print(
                 f"Creating property {full_property.name} ({full_property.type})",
-                style="info"
+                style="info",
             )
-            prop = client.create_property(team_slug=full_property.slug, params=full_property)
+            prop = client.create_property(
+                team_slug=full_property.slug, params=full_property
+            )
             created_properties.append(prop)
 
     updated_properties = []
@@ -533,9 +550,11 @@ def _import_properties(
         for full_property in update_properties:
             console.print(
                 f"Updating property {full_property.name} ({full_property.type})",
-                style="info"
+                style="info",
             )
-            prop = client.update_property(team_slug=full_property.slug, params=full_property)
+            prop = client.update_property(
+                team_slug=full_property.slug, params=full_property
+            )
             updated_properties.append(prop)
 
     # update annotation_property_map with property ids from created_properties & updated_properties
@@ -547,19 +566,23 @@ def _import_properties(
         for a_prop in annotation.properties or []:
             frame_index = str(a_prop.frame_index)
 
-            for prop in (created_properties + updated_properties):
+            for prop in created_properties + updated_properties:
                 if prop.name == a_prop.name:
                     if a_prop.value is None:
-                        if not annotation_property_map[annotation_id][frame_index][prop.id]:
-                            annotation_property_map[annotation_id][frame_index][prop.id] = set()
+                        if not annotation_property_map[annotation_id][frame_index][
+                            prop.id
+                        ]:
+                            annotation_property_map[annotation_id][frame_index][
+                                prop.id
+                            ] = set()
                             break
 
                     # find the property-id and property-value-id in the response
                     for prop_val in prop.property_values or []:
                         if prop_val.value == a_prop.value:
-                            annotation_property_map[annotation_id][frame_index][prop.id].add(
-                                prop_val.id
-                            )
+                            annotation_property_map[annotation_id][frame_index][
+                                prop.id
+                            ].add(prop_val.id)
                             break
                     break
 
@@ -815,9 +838,9 @@ def import_annotations(  # noqa: C901
 
     # Need to re parse the files since we didn't save the annotations in memory
     for local_path in set(local_file.path for local_file in local_files):  # noqa: C401
-        imported_files: Union[
-            List[dt.AnnotationFile], dt.AnnotationFile, None
-        ] = importer(local_path)
+        imported_files: Union[List[dt.AnnotationFile], dt.AnnotationFile, None] = (
+            importer(local_path)
+        )
         if imported_files is None:
             parsed_files = []
         elif not isinstance(imported_files, List):
@@ -1000,18 +1023,25 @@ def _handle_video_annotation_subs(annotation: dt.VideoAnnotation):
     """
     Remove duplicate sub-annotations from the VideoAnnotation.annotation(s) to be imported.
     """
-    last_sub_type, last_sub_data = None, None
+    last_subs = None
     for _, _annotation in annotation.frames.items():
         _annotation: dt.Annotation
         subs = []
         for sub in _annotation.subs:
-            if last_sub_type == sub.annotation_type and last_sub_data == sub.data:
+            if last_subs is not None and all(
+                any(
+                    last_sub.annotation_type == sub.annotation_type
+                    and last_sub.data == sub.data
+                    for last_sub in last_subs
+                )
+                for sub in _annotation.subs
+            ):
                 # drop sub-annotation whenever we know it didn't change since last one
                 # which likely wouldn't create on backend side sub-annotation keyframe.
                 # this is a workaround for the backend not handling duplicate sub-annotations.
                 continue
-            last_sub_type, last_sub_data = sub.annotation_type, sub.data
             subs.append(sub)
+        last_subs = _annotation.subs
         _annotation.subs = subs
 
 
@@ -1211,7 +1241,9 @@ def _import_annotations(
         # Insert the default slot name if not available in the import source
         annotation = _handle_slot_names(annotation, dataset.version, default_slot_name)
 
-        annotation_class_ids_map[(annotation_class.name, annotation_type)] = annotation_class_id
+        annotation_class_ids_map[(annotation_class.name, annotation_type)] = (
+            annotation_class_id
+        )
         serial_obj = {
             "annotation_class_id": annotation_class_id,
             "data": data,
@@ -1232,10 +1264,7 @@ def _import_annotations(
         annotations,  # type: ignore
         annotation_class_ids_map,
     )
-    _update_payload_with_properties(
-        serialized_annotations,
-        annotation_id_property_map
-    )
+    _update_payload_with_properties(serialized_annotations, annotation_id_property_map)
 
     payload: dt.DictFreeForm = {"annotations": serialized_annotations}
     payload["overwrite"] = _get_overwrite_value(append)

--- a/e2e_tests/cli/convert/test_convert.py
+++ b/e2e_tests/cli/convert/test_convert.py
@@ -61,7 +61,11 @@ class TestExportCli:
                     reason="File paths are different on Windows, leading to test failure",
                 ),
             ),
-            ("semantic_mask", data_path / "semantic_mask/from", data_path / "semantic_mask/to"),
+            (
+                "semantic_mask",
+                data_path / "semantic_mask/from",
+                data_path / "semantic_mask/to",
+            ),
         ],
     )
     def test_darwin_convert(

--- a/tests/darwin/importer/importer_test.py
+++ b/tests/darwin/importer/importer_test.py
@@ -286,7 +286,9 @@ def test_get_overwrite_value() -> None:
 
 @pytest.fixture
 def raster_layer_annotations():
-    annotation_raster_layer_data = Path(__file__).parent.parent / f"data/annotation_raster_layer_data.json"
+    annotation_raster_layer_data = (
+        Path(__file__).parent.parent / f"data/annotation_raster_layer_data.json"
+    )
     with open(annotation_raster_layer_data) as f:
         data = json.load(f)
 
@@ -298,94 +300,97 @@ def raster_layer_annotations():
             ),
             data=data,
             subs=[],
-            slot_names=['0'],
+            slot_names=["0"],
             annotators=None,
             reviewers=None,
-            id='2ef45c58-9556-4a08-b561-61680fd3ba8e',
-            properties=None
+            id="2ef45c58-9556-4a08-b561-61680fd3ba8e",
+            properties=None,
         ),
         dt.Annotation(
             annotation_class=dt.AnnotationClass(
-                name='CROP:CORN',
-                annotation_type='mask',
+                name="CROP:CORN",
+                annotation_type="mask",
             ),
-            data={'sparse_rle': None},
+            data={"sparse_rle": None},
             subs=[],
-            slot_names=['0'],
+            slot_names=["0"],
             annotators=None,
             reviewers=None,
-            id='8236a56f-f51b-405e-be02-5c23e0954037',
-            properties=None
+            id="8236a56f-f51b-405e-be02-5c23e0954037",
+            properties=None,
         ),
         dt.Annotation(
             annotation_class=dt.AnnotationClass(
-                name='CROP:SOYBEAN',
-                annotation_type='mask',
+                name="CROP:SOYBEAN",
+                annotation_type="mask",
             ),
-            data={'sparse_rle': None},
+            data={"sparse_rle": None},
             subs=[],
-            slot_names=['0'],
+            slot_names=["0"],
             annotators=None,
             reviewers=None,
-            id='0835d3c0-2c79-4066-8bd7-41de8bdb695b',
-            properties=None),
-        dt.Annotation(
-            annotation_class=dt.AnnotationClass(
-                name='WEED:UNKNOWN',
-                annotation_type='mask',
-            ),
-            data={'sparse_rle': None},
-            subs=[],
-            slot_names=['0'],
-            annotators=None,
-            reviewers=None,
-            id='e1beb46e-1343-41ee-a856-6659b89ccd46',
-            properties=None
+            id="0835d3c0-2c79-4066-8bd7-41de8bdb695b",
+            properties=None,
         ),
         dt.Annotation(
             annotation_class=dt.AnnotationClass(
-                name='WEED:GRASS',
-                annotation_type='mask',
+                name="WEED:UNKNOWN",
+                annotation_type="mask",
             ),
-            data={'sparse_rle': None},
+            data={"sparse_rle": None},
             subs=[],
-            slot_names=['0'],
+            slot_names=["0"],
             annotators=None,
             reviewers=None,
-            id='954bbd3e-743f-49b8-b9db-f27e6f7b4ba7',
-            properties=None
+            id="e1beb46e-1343-41ee-a856-6659b89ccd46",
+            properties=None,
         ),
         dt.Annotation(
             annotation_class=dt.AnnotationClass(
-                name='WEED:BROADLEAF',
-                annotation_type='mask',
+                name="WEED:GRASS",
+                annotation_type="mask",
             ),
-            data={'sparse_rle': None},
+            data={"sparse_rle": None},
             subs=[],
-            slot_names=['0'],
+            slot_names=["0"],
             annotators=None,
             reviewers=None,
-            id='1a32e512-b135-4307-8aff-46e1ba50f421',
-            properties=None
+            id="954bbd3e-743f-49b8-b9db-f27e6f7b4ba7",
+            properties=None,
         ),
         dt.Annotation(
             annotation_class=dt.AnnotationClass(
-                name='OBSCURITY:DIRTY_LENS',
-                annotation_type='mask'),
-            data={'sparse_rle': None},
+                name="WEED:BROADLEAF",
+                annotation_type="mask",
+            ),
+            data={"sparse_rle": None},
             subs=[],
-            slot_names=['0'],
+            slot_names=["0"],
             annotators=None,
             reviewers=None,
-            id='20679c9a-4c6e-4ff5-8e41-e4b2e3437c3d',
-            properties=None
+            id="1a32e512-b135-4307-8aff-46e1ba50f421",
+            properties=None,
+        ),
+        dt.Annotation(
+            annotation_class=dt.AnnotationClass(
+                name="OBSCURITY:DIRTY_LENS", annotation_type="mask"
+            ),
+            data={"sparse_rle": None},
+            subs=[],
+            slot_names=["0"],
+            annotators=None,
+            reviewers=None,
+            id="20679c9a-4c6e-4ff5-8e41-e4b2e3437c3d",
+            properties=None,
         ),
     ]
 
 
 @pytest.fixture
 def raster_layer_video_annotations():
-    annotation_raster_layer_data = Path(__file__).parent.parent / f"data/video_annotation_raster_layer_data.json"
+    annotation_raster_layer_data = (
+        Path(__file__).parent.parent / f"data/video_annotation_raster_layer_data.json"
+    )
     with open(annotation_raster_layer_data) as f:
         data = json.load(f)
 
@@ -398,55 +403,55 @@ def raster_layer_video_annotations():
             frames={
                 0: dt.Annotation(
                     annotation_class=dt.AnnotationClass(
-                        name='__raster_layer__',
-                        annotation_type='raster_layer',
+                        name="__raster_layer__",
+                        annotation_type="raster_layer",
                     ),
                     data=data,
                     subs=[],
-                    slot_names=['0'],
+                    slot_names=["0"],
                     annotators=None,
                     reviewers=None,
-                    id='220588d7-559d-4797-a465-c0b03fe44a5e',
+                    id="220588d7-559d-4797-a465-c0b03fe44a5e",
                     properties=None,
                 ),
             },
             keyframes={0: True},
             segments=[[0, 1]],
             interpolated=False,
-            slot_names=['0'],
+            slot_names=["0"],
             annotators=None,
-            reviewers=None, 
-            id='220588d7-559d-4797-a465-c0b03fe44a5e',
+            reviewers=None,
+            id="220588d7-559d-4797-a465-c0b03fe44a5e",
             properties=None,
         ),
         dt.VideoAnnotation(
             annotation_class=dt.AnnotationClass(
-                name='BAC_mask',
-                annotation_type='mask',
+                name="BAC_mask",
+                annotation_type="mask",
             ),
             frames={
                 0: dt.Annotation(
                     annotation_class=dt.AnnotationClass(
-                        name='BAC_mask',
-                        annotation_type='mask',
+                        name="BAC_mask",
+                        annotation_type="mask",
                     ),
                     data={},
                     subs=[],
                     slot_names=[],
                     annotators=None,
                     reviewers=None,
-                    id='ef002bce-99cc-4d9e-bab0-5ef72634ce75',
-                    properties=None
+                    id="ef002bce-99cc-4d9e-bab0-5ef72634ce75",
+                    properties=None,
                 )
             },
             keyframes={0: True},
             segments=[[0, 1]],
             interpolated=False,
-            slot_names=['0'],
+            slot_names=["0"],
             annotators=None,
             reviewers=None,
-            id='ef002bce-99cc-4d9e-bab0-5ef72634ce75',
-            properties=None
+            id="ef002bce-99cc-4d9e-bab0-5ef72634ce75",
+            properties=None,
         ),
     ]
 
@@ -457,16 +462,23 @@ def test__parse_empty_masks(raster_layer_annotations) -> None:
     rl_dense_rle_ids_frames = None
     for annotation in annotations:
         _parse_empty_masks(annotation, rl, rl_dense_rle_ids, rl_dense_rle_ids_frames)
-    assert rl.data['mask_annotation_ids_mapping'] == {'0835d3c0-2c79-4066-8bd7-41de8bdb695b': 2}
+    assert rl.data["mask_annotation_ids_mapping"] == {
+        "0835d3c0-2c79-4066-8bd7-41de8bdb695b": 2
+    }
 
 
 def test__parse_empty_masks_video(raster_layer_video_annotations) -> None:
-    rl, annotations = raster_layer_video_annotations[0], raster_layer_video_annotations[1:]
+    rl, annotations = (
+        raster_layer_video_annotations[0],
+        raster_layer_video_annotations[1:],
+    )
     rl_dense_rle_ids = None
     rl_dense_rle_ids_frames = None
     for annotation in annotations:
         _parse_empty_masks(annotation, rl, rl_dense_rle_ids, rl_dense_rle_ids_frames)
-    assert rl.frames[0].data['mask_annotation_ids_mapping'] == {'ef002bce-99cc-4d9e-bab0-5ef72634ce75': 1}
+    assert rl.frames[0].data["mask_annotation_ids_mapping"] == {
+        "ef002bce-99cc-4d9e-bab0-5ef72634ce75": 1
+    }
 
 
 def test__import_annotations() -> None:

--- a/tests/darwin/path_utils_test.py
+++ b/tests/darwin/path_utils_test.py
@@ -90,6 +90,8 @@ def test_is_properties_enabled_v7(filename, expected_bool):
         shutil.copy(metadata_path, tmpdir_v7)
 
         if expected_bool:
-            assert is_properties_enabled(tmpdir, filename=filename) == tmpdir_v7 / filename
+            assert (
+                is_properties_enabled(tmpdir, filename=filename) == tmpdir_v7 / filename
+            )
         else:
             assert is_properties_enabled(tmpdir, filename=filename) == expected_bool


### PR DESCRIPTION
# Problem
As of now, when importing annotations, we automatically make every keyframe a "sub-annotation keyframe" by marking that the sub-annotation has changed.

# Solution
> during import, between D-Py and backend we still use this format which include both annotation and sub-annotation data at the same time, for each "keyframe". It would be kinda-possible to drop sub-annotation data from the request whenever we know it didn't change since last one, which likely wouldn't create on backend side sub-annotation keyframe.

# Changelog
Don't create sub-annotation keyframe for every keyframe when importing annotations
