### PR TITLE
[DAR-2528][External] Fixed issue installing scipy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,11 @@ optional = true
 python = ">=3.8.1,<3.12"
 version = "^1.2.0"
 
+[tool.poetry.dependencies.scipy]
+optional = true
+python = ">=3.8.1,<3.12"
+version = "^1.10.1"
+
 [tool.poetry.dependencies.albumentations]
 optional = true
 python = ">=3.8"
@@ -158,7 +163,6 @@ version = "^1.0.0"
 [tool.poetry.dependencies.opencv-python-headless]
 optional = true
 version = "^4.8.0.76"
-
 [tool.poetry.dependencies.pytest-rerunfailures]
 optional = true
 version = "^12.0"


### PR DESCRIPTION
# Problem
When installing darwin-py with `pip install darwin-py\[medical]`, scipy is not installed due to a missing `tool.poetry.depedencies.scipy` section in `pyproject.toml`

# Solution
Add this section to `pyproject.toml`

# Changelog
Fixed `scipy` installation when installing darwin-py with medical dependencies
