### PR TITLE
[DAR-2237][External] Fix bug with compute_distributions()

### DIFF
--- a/darwin/dataset/utils.py
+++ b/darwin/dataset/utils.py
@@ -780,7 +780,9 @@ def compute_distributions(
             stems: List[str] = [e.rstrip("\n\r") for e in split_file.open()]
 
             for stem in stems:
-                annotation_path: Path = annotations_dir / f"{stem}.json"
+                if not stem.endswith(".json"):
+                    stem = f"{stem}.json"
+                annotation_path: Path = annotations_dir / stem
                 annotation_file: Optional[dt.AnnotationFile] = parse_path(
                     annotation_path
                 )


### PR DESCRIPTION
# Problem
Changes made to the way that darwin-py refers to annotation files a few versions ago mean that the "stems" passed to the `compute_distributions()` function when training in-platform models now end with `.json`. This breaks this function, which so far as assumed that they don't

# Solution
Allow the function to work with both files ending with `.json` and those that don't

# Changelog
Improved tolerance of a darwin-py function used for in-platform model training