### PR TITLE
[DAR-2110][External] Fixed multiprocessing annotation parsing issue with console

### DIFF
--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -136,7 +136,7 @@ def _find_and_parse(  # noqa: C901
         maybe_console(f"Using multiprocessing with {cpu_limit} workers")
         try:
             with WorkerPool(cpu_limit) as pool:
-                parsed_files = pool.map(importer, files, progress_bar=is_console)
+                parsed_files = pool.map(importer, tqdm(files) if is_console else files)
         except KeyboardInterrupt:
             maybe_console("Keyboard interrupt. Stopping.")
             return None


### PR DESCRIPTION
# Problem
When using `importer.import_annotations`, if the `use_multi_cpu` flag is set to `True`, no annotation files can be read

# Solution
The problem appears to be that the multi-processed parsing attempts to use a different progress bar to display progress. If we make it use the same progress bar (tqdm) as the single CPU case, the issue is resolved

# Changelog
Resolved bug with multi-processed annotation parsing