### PR TITLE
[DAR-2660][External] Pinned dependency major versions

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2178,4 +2178,4 @@ test = ["pytest", "responses"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.0,<3.12"
-content-hash = "61407749d7ce2f08c814267a26d7b7a9db3eaa3627fab45847e2ad9e0584e312"
+content-hash = "e9cd836ceb0ae099b5db898c5d0e8695ba2603900f6b0cf117c9add6d87908ab"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,8 +67,8 @@ argcomplete = "^2.0.0"
 deprecation = "^2.1.0"
 humanize = "^4.4.0"
 json-stream = "^2.3.2"
-jsonschema = ">=4.0.0"
-numpy = "*"
+jsonschema = "^4.0.0"
+numpy = "^1.24.4"
 orjson = "^3.8.5"
 pillow = "^10.1.0"
 pydantic = "^2.0.0"
@@ -131,7 +131,7 @@ version = "^0.15.0"
 
 [tool.poetry.dependencies.black]
 optional = true
-version = ">=22.12,<25.0"
+version = "^24.4.2"
 
 [tool.poetry.dependencies.isort]
 optional = true
@@ -144,7 +144,7 @@ version = "^1.5"
 
 [tool.poetry.dependencies.responses]
 optional = true
-version = ">=0.22,<0.26"
+version = "^0.25.0"
 
 [tool.poetry.dependencies.pytest]
 optional = true
@@ -152,7 +152,7 @@ version = "^7.2.1"
 
 [tool.poetry.dependencies.debugpy]
 optional = true
-version = "1.8.1"
+version = "^1.8.1"
 
 [tool.poetry.dependencies.mpire]
 version = "^2.7.0"
@@ -171,7 +171,7 @@ version = "^12.0"
 
 [tool.poetry.dependencies.ruff]
 optional = true
-version = ">=0.0.292,<0.4.8"
+version = "^0.4.7"
 
 [tool.poetry.dependencies.validate-pyproject]
 optional = true


### PR DESCRIPTION
# Problem
Not pinning dependencies to major versions can introduce breaking changes

# Solution
Pin dependencies to major versions

# Changelog
Pinned darwin-py dependencies to major versions to prevent accidentally introducing breaking changes
