### PR TITLE
[DAR-2305][External] Ignore the properties metadata file when reading annotations on Windows filesystems

### DIFF
--- a/darwin/utils/utils.py
+++ b/darwin/utils/utils.py
@@ -1471,7 +1471,7 @@ def get_annotation_files_from_dir(path: Path) -> Iterator[str]:
     return (
         str(filepath)
         for filepath in sorted(path.glob("**/*.json"))
-        if "/.v7/" not in str(filepath)
+        if "/.v7/" not in str(filepath) and "\\.v7\\" not in str(filepath)
     )
 
 

--- a/tests/darwin/exporter/formats/export_darwin_test.py
+++ b/tests/darwin/exporter/formats/export_darwin_test.py
@@ -141,3 +141,4 @@ def test_properties_metadata_is_ignored_when_reading_annotations_directory():
         annotation_filepaths = list(get_annotation_files_from_dir(Path(tmpdirname)))
         for annotation_filepath in annotation_filepaths:
             assert "./v7/" not in annotation_filepath
+            assert "\\.v7\\" not in annotation_filepath


### PR DESCRIPTION
# Problem
In [DAR-1679](https://github.com/v7labs/darwin-py/pull/823), we made darwin-py ignore the properties metadata file when trying to read annotation files to avoid a bug. We did not implement this behaviour for Windows filesystems

# Solution
Update solution to include Windows filesystems

# Changelog
Made Windows filesystems ignore the properties metadata file when reading annotation files