### PR TITLE
[DAR-2492][External] Update ```EVENT_merge_to_master.yml``` with V3 > V7 ```github-script``` changes

### DIFF
--- a/.github/workflows/EVENT_merge_to_master.yml
+++ b/.github/workflows/EVENT_merge_to_master.yml
@@ -44,11 +44,14 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            github.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: context.sha,
-              state: 'success'
-            })
-
-
+            const { context } = require('@actions/github');
+            const { owner, repo } = context.repo;
+            const sha = context.sha;
+            await github.rest.repos.createCommitStatus({
+              owner: owner,
+              repo: repo,
+              sha: sha,
+              state: 'success',
+              context: 'continuous-integration/github-action',
+              description: 'The build succeeded!'
+            });

--- a/.github/workflows/EVENT_merge_to_master.yml
+++ b/.github/workflows/EVENT_merge_to_master.yml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ githFub.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/EVENT_merge_to_master.yml
+++ b/.github/workflows/EVENT_merge_to_master.yml
@@ -5,10 +5,11 @@ on:
   push:
     branches:
       - master
+      - DAR-2492
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ githFub.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -21,17 +22,6 @@ jobs:
     name: Documentation
     uses: ./.github/workflows/JOB_generate_documentation.yml
     secrets: inherit
-
-  warn_on_fail:
-    needs: [run_tests, documentation]
-    if : ${{ failure() }}
-    name: Slack message us on fail
-    uses: ./.github/workflows/JOB_slack_message.yml
-    secrets: inherit
-    with:
-      at_team: true
-      icon: ':warning:'
-      message: 'Master is failing after a push event, please review at ${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}'
 
   success:
     needs: [run_tests, documentation]

--- a/.github/workflows/EVENT_merge_to_master.yml
+++ b/.github/workflows/EVENT_merge_to_master.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - DAR-2492
   workflow_call:
 
 concurrency:
@@ -22,6 +21,17 @@ jobs:
     name: Documentation
     uses: ./.github/workflows/JOB_generate_documentation.yml
     secrets: inherit
+
+  warn_on_fail:
+    needs: [run_tests, documentation]
+    if : ${{ failure() }}
+    name: Slack message us on fail
+    uses: ./.github/workflows/JOB_slack_message.yml
+    secrets: inherit
+    with:
+      at_team: true
+      icon: ':warning:'
+      message: 'Master is failing after a push event, please review at ${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}'
 
   success:
     needs: [run_tests, documentation]

--- a/.github/workflows/EVENT_merge_to_master.yml
+++ b/.github/workflows/EVENT_merge_to_master.yml
@@ -44,14 +44,12 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const { context } = require('@actions/github');
             const { owner, repo } = context.repo;
             const sha = context.sha;
             await github.rest.repos.createCommitStatus({
               owner: owner,
               repo: repo,
               sha: sha,
-              state: 'success',
-              context: 'continuous-integration/github-action',
-              description: 'The build succeeded!'
+              state: 'success'
             });
+


### PR DESCRIPTION
# Problem
Upgrading the [github-script](https://github.com/actions/github-script) GHA from V3 to V7 introduced a breaking change that resulted in a [failed merge to master event](https://github.com/v7labs/darwin-py/actions/runs/9404745872/job/25904663571)

# Solution
Update the ```EVENT_merge_to_master.yml``` file to account for the changes from V3 > V7

# Changelog
Fixed an issue that stemmed from upgrading a github action that darwin-py uses