### PR TITLE
[DAR-2239][External] Added missing argument for call of get_image_path_from_stream()

### DIFF
--- a/darwin/dataset/local_dataset.py
+++ b/darwin/dataset/local_dataset.py
@@ -147,7 +147,7 @@ class LocalDataset:
             annotation_filepath = Path(annotation_filepath)
             darwin_json = stream_darwin_json(annotation_filepath)
             image_path = get_image_path_from_stream(
-                darwin_json, images_dir, with_folders, annotation_filepath
+                darwin_json, images_dir, annotation_filepath, with_folders
             )
             if image_path.exists():
                 if not keep_empty_annotations and is_stream_list_empty(

--- a/darwin/dataset/utils.py
+++ b/darwin/dataset/utils.py
@@ -580,8 +580,10 @@ def _map_annotations_to_images(
     annotations_paths = []
     invalid_annotation_paths = []
     for annotation_path in get_annotation_files_from_dir(annotations_dir):
-        darwin_json = stream_darwin_json(annotation_path)
-        image_path = get_image_path_from_stream(darwin_json, images_dir)
+        darwin_json = stream_darwin_json(Path(annotation_path))
+        image_path = get_image_path_from_stream(
+            darwin_json, images_dir, Path(annotation_path)
+        )
         if image_path.exists():
             images_paths.append(image_path)
             annotations_paths.append(annotation_path)

--- a/darwin/utils/utils.py
+++ b/darwin/utils/utils.py
@@ -447,7 +447,7 @@ def get_image_path_from_stream(
         Path to the directory containing the images.
     with_folders: bool
         Flag to determine if the release was pulled with or without folders.
-    annotaiton_filepath : Path
+    annotation_filepath : Path
         Path to the annotation file. Used if loading the JSON as a dictionary fails.
 
     Returns

--- a/darwin/utils/utils.py
+++ b/darwin/utils/utils.py
@@ -448,7 +448,7 @@ def get_image_path_from_stream(
     with_folders: bool
         Flag to determine if the release was pulled with or without folders.
     annotation_filepath : Path
-        Path to the annotation file. Used if loading the JSON as a dictionary fails.
+        Path to the annotation file. Used if loading the JSON as a stream fails.
 
     Returns
     -------

--- a/darwin/utils/utils.py
+++ b/darwin/utils/utils.py
@@ -432,8 +432,8 @@ def stream_darwin_json(path: Path) -> PersistentStreamingJSONObject:
 def get_image_path_from_stream(
     darwin_json: PersistentStreamingJSONObject,
     images_dir: Path,
-    with_folders: bool,
     annotation_filepath: Path,
+    with_folders: bool = True,
 ) -> Path:
     """
     Returns the path to the image file associated with the given darwin json file.
@@ -447,6 +447,8 @@ def get_image_path_from_stream(
         Path to the directory containing the images.
     with_folders: bool
         Flag to determine if the release was pulled with or without folders.
+    annotaiton_filepath : Path
+        Path to the annotation file. Used if loading the JSON as a dictionary fails.
 
     Returns
     -------


### PR DESCRIPTION
# Problem
The call of this function is missing the `annotation_path` argument in `_map_annotations_to_images()`

# Solution
Add this argument to the function

# Changelog
Fixed broken function call by adding missing required argument