### PR TITLE
[DAR-2469][External] Fixed opencv version to 4.10.0.82

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2178,4 +2178,4 @@ test = ["pytest", "responses"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.0,<3.12"
-content-hash = "0d694891abf5df0e8e04d0a17e6ca5a3028c9a04fe079e36fe2920ae9f8a5dc6"
+content-hash = "85b3132831c00960603b4657ef0331b91772d483f60eec944d20f6c1e10d4cad"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,9 +161,7 @@ version = "^2.7.0"
 python = ">3.8"
 version = "^1.0.0"
 
-[tool.poetry.dependencies.opencv-python-headless]
-optional = true
-version = "^4.8.0.76"
+opencv-python-headless = {version = "4.10.0.82", optional = true}
 [tool.poetry.dependencies.pytest-rerunfailures]
 optional = true
 version = "^12.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,10 @@ version = "^2.7.0"
 python = ">3.8"
 version = "^1.0.0"
 
-opencv-python-headless = {version = "4.10.0.82", optional = true}
+[tool.poetry.dependencies.opencv-python-headless]
+optional = true
+version = "4.8.0.82"
+
 [tool.poetry.dependencies.pytest-rerunfailures]
 optional = true
 version = "^12.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,7 +163,7 @@ version = "^1.0.0"
 
 [tool.poetry.dependencies.opencv-python-headless]
 optional = true
-version = "4.8.0.82"
+version = "4.10.0.82"
 
 [tool.poetry.dependencies.pytest-rerunfailures]
 optional = true


### PR DESCRIPTION
# Problem
The `opencv-python-headless` package released version [4.10.0.84](https://pypi.org/project/opencv-python-headless/#history) yesterday, but it has an [issue](https://github.com/opencv/opencv-python/issues/1005) for MacOS arm64 wheels

# Solution
We should pin to 4.10.0.82 until we need to change

# Changelog
Fixed opencv version used by darwin-py
