### PR TITLE
[DAR-2487][External] Fixed long-standing ruff linter issues

### DIFF
--- a/darwin/backend_v2.py
+++ b/darwin/backend_v2.py
@@ -18,7 +18,7 @@ def inject_default_team_slug(method: Callable) -> Callable:
 
 
 class BackendV2:
-    def __init__(self, client: "Client", default_team):
+    def __init__(self, client: "Client", default_team):  # noqa F821
         self._client = client
         self._default_team = default_team
 

--- a/darwin/client.py
+++ b/darwin/client.py
@@ -951,7 +951,7 @@ class Client:
             error_code: Optional[str] = None
             try:
                 error_code = response.json()["errors"]["code"]
-            except:
+            except Exception:
                 pass
 
             if error_code == "INSUFFICIENT_REMAINING_STORAGE":

--- a/darwin/dataset/remote_dataset.py
+++ b/darwin/dataset/remote_dataset.py
@@ -297,8 +297,8 @@ class RemoteDataset(ABC):
                     ):
                         # will raise if not installed via pip install darwin-py[ocv]
                         try:
-                            from cv2 import (
-                                VideoCapture,  # pylint: disable=import-outside-toplevel
+                            from cv2 import (  # pylint: disable=import-outside-toplevel # noqa F401
+                                VideoCapture,
                             )
                         except ImportError as e:
                             raise MissingDependency(

--- a/darwin/dataset/remote_dataset_v2.py
+++ b/darwin/dataset/remote_dataset_v2.py
@@ -297,7 +297,7 @@ class RemoteDatasetV2(RemoteDataset):
                 "item_paths",
             ]:
                 if list_type in filters:
-                    if type(filters[list_type]) is list:
+                    if isinstance(filters[list_type], list):
                         for value in filters[list_type]:
                             post_filters.append(("{}[]".format(list_type), value))
                     else:

--- a/darwin/exporter/formats/mask.py
+++ b/darwin/exporter/formats/mask.py
@@ -10,7 +10,7 @@ import numpy as np
 try:
     from numpy.typing import NDArray
 except ImportError:
-    NDArray = Any  # type:ignore
+    NDArray = Any  # type:ignore # noqa F821
 from PIL import Image
 from upolygon import draw_polygon
 

--- a/darwin/importer/formats/csv_tags.py
+++ b/darwin/importer/formats/csv_tags.py
@@ -34,7 +34,7 @@ def parse_path(path: Path) -> Optional[List[dt.AnnotationFile]]:
                 continue
             annotations = [dt.make_tag(tag) for tag in tags if len(tag) > 0]
             if filename not in tags_and_files:
-                tags_and_files[filename] = [annotation for annotation in annotations]
+                tags_and_files[filename] = list(annotations)
             else:
                 tags_and_files[filename].extend(annotations)
 

--- a/darwin/utils/__init__.py
+++ b/darwin/utils/__init__.py
@@ -1,2 +1,2 @@
 from .flatten_list import flatten_list
-from .utils import *
+from .utils import *  # noqa F403

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,9 +51,9 @@ warn_required_dynamic_aliases = true
 warn_untyped_fields = true
 
 [tool.ruff]
-ignore = ["E203", "E402", "E501"]
+lint.ignore = ["E203", "E402", "E501", "C901"]
 line-length = 88
-select = ["E", "F", "C"]
+lint.select = ["E", "F", "C"]
 
 [tool.flake8]
 ignore = ["E203", "W503", "E402"]
@@ -92,7 +92,7 @@ test = ["responses", "pytest", "flake8-pyproject"]
 [tool.poetry.scripts]
 darwin = "darwin.cli:main"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "**/{tests,docs,tools}/*" = ["E402", "F403"]
 "__init__.py" = ["E402", "F401"]
 

--- a/tests/darwin/dataset/release_test.py
+++ b/tests/darwin/dataset/release_test.py
@@ -1,6 +1,8 @@
 import shutil
+from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 import requests
 
 from darwin.dataset.release import Release

--- a/tests/darwin/dataset/remote_dataset_test.py
+++ b/tests/darwin/dataset/remote_dataset_test.py
@@ -1,3 +1,4 @@
+import shutil
 import types
 from datetime import datetime
 from pathlib import Path

--- a/tests/darwin/dataset/split_manager_test.py
+++ b/tests/darwin/dataset/split_manager_test.py
@@ -1,4 +1,5 @@
 import sys
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -71,6 +72,6 @@ class TestClassificationDataset:
 
         for size, name in zip(sizes, names):
             with open(splits / f"random_{name}.txt", "r") as f:
-                lines_len = len([l for l in f.readlines() if l.strip() != ""])
+                lines_len = len([line for line in f.readlines() if line.strip() != ""])
                 local_size = lines_len / tot_size, size
                 assert np.allclose(local_size, size, atol=1e-3)

--- a/tests/darwin/exporter/formats/export_mask_test.py
+++ b/tests/darwin/exporter/formats/export_mask_test.py
@@ -13,7 +13,7 @@ from PIL import Image
 try:
     from numpy.typing import NDArray
 except ImportError:
-    NDArray = Any  # type:ignore
+    NDArray = Any  # type:ignore # noqa F821
 
 from darwin import datatypes as dt
 from darwin.exporter.formats.mask import (

--- a/tests/darwin/importer/formats/import_nifti_test.py
+++ b/tests/darwin/importer/formats/import_nifti_test.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 from zipfile import ZipFile
 
 import numpy as np
+import pytest
 from scipy import ndimage
 
 from darwin.datatypes import (


### PR DESCRIPTION
# Problem
We use [ruff](https://docs.astral.sh/ruff/) to lint darwin-py. There've been some long standing non-functional errors highlighted by the linter

# Solution
Resolve the errors worth resolving, and suppress those that are not 

# Changelog
Fixed or suppressed remaining darwin-py errors highlighted by the ruff linter
