### PR TITLE
[DAR-2640][External] Lock tenacity to 8.3.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2178,4 +2178,4 @@ test = ["pytest", "responses"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.0,<3.12"
-content-hash = "0d694891abf5df0e8e04d0a17e6ca5a3028c9a04fe079e36fe2920ae9f8a5dc6"
+content-hash = "64854692bd93c4182469e323f692cd311e36e196f0dc4accf27ccc42e54217bf"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2178,4 +2178,4 @@ test = ["pytest", "responses"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.0,<3.12"
-content-hash = "64854692bd93c4182469e323f692cd311e36e196f0dc4accf27ccc42e54217bf"
+content-hash = "61407749d7ce2f08c814267a26d7b7a9db3eaa3627fab45847e2ad9e0584e312"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ tqdm = "^4.64.1"
 types-pyyaml = "^6.0.12.9"
 types-requests = "^2.28.11.8"
 upolygon = "0.1.11"
-tenacity = "^8.3.0"
+tenacity = "8.3.0"
 
 [tool.poetry.extras]
 dev = ["black", "isort", "flake8", "mypy", "debugpy", "responses", "pytest", "flake8-pyproject", "pytest-rerunfailures", "ruff", "validate-pyproject"]


### PR DESCRIPTION
# Problem
In darwin-py 0.8.62, we added tenacity as a dependency for exponential backoff. The latest version (8.4.0) released this morning [broke](https://github.com/langchain-ai/langchain/issues/22972), resulting in an [issue](https://github.com/v7labs/darwin-py/issues/867) with darwin-py

# Solution
We gain nothing from upgrading beyond 8.3.0, so lock tenacity to 8.3.0 until we need to upgrade

# Changelog
Locked tenacity to 8.3.0
