### PR TITLE
[PY-668][Internal] Exclude macos from testing on 3.8 and 3.9

### DIFF
--- a/.github/workflows/JOB_generate_documentation.yml
+++ b/.github/workflows/JOB_generate_documentation.yml
@@ -9,7 +9,7 @@ on:
 
 permissions:
   id-token: write # This is required for requesting the JWT
-  contents: read  # This is required for actions/checkout
+  contents: read # This is required for actions/checkout
 
 env:
   AWS_REGION: eu-west-1
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -59,7 +59,5 @@ jobs:
           role-session-name: ${{ env.AWS_SESSION_NAME }}
           aws-region: ${{ env.AWS_REGION }}
 
-
       - name: Upload docs to S3
         run: aws s3 cp docs/ s3://darwin-py-sdk.v7labs.com/ --recursive
-

--- a/.github/workflows/JOB_tests.yml
+++ b/.github/workflows/JOB_tests.yml
@@ -12,6 +12,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
+        exclude:
+          - os: macos-latest
+            version: "3.8"
+          - os: macos-latest
+            version: "3.9"
+
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/JOB_tests.yml
+++ b/.github/workflows/JOB_tests.yml
@@ -14,14 +14,14 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         exclude:
           - os: macos-latest
-            version: "3.8"
+            python-version: "3.8"
           - os: macos-latest
-            version: "3.9"
+            python-version: "3.9"
         include:
           - os: macos-13
-            version: "3.8"
+            python-version: "3.8"
           - os: macos-13
-            version: "3.9"
+            python-version: "3.9"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/JOB_tests.yml
+++ b/.github/workflows/JOB_tests.yml
@@ -17,7 +17,11 @@ jobs:
             version: "3.8"
           - os: macos-latest
             version: "3.9"
-
+        include:
+          - os: macos-13
+            version: "3.8"
+          - os: macos-13
+            version: "3.9"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
# Problem
From https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json, Python 3.8 and Python 3.9 is not available for Arm64 / MacOS.

# Solution
Exclude Python 3.8 and 3.9 test for MacOS.
