### PR TITLE
[PLA-702] Add dependabot for pip and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,10 +10,16 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "github-actions-updates"
+
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    ignore:
+      # For all packages, ignore all major updates
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     reviewers:
       - "saurbhc"
       - "JBWilkie"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "saurbhc"
+      - "JBWilkie"
+    open-pull-requests-limit: 5
+    labels:
+      - "github-actions-updates"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "saurbhc"
+      - "JBWilkie"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"


### PR DESCRIPTION
# Problem
running tests for #786, I noticed out of date github-actions.

# Solution
I've added a dependabot config(s) to make sure we stay relatively up to date.
  - for github-actions to run weekly
  - for pip to run weekly and ignore major version updates (as it could be breaking changes)

# Changelog
Add dependabot for pip and GitHub Actions
