### PR TITLE
[DAR-1654][External] Updated dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,26 +3,34 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - '*'
     reviewers:
       - "saurbhc"
       - "JBWilkie"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
     labels:
       - "github-actions-updates"
 
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     ignore:
       # For all packages, ignore all major updates
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
+    groups:
+      python-requirements:
+        patterns:
+          - '*'
     reviewers:
       - "saurbhc"
       - "JBWilkie"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
     labels:
       - "dependencies"


### PR DESCRIPTION
# Problem
Dependabot was submitting dependency updates weekly in individual PRs, making it difficult to manage

# Solution
Change frequency to monthly, and group PRs for ease of testing

# Changelog
Improved dependabot config to make it more manageable
