### PR TITLE
[DAR-1657][External] Introduce by-passable warning when an import will overwrite annotations

### DIFF
--- a/darwin/backend_v2.py
+++ b/darwin/backend_v2.py
@@ -253,3 +253,20 @@ class BackendV2:
         return self._client._post_raw(
             f"/v2/teams/{team_slug}/items/register_existing", payload
         )
+
+    def _get_remote_annotations(
+        self,
+        item_id: str,
+        team_slug: str,
+    ) -> List:
+        """
+        Returns the annotations currently present on a remote dataset item.
+
+        Parameters
+        ----------
+        item_id: str
+            The UUID of the item.
+        team_slug: str
+            The team slug.
+        """
+        return self._client._get(f"v2/teams/{team_slug}/items/{item_id}/annotations")

--- a/darwin/cli.py
+++ b/darwin/cli.py
@@ -166,6 +166,7 @@ def _run(args: Namespace, parser: ArgumentParser) -> None:
                 args.delete_for_empty,
                 args.import_annotators,
                 args.import_reviewers,
+                args.overwrite,
                 cpu_limit=args.cpu_limit,
             )
         elif args.action == "convert":

--- a/darwin/cli_functions.py
+++ b/darwin/cli_functions.py
@@ -851,6 +851,7 @@ def dataset_import(
     delete_for_empty: bool = False,
     import_annotators: bool = False,
     import_reviewers: bool = False,
+    overwrite: bool = False,
     use_multi_cpu: bool = False,
     cpu_limit: Optional[int] = None,
 ) -> None:
@@ -881,6 +882,9 @@ def dataset_import(
     import_reviewers : bool, default: False
         If ``True`` it will import the reviewers from the files to the dataset, if .
         If ``False`` it will not import the reviewers.
+    overwrite : bool, default: False
+        If ``True`` it will bypass a warning that the import will overwrite the current annotations if any are present.
+        If ``False`` this warning will be skipped and the import will overwrite the current annotations.
     use_multi_cpu : bool, default: False
         If ``True`` it will use all multiple CPUs to speed up the import process.
     cpu_limit : Optional[int], default: Core count - 2
@@ -904,6 +908,7 @@ def dataset_import(
             delete_for_empty,
             import_annotators,
             import_reviewers,
+            overwrite,
             use_multi_cpu,
             cpu_limit,
         )

--- a/darwin/cli_functions.py
+++ b/darwin/cli_functions.py
@@ -884,7 +884,7 @@ def dataset_import(
         If ``False`` it will not import the reviewers.
     overwrite : bool, default: False
         If ``True`` it will bypass a warning that the import will overwrite the current annotations if any are present.
-        If ``False`` this warning will be skipped and the import will overwrite the current annotations.
+        If ``False`` this warning will be skipped and the import will overwrite the current annotations without warning.
     use_multi_cpu : bool, default: False
         If ``True`` it will use all multiple CPUs to speed up the import process.
     cpu_limit : Optional[int], default: Core count - 2

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -944,8 +944,6 @@ def import_annotations(  # noqa: C901
         ]
         if files_to_track:
             if not append and not overwrite:
-                # Remember to add a flag that can bypass this warning!
-                # Add unit test(s) for this functionality at the end
                 continue_to_overwrite = _overwrite_warning(
                     dataset.client, dataset, files_to_track, remote_files, console
                 )
@@ -1376,6 +1374,28 @@ def _overwrite_warning(
     remote_files: Dict[str, Tuple[str, str]],
     console: Console,
 ) -> bool:
+    """
+    Determines if any dataset items targeted for import already have annotations that will be overwritten.
+    If they do, a warning is displayed to the user and they are prompted to confirm if they want to proceed with the import.
+
+    Parameters
+    ----------
+    client : Client
+        The Darwin Client object.
+    dataset : RemoteDataset
+        The dataset where the annotations will be imported.
+    files : List[dt.AnnotationFile]
+        The list of annotation files that will be imported.
+    remote_files : Dict[str, Tuple[str, str]]
+        A dictionary of the remote files in the dataset.
+    console : Console
+        The console object.
+
+    Returns
+    -------
+    bool
+        True if the user wants to proceed with the import, False otherwise.
+    """
     files_to_overwrite = []
     for file in files:
         item_id = remote_files[file.full_path][0]

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -673,6 +673,7 @@ def import_annotations(  # noqa: C901
     delete_for_empty: bool = False,
     import_annotators: bool = False,
     import_reviewers: bool = False,
+    overwrite: bool = False,
     use_multi_cpu: bool = False,  # Set to False to give time to resolve MP behaviours
     cpu_limit: Optional[int] = None,  # 0 because it's set later in logic
 ) -> None:
@@ -704,6 +705,9 @@ def import_annotations(  # noqa: C901
     import_reviewers : bool, default: False
         If ``True`` it will import the reviewers from the files to the dataset, if .
         If ``False`` it will not import the reviewers.
+    overwrite : bool, default: False
+        If ``True`` it will bypass a warning that the import will overwrite the current annotations if any are present.
+        If ``False`` this warning will be skipped and the import will overwrite the current annotations.
     use_multi_cpu : bool, default: True
         If ``True`` will use multiple available CPU cores to parse the annotation files.
         If ``False`` will use only the current Python process, which runs in one core.
@@ -939,7 +943,7 @@ def import_annotations(  # noqa: C901
             file for file in parsed_files if file not in files_to_not_track
         ]
         if files_to_track:
-            if not append:
+            if not append and not overwrite:
                 # Remember to add a flag that can bypass this warning!
                 # Add unit test(s) for this functionality at the end
                 continue_to_overwrite = _overwrite_warning(

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -707,7 +707,7 @@ def import_annotations(  # noqa: C901
         If ``False`` it will not import the reviewers.
     overwrite : bool, default: False
         If ``True`` it will bypass a warning that the import will overwrite the current annotations if any are present.
-        If ``False`` this warning will be skipped and the import will overwrite the current annotations.
+        If ``False`` this warning will be skipped and the import will overwrite the current annotations without warning.
     use_multi_cpu : bool, default: True
         If ``True`` will use multiple available CPU cores to parse the annotation files.
         If ``False`` will use only the current Python process, which runs in one core.

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -1379,15 +1379,15 @@ def _overwrite_warning(
             item_id,
             dataset.team,
         )
-        if remote_annotations:
-            files_to_overwrite.append(file)
+        if remote_annotations and file.full_path not in files_to_overwrite:
+            files_to_overwrite.append(file.full_path)
     if files_to_overwrite:
         console.print(
-            "The following dataset items already have annotations that will be overwritten by this import:",
+            f"The following {len(files_to_overwrite)} dataset items already have annotations that will be overwritten by this import:",
             style="warning",
         )
         for file in files_to_overwrite:
-            console.print(f"- {file.full_path}", style="warning")
+            console.print(f"- {file}", style="warning")
         proceed = input("Do you want to proceed with the import? [y/N] ")
         if proceed.lower() != "y":
             return False

--- a/darwin/options.py
+++ b/darwin/options.py
@@ -333,6 +333,11 @@ class Options:
             action="store_true",
             help="Import reviewers metadata from the annotation files, where available",
         )
+        parser_import.add_argument(
+            "--overwrite",
+            action="store_true",
+            help="Bypass warnings about overwiting existing annotations.",
+        )
 
         # Cpu limit for multiprocessing tasks
         def cpu_default_types(input: Any) -> Optional[int]:  # type: ignore


### PR DESCRIPTION
# Problem
When importing annotations to a dataset item with existing annotations, unless `append` is set to `True`, the current annotations will be overwritten. Several users have been inconvenienced by the lack of warning when doing this

# Solution
Introduce a by-passable warning that presents users with the potential impact of their import **if** any item targeted in the import has annotations. The warning is not displayed if:
- No item targeted by the import has annotations, or:
- The `--overwrite` option is set to `True` when executing the import

# Changelog
Introduced a by-passable warning when performing an annotation import that would overwrite existing annotations