### PR TITLE
[DAR-2275][External] Correct get_release() NotFound error

### DIFF
--- a/darwin/dataset/remote_dataset.py
+++ b/darwin/dataset/remote_dataset.py
@@ -743,7 +743,11 @@ class RemoteDataset(ABC):
         for release in releases:
             if str(release.name) == name:
                 return release
-        raise NotFound(str(self.identifier))
+        raise NotFound(
+            str(
+                f"Release name {name} not found in dataset {self.name}. Please check this release exists for this dataset."
+            )
+        )
 
     def split(
         self,


### PR DESCRIPTION
# Problem
When using `RemoteDataset.get_release()`, if the specified release cannot be found, a `NotFound` error is raised with the dataset identifier

# Solution
Instead, raise the `NotFound` error with the release name

# Changelog
Corrected error message when trying to get a dataset release that doesn't exist