### PR TITLE
Revert "Bump the github-actions group with 2 updates"

### DIFF
--- a/.github/workflows/EVENT_merge_to_master.yml
+++ b/.github/workflows/EVENT_merge_to_master.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set branch status to success
-        uses: actions/github-script@v7
+        uses: actions/github-script@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/EVENT_release.yml
+++ b/.github/workflows/EVENT_release.yml
@@ -63,7 +63,7 @@ jobs:
 
       - run: pip install pip --upgrade
       - name: Setup Poetry
-        uses: abatilo/actions-poetry@v3
+        uses: abatilo/actions-poetry@v2
         with:
           poetry-version: "1.3.1"
       - name: Publish on pypi.org
@@ -88,7 +88,7 @@ jobs:
           python-version: "3.9"
       - run: pip install pip --upgrade
       - name: Setup Poetry
-        uses: abatilo/actions-poetry@v3
+        uses: abatilo/actions-poetry@v2
         with:
           poetry-version: "1.3.1"
       - name: Check secrets are set

--- a/.github/workflows/JOB_check-master-can-release.yml
+++ b/.github/workflows/JOB_check-master-can-release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check master is passing
-        uses: actions/github-script@v7
+        uses: actions/github-script@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -25,7 +25,7 @@ jobs:
             }
 
       - name: Check there are commits in master since last release
-        uses: actions/github-script@v7
+        uses: actions/github-script@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/JOB_e2e.yml
+++ b/.github/workflows/JOB_e2e.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
       - name: Setup Poetry
-        uses: abatilo/actions-poetry@v3
+        uses: abatilo/actions-poetry@v2
         with:
           poetry-version: ${{ matrix.poetry-version }}
       - name: Install dependencies


### PR DESCRIPTION
Reverts v7labs/darwin-py#821

github-script V3 -> V7 introduced significantly breaking changes we can't test outside of the master branch. There are no benefits to upgrading at this stage, so revert