### PR TITLE
[DAR-1165][DAR-1734][External] Polygons from other plane export correctly

### DIFF
--- a/darwin/exporter/formats/nifti.py
+++ b/darwin/exporter/formats/nifti.py
@@ -350,7 +350,7 @@ def populate_output_volumes_from_polygons(
                 plane,
                 frame_idx,
             )
-        return volume
+    return volume
 
 
 def populate_output_volumes_from_raster_layer(


### PR DESCRIPTION
# Problem
The polygons at Coronal and Sagittal are not exported.

# Solution
Go through all the slots to ensure all the polygons are exported. 

Fixes DAR-1165
Fixes DAR-1734

# Changelog
- Polygon from Coronal and Sagittal plane are exported correctly. 