### PR TITLE
[DAR-991][Internal] Add support of hidden_areas to darwin py importer

### DIFF
--- a/darwin/datatypes.py
+++ b/darwin/datatypes.py
@@ -53,6 +53,7 @@ Node = Dict[str, UnknownType]
 EllipseData = Dict[str, Union[float, Point]]
 CuboidData = Dict[str, Dict[str, float]]
 Segment = List[int]
+HiddenArea = List[int]
 
 DarwinVersionNumber = Tuple[int, int, int]
 
@@ -276,6 +277,9 @@ class VideoAnnotation:
     # Properties of this annotation.
     properties: Optional[list[SelectedProperty]] = None
 
+    #: A list of ``HiddenArea``\'s.
+    hidden_areas: List[HiddenArea] = field(default_factory=list)
+
     def get_data(
         self,
         only_keyframes: bool = True,
@@ -334,6 +338,7 @@ class VideoAnnotation:
             },
             "segments": self.segments,
             "interpolated": self.interpolated,
+            "hidden_areas": self.hidden_areas,
         }
 
         return output
@@ -1283,6 +1288,7 @@ def make_video_annotation(
     interpolated: bool,
     slot_names: List[str],
     properties: Optional[list[SelectedProperty]] = None,
+    hidden_areas: Optional[List[HiddenArea]] = None,
 ) -> VideoAnnotation:
     """
     Creates and returns a ``VideoAnnotation``.
@@ -1320,6 +1326,7 @@ def make_video_annotation(
         interpolated,
         slot_names=slot_names or [],
         properties=properties,
+        hidden_areas=hidden_areas or [],
     )
 
 

--- a/darwin/utils/utils.py
+++ b/darwin/utils/utils.py
@@ -909,6 +909,7 @@ def _parse_darwin_video_annotation(annotation: dict) -> Optional[dt.VideoAnnotat
         annotation.get("interpolated", False),
         slot_names=parse_slot_names(annotation),
         properties=_parse_properties(annotation.get("properties", [])),
+        hidden_areas=annotation.get("hidden_areas", []),
     )
 
     if "id" in annotation:

--- a/tests/darwin/dataset/remote_dataset_test.py
+++ b/tests/darwin/dataset/remote_dataset_test.py
@@ -105,6 +105,7 @@ def annotation_content() -> Dict[str, Any]:
                 "name": "test_class",
                 "slot_names": ["0"],
                 "ranges": [[0, 3]],
+                "hidden_areas": [[1, 2]],
                 "id": "test_id",
                 "frames": {
                     "0": {

--- a/tests/darwin/utils_test.py
+++ b/tests/darwin/utils_test.py
@@ -221,6 +221,12 @@ class TestParseDarwinJson:
                             3,
                             46
                         ]
+                    ],
+                    "hidden_areas": [
+                        [
+                            5,
+                            8
+                        ]
                     ]
                 }
             ]
@@ -294,6 +300,7 @@ class TestParseDarwinJson:
                 },
                 keyframes={3: True},
                 segments=[[3, 46]],
+                hidden_areas=[[5, 8]],
                 interpolated=True,
             )
         ]


### PR DESCRIPTION
# Problem
We added new field to the video annotation - `hidden_areas`.

# Solution
Add logic which takes the field into account during import,
