### PR TITLE
[PLA-640] Updating metadata property values while importing annotations

### DIFF
--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -578,10 +578,11 @@ def _import_properties(
             continue
 
         # get metadata property values
-        m_prop_values = {}
-        for m_prop_val in m_prop.property_values or []:
-            if m_prop_val["value"]:
-                m_prop_values[m_prop_val["value"]] = m_prop_val
+        m_prop_values = {
+            m_prop_val["value"]: m_prop_val
+            for m_prop_val in m_prop.property_values or []
+            if m_prop_val["value"]
+        }
 
         # get team property
         t_prop: FullProperty = team_properties_annotation_lookup[
@@ -598,8 +599,8 @@ def _import_properties(
         if extra_values:
             extra_property_values = [
                 PropertyValue(
-                    value=m_prop_values[extra_value]["value"],
-                    color=m_prop_values[extra_value].get("color"),
+                    value=m_prop_values[extra_value].get("value"),  # type: ignore
+                    color=m_prop_values[extra_value].get("color"),  # type: ignore
                 )
                 for extra_value in extra_values
             ]


### PR DESCRIPTION
# Problem
While importing annotations with properties, property-values which are not in annotation file but present in metadata.json are not created/updated in annotation-property.

# Solution

Adding additional logic after annotation-properties are created/updated on the server. Logic is:
1. get the latest team-properties
2. only go ahead in the case when annotation-properties are present in team-properties
3. _build metadata-property-values set_
4. _build team-property-values set_
5. extra values: _diff b/w metadata & team property-values set_
6. update property with extra-property-values!

# Changelog
Updating additional metadata property values while importing annotations
