### PR TITLE
[PLA-672][external] Support for importing simple_table annotations

### DIFF
--- a/darwin/datatypes.py
+++ b/darwin/datatypes.py
@@ -998,6 +998,51 @@ def make_table(
     )
 
 
+def make_simple_table(
+    class_name: str,
+    bounding_box: BoundingBox,
+    col_offsets: List[float],
+    row_offsets: List[float],
+    subs: Optional[List[SubAnnotation]] = None,
+    slot_names: Optional[List[str]] = None,
+) -> Annotation:
+    """
+    Creates and returns a simple table annotation.
+
+    Parameters
+    ----------
+    class_name : str
+        The name of the class for this ``Annotation``.
+
+    bounding_box : BoundingBox
+        Bounding box that wraps around the table.
+
+    col_offsets : List[float]
+        List of floats representing the column offsets.
+
+    row_offsets : List[float]
+        List of floats representing the row offsets.
+
+    subs : Optional[List[SubAnnotation]], default: None
+        List of ``SubAnnotation``\\s for this ``Annotation``.
+
+    Returns
+    -------
+    Annotation
+        A simple table ``Annotation``.
+    """
+    return Annotation(
+        AnnotationClass(class_name, "simple_table"),
+        {
+            "bounding_box": bounding_box,
+            "col_offsets": col_offsets,
+            "row_offsets": row_offsets,
+        },
+        subs or [],
+        slot_names=slot_names or [],
+    )
+
+
 def make_string(
     class_name: str,
     sources: List[Dict[str, UnknownType]],

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -92,6 +92,7 @@ def build_main_annotations_lookup_table(
         "tag",
         "string",
         "table",
+        "simple_table",
         "graph",
         "mask",
         "raster_layer",
@@ -280,7 +281,9 @@ def _get_team_properties_annotation_lookup(client):
     team_properties = client.get_team_properties()
 
     # (property-name, annotation_class_id): FullProperty object
-    team_properties_annotation_lookup: Dict[Tuple[str, Optional[int]], FullProperty] = {}
+    team_properties_annotation_lookup: Dict[Tuple[str, Optional[int]], FullProperty] = (
+        {}
+    )
     for prop in team_properties:
         team_properties_annotation_lookup[(prop.name, prop.annotation_class_id)] = prop
 
@@ -1295,9 +1298,9 @@ def _import_annotations(
         # Insert the default slot name if not available in the import source
         annotation = _handle_slot_names(annotation, dataset.version, default_slot_name)
 
-        annotation_class_ids_map[
-            (annotation_class.name, annotation_type)
-        ] = annotation_class_id
+        annotation_class_ids_map[(annotation_class.name, annotation_type)] = (
+            annotation_class_id
+        )
         serial_obj = {
             "annotation_class_id": annotation_class_id,
             "data": data,

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -281,9 +281,9 @@ def _get_team_properties_annotation_lookup(client):
     team_properties = client.get_team_properties()
 
     # (property-name, annotation_class_id): FullProperty object
-    team_properties_annotation_lookup: Dict[Tuple[str, Optional[int]], FullProperty] = (
-        {}
-    )
+    team_properties_annotation_lookup: Dict[
+        Tuple[str, Optional[int]], FullProperty
+    ] = {}
     for prop in team_properties:
         team_properties_annotation_lookup[(prop.name, prop.annotation_class_id)] = prop
 
@@ -428,7 +428,6 @@ def _import_properties(
                 a_prop.name,
                 annotation_class_id,
             ) not in team_properties_annotation_lookup:
-
                 # check if fullproperty exists in create_properties
                 for full_property in create_properties:
                     if (
@@ -896,9 +895,9 @@ def import_annotations(  # noqa: C901
 
     # Need to re parse the files since we didn't save the annotations in memory
     for local_path in set(local_file.path for local_file in local_files):  # noqa: C401
-        imported_files: Union[List[dt.AnnotationFile], dt.AnnotationFile, None] = (
-            importer(local_path)
-        )
+        imported_files: Union[
+            List[dt.AnnotationFile], dt.AnnotationFile, None
+        ] = importer(local_path)
         if imported_files is None:
             parsed_files = []
         elif not isinstance(imported_files, List):
@@ -1298,9 +1297,9 @@ def _import_annotations(
         # Insert the default slot name if not available in the import source
         annotation = _handle_slot_names(annotation, dataset.version, default_slot_name)
 
-        annotation_class_ids_map[(annotation_class.name, annotation_type)] = (
-            annotation_class_id
-        )
+        annotation_class_ids_map[
+            (annotation_class.name, annotation_type)
+        ] = annotation_class_id
         serial_obj = {
             "annotation_class_id": annotation_class_id,
             "data": data,

--- a/darwin/utils/utils.py
+++ b/darwin/utils/utils.py
@@ -823,6 +823,14 @@ def _parse_darwin_annotation(annotation: Dict[str, Any]) -> Optional[dt.Annotati
             annotation["table"]["cells"],
             slot_names=slot_names,
         )
+    elif "simple_table" in annotation:
+        main_annotation = dt.make_simple_table(
+            name,
+            annotation["simple_table"]["bounding_box"],
+            annotation["simple_table"]["col_offsets"],
+            annotation["simple_table"]["row_offsets"],
+            slot_names=slot_names,
+        )
     elif "string" in annotation:
         main_annotation = dt.make_string(
             name, annotation["string"]["sources"], slot_names=slot_names


### PR DESCRIPTION
# Problem
The optional `simple_table` annotation type can be exported, but not imported with darwin-py. This is because darwin-py doesn't have an annotation constructor for this type

# Solution
Added a `make_simple_table()` function 

# Changelog
Added support to darwin-py for importing simple_table annotations