### PR TITLE
[DAR-2294][External] Made text a required argument when posting comments through CLI

### DIFF
--- a/darwin/options.py
+++ b/darwin/options.py
@@ -473,7 +473,9 @@ class Options:
             help="[Remote] Dataset name: to list all the existing dataset, run 'darwin dataset remote'. ",
         )
         parser_comment.add_argument("file", type=str, help="File to comment")
-        parser_comment.add_argument("text", type=str, help="Comment: list of words")
+        parser_comment.add_argument(
+            "--text", type=str, help="Comment: list of words", required=True
+        )
         parser_comment.add_argument(
             "--x",
             required=False,

--- a/darwin/options.py
+++ b/darwin/options.py
@@ -473,7 +473,7 @@ class Options:
             help="[Remote] Dataset name: to list all the existing dataset, run 'darwin dataset remote'. ",
         )
         parser_comment.add_argument("file", type=str, help="File to comment")
-        parser_comment.add_argument("--text", type=str, help="Comment: list of words")
+        parser_comment.add_argument("text", type=str, help="Comment: list of words")
         parser_comment.add_argument(
             "--x",
             required=False,


### PR DESCRIPTION
# Problem
When posting dataset item comments through the CLI, the text argument should be required. Not providing the text argument with a value causes the API request to post the comment to fail

# Solution
Make the text argument required instead

# Changelog
Made the comment text argument required when posting dataset item comments through the CLI