### PR TITLE
[PLA-753][External] Combine the register & register_multi_slotted functions

### DIFF
--- a/darwin/client.py
+++ b/darwin/client.py
@@ -1063,7 +1063,7 @@ class Client:
 
     def get_external_storage(
         self, team_slug: Optional[str] = None, name: Optional[str] = None
-    ) -> Optional[ObjectStore]:
+    ) -> ObjectStore:
         """
         Get an external storage connection by name.
 

--- a/darwin/dataset/remote_dataset_v2.py
+++ b/darwin/dataset/remote_dataset_v2.py
@@ -612,35 +612,35 @@ class RemoteDatasetV2(RemoteDataset):
         if multi_slotted:
             try:
                 StorageKeyDictModel(storage_keys=storage_keys)  # type: ignore
-                results = self.register_multi_slotted(
-                    object_store,
-                    storage_keys,  # type: ignore
-                    fps,
-                    multi_planar_view,
-                    preserve_folders,
-                )
-                return results
             except ValidationError as e:
                 print(
                     f"Error validating storage keys: {e}\n\nPlease make sure your storage keys are a list of strings"
                 )
                 raise e
+            results = self.register_multi_slotted(
+                object_store,
+                storage_keys,  # type: ignore
+                fps,
+                multi_planar_view,
+                preserve_folders,
+            )
+            return results
         else:
             try:
                 StorageKeyListModel(storage_keys=storage_keys)  # type: ignore
-                results = self.register_single_slotted(
-                    object_store,
-                    storage_keys,  # type: ignore
-                    fps,
-                    multi_planar_view,
-                    preserve_folders,
-                )
-                return results
             except ValidationError as e:
                 print(
                     f"Error validating storage keys: {e}\n\nPlease make sure your storage keys are a dictionary with keys as item names and values as lists of storage keys"
                 )
                 raise e
+            results = self.register_single_slotted(
+                object_store,
+                storage_keys,  # type: ignore
+                fps,
+                multi_planar_view,
+                preserve_folders,
+            )
+            return results
 
     def register_single_slotted(
         self,

--- a/darwin/dataset/utils.py
+++ b/darwin/dataset/utils.py
@@ -10,6 +10,8 @@ from rich.live import Live
 from rich.progress import ProgressBar, track
 
 import darwin.datatypes as dt
+
+# from darwin.dataset.remote_dataset_v2 import RemoteDatasetV2
 from darwin.datatypes import PathLike
 from darwin.exceptions import NotFound
 from darwin.importer.formats.darwin import parse_path

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -395,7 +395,6 @@ def _import_properties(
 
             # raise error if annotation-property not present in metadata
             if (annotation_name, a_prop.name) not in metadata_cls_prop_lookup:
-
                 # check if they are present in team properties
                 if (
                     a_prop.name,

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -282,9 +282,9 @@ def _get_team_properties_annotation_lookup(client):
     team_properties = client.get_team_properties()
 
     # (property-name, annotation_class_id): FullProperty object
-    team_properties_annotation_lookup: Dict[Tuple[str, Optional[int]], FullProperty] = (
-        {}
-    )
+    team_properties_annotation_lookup: Dict[
+        Tuple[str, Optional[int]], FullProperty
+    ] = {}
     for prop in team_properties:
         team_properties_annotation_lookup[(prop.name, prop.annotation_class_id)] = prop
 
@@ -397,7 +397,10 @@ def _import_properties(
             if (annotation_name, a_prop.name) not in metadata_cls_prop_lookup:
 
                 # check if they are present in team properties
-                if (a_prop.name, annotation_class_id) in team_properties_annotation_lookup:
+                if (
+                    a_prop.name,
+                    annotation_class_id,
+                ) in team_properties_annotation_lookup:
                     # get team property
                     t_prop: FullProperty = team_properties_annotation_lookup[
                         (a_prop.name, annotation_class_id)
@@ -411,7 +414,7 @@ def _import_properties(
                         ] = set()
                         continue
 
-                    # get team property value
+                    # get team property value
                     t_prop_val = None
                     for prop_val in t_prop.property_values or []:
                         if prop_val.value == a_prop.value:
@@ -921,9 +924,9 @@ def import_annotations(  # noqa: C901
 
     # Need to re parse the files since we didn't save the annotations in memory
     for local_path in set(local_file.path for local_file in local_files):  # noqa: C401
-        imported_files: Union[List[dt.AnnotationFile], dt.AnnotationFile, None] = (
-            importer(local_path)
-        )
+        imported_files: Union[
+            List[dt.AnnotationFile], dt.AnnotationFile, None
+        ] = importer(local_path)
         if imported_files is None:
             parsed_files = []
         elif not isinstance(imported_files, List):
@@ -1323,9 +1326,9 @@ def _import_annotations(
         # Insert the default slot name if not available in the import source
         annotation = _handle_slot_names(annotation, dataset.version, default_slot_name)
 
-        annotation_class_ids_map[(annotation_class.name, annotation_type)] = (
-            annotation_class_id
-        )
+        annotation_class_ids_map[
+            (annotation_class.name, annotation_type)
+        ] = annotation_class_id
         serial_obj = {
             "annotation_class_id": annotation_class_id,
             "data": data,

--- a/tests/darwin/dataset/remote_dataset_test.py
+++ b/tests/darwin/dataset/remote_dataset_test.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import orjson as json
 import pytest
 import responses
+from pydantic import ValidationError
 
 from darwin.client import Client
 from darwin.config import Config
@@ -960,8 +961,8 @@ class TestRegisterMultiSlotted:
     def test_raises_if_storage_keys_not_dictionary(
         self, remote_dataset: RemoteDatasetV2
     ):
-        with pytest.raises(ValueError):
-            remote_dataset.register_multi_slotted(
+        with pytest.raises(ValidationError):
+            remote_dataset.register(
                 ObjectStore(
                     name="test",
                     prefix="test_prefix",
@@ -970,11 +971,12 @@ class TestRegisterMultiSlotted:
                     default=True,
                 ),
                 {"item1": [1, 2, 3]},
+                multi_slotted=True,
             )
 
     def test_raises_if_unsupported_file_type(self, remote_dataset: RemoteDatasetV2):
         with pytest.raises(TypeError):
-            remote_dataset.register_multi_slotted(
+            remote_dataset.register(
                 ObjectStore(
                     name="test",
                     prefix="test_prefix",
@@ -983,6 +985,7 @@ class TestRegisterMultiSlotted:
                     default=True,
                 ),
                 {"item1": ["unsupported_file.xyz"]},
+                multi_slotted=True,
             )
 
     @responses.activate
@@ -996,7 +999,7 @@ class TestRegisterMultiSlotted:
             },
             status=200,
         )
-        result = remote_dataset.register_multi_slotted(
+        result = remote_dataset.register(
             ObjectStore(
                 name="test",
                 prefix="test_prefix",
@@ -1005,6 +1008,7 @@ class TestRegisterMultiSlotted:
                 default=True,
             ),
             {"item1": ["test.jpg"]},
+            multi_slotted=True,
         )
         assert len(result["registered"]) == 1
         assert len(result["blocked"]) == 0
@@ -1022,7 +1026,7 @@ class TestRegisterMultiSlotted:
             },
             status=200,
         )
-        remote_dataset.register_multi_slotted(
+        remote_dataset.register(
             ObjectStore(
                 name="test",
                 prefix="test_prefix",
@@ -1031,4 +1035,5 @@ class TestRegisterMultiSlotted:
                 default=True,
             ),
             {"item1": ["test.jpg"]},
+            multi_slotted=True,
         )


### PR DESCRIPTION
# Problem
Instead of 2 client-facing registration functions, it's better UX to have a single function which takes an optional `multi_slotted` flag

# Solution
Combine `register()` & `register_multi_slotted()` functions into a single `register()` function with an optional `multi_slotted` argument

# Changelog
Improved UX for external storage registration with darwin-py