### PR TITLE
[DAR-2044][External] Bundle tags bound for the same item when using CSV importer

### DIFF
--- a/darwin/importer/formats/csv_tags.py
+++ b/darwin/importer/formats/csv_tags.py
@@ -25,6 +25,7 @@ def parse_path(path: Path) -> Optional[List[dt.AnnotationFile]]:
         return None
 
     files = []
+    tags_and_files = {}
     with path.open() as f:
         reader = csv.reader(f)
         for row in reader:
@@ -32,6 +33,12 @@ def parse_path(path: Path) -> Optional[List[dt.AnnotationFile]]:
             if filename == "":
                 continue
             annotations = [dt.make_tag(tag) for tag in tags if len(tag) > 0]
+            if filename not in tags_and_files:
+                tags_and_files[filename] = [annotation for annotation in annotations]
+            else:
+                tags_and_files[filename].extend(annotations)
+
+        for filename, annotations in tags_and_files.items():
             annotation_classes = {
                 annotation.annotation_class for annotation in annotations
             }

--- a/tests/darwin/importer/formats/import_csv_tags_test.py
+++ b/tests/darwin/importer/formats/import_csv_tags_test.py
@@ -50,3 +50,18 @@ class TestParsePath:
         assert annotation_files[1].filename == "image2.jpg"
         assert annotation_files[1].remote_path == "/folder"
         assert len(annotation_files[1].annotations) == 2
+
+    def test_bundles_tags_correctly(self, file_path: Path):
+        with file_path.open("w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(["image1.jpg", "tag1", "tag2"])
+            writer.writerow(["image1.jpg", "tag3", "tag4"])
+            writer.writerow(["image2.jpg", "tag5", "tag6"])
+            writer.writerow(["image2.jpg", "tag7", "tag8"])
+
+        annotation_files: Optional[List[AnnotationFile]] = parse_path(file_path)
+        assert annotation_files is not None
+
+        assert len(annotation_files) == 2
+        assert len(annotation_files[0].annotations) == 4
+        assert len(annotation_files[1].annotations) == 4

--- a/tests/darwin/importer/formats/import_csv_tags_video_test.py
+++ b/tests/darwin/importer/formats/import_csv_tags_video_test.py
@@ -68,3 +68,18 @@ class TestParsePathVideo:
 
         # Check that the keyframes are recorded correctly
         assert video_annotation.keyframes == {i: i == 1 for i in range(1, 11)}
+
+    def test_bundles_tags_correctly(self, file_path: Path):
+        with file_path.open("w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(["video1.mp4", "tag1", "1", "10"])
+            writer.writerow(["video1.mp4", "tag2", "5", "15"])
+            writer.writerow(["video2.mp4", "tag3", "1", "10"])
+            writer.writerow(["video2.mp4", "tag4", "5", "15"])
+
+        annotation_files: Optional[List[dt.AnnotationFile]] = parse_path(file_path)
+        assert annotation_files is not None
+
+        assert len(annotation_files) == 2
+        assert len(annotation_files[0].annotations) == 2
+        assert len(annotation_files[1].annotations) == 2


### PR DESCRIPTION
# Problem
When importing CSV tags, the importer currently sends one request per tag per item. If importing multiple tags to the same item, this can be sped up by bundling tags bound for the same item in the same request

# Solution
This PR groups tags bound for the same item into the same request payload, and adds unit tests. I only had to implement this for `csv_tags`, since it turns out this was already implemented for `csv_tags_video`

I thought about splitting up annotation payloads if they grow beyond a certain size, but I tested up to 100000 tags in a single payload without issue

# Changelog
Improved speed of CSV tag importer when importing multiple tags to the same dataset item