### PR TITLE
[DAR-2463][External] Adjusted maximum number of items that can be registered in a single request

### DIFF
--- a/darwin/dataset/remote_dataset_v2.py
+++ b/darwin/dataset/remote_dataset_v2.py
@@ -702,8 +702,8 @@ class RemoteDatasetV2(RemoteDataset):
                 item["extract_views"] = "true"
             items.append(item)
 
-        # Do not register more than 100 items in a single request
-        chunk_size = 100
+        # Do not register more than 10 items in a single request
+        chunk_size = 10
         chunked_items = chunk_items(items, chunk_size)
         print(f"Registering {len(items)} items in chunks of {chunk_size} items...")
         results = {
@@ -800,8 +800,8 @@ class RemoteDatasetV2(RemoteDataset):
                 }
             )
 
-        # Do not register more than 100 items in a single request
-        chunk_size = 100
+        # Do not register more than 10 items in a single request
+        chunk_size = 10
         chunked_items = chunk_items(items, chunk_size)
         print(f"Registering {len(items)} items in chunks of {chunk_size} items...")
         results = {

--- a/darwin/dataset/remote_dataset_v2.py
+++ b/darwin/dataset/remote_dataset_v2.py
@@ -703,7 +703,7 @@ class RemoteDatasetV2(RemoteDataset):
             items.append(item)
 
         # Do not register more than 10 items in a single request
-        chunk_size = 10
+        chunk_size = 100
         chunked_items = chunk_items(items, chunk_size)
         print(f"Registering {len(items)} items in chunks of {chunk_size} items...")
         results = {
@@ -801,7 +801,7 @@ class RemoteDatasetV2(RemoteDataset):
             )
 
         # Do not register more than 500 items in a single request
-        chunk_size = 500
+        chunk_size = 100
         chunked_items = chunk_items(items, chunk_size)
         print(f"Registering {len(items)} items in chunks of {chunk_size} items...")
         results = {

--- a/darwin/dataset/remote_dataset_v2.py
+++ b/darwin/dataset/remote_dataset_v2.py
@@ -702,7 +702,7 @@ class RemoteDatasetV2(RemoteDataset):
                 item["extract_views"] = "true"
             items.append(item)
 
-        # Do not register more than 10 items in a single request
+        # Do not register more than 100 items in a single request
         chunk_size = 100
         chunked_items = chunk_items(items, chunk_size)
         print(f"Registering {len(items)} items in chunks of {chunk_size} items...")
@@ -800,7 +800,7 @@ class RemoteDatasetV2(RemoteDataset):
                 }
             )
 
-        # Do not register more than 500 items in a single request
+        # Do not register more than 100 items in a single request
         chunk_size = 100
         chunked_items = chunk_items(items, chunk_size)
         print(f"Registering {len(items)} items in chunks of {chunk_size} items...")

--- a/darwin/dataset/remote_dataset_v2.py
+++ b/darwin/dataset/remote_dataset_v2.py
@@ -702,8 +702,8 @@ class RemoteDatasetV2(RemoteDataset):
                 item["extract_views"] = "true"
             items.append(item)
 
-        # Do not register more than 500 items in a single request
-        chunk_size = 500
+        # Do not register more than 10 items in a single request
+        chunk_size = 10
         chunked_items = chunk_items(items, chunk_size)
         print(f"Registering {len(items)} items in chunks of {chunk_size} items...")
         results = {


### PR DESCRIPTION
# Problem
Recently, we've encountered significant issues with our item processing queues being overloaded. Part of our strategy to mitigate this is to introduce rate limiting for the registration endpoints and a cap on the maximum number of items that can be registered in a single request. This PR introduces the latter for registration through darwin-py

# Solution
Significantly reduce the maximum number of items that can be registered in a single request to 10

# Changelog
Adjusted the maximum number of items that can be registered in a single request to 10 to reduce the chance of overloading our processing queues