### PR TITLE
[DAR-2739][External] Add `.mkv`, `.hevc`, `.qtiff` and `.rvg` as supported extensions

### DIFF
--- a/darwin/utils/utils.py
+++ b/darwin/utils/utils.py
@@ -50,6 +50,7 @@ SUPPORTED_IMAGE_EXTENSIONS = [
     ".jfif",
     ".tif",
     ".tiff",
+    ".qtiff",
     ".bmp",
     ".svs",
     ".webp",
@@ -68,6 +69,7 @@ SUPPORTED_VIDEO_EXTENSIONS = [
     ".nii",
     ".nii.gz",
     ".ndpi",
+    ".rvg",
 ]
 SUPPORTED_EXTENSIONS = SUPPORTED_IMAGE_EXTENSIONS + SUPPORTED_VIDEO_EXTENSIONS
 

--- a/darwin/utils/utils.py
+++ b/darwin/utils/utils.py
@@ -62,6 +62,8 @@ SUPPORTED_VIDEO_EXTENSIONS = [
     ".dcm",
     ".mov",
     ".mp4",
+    ".mkv",
+    ".hevc",
     ".pdf",
     ".nii",
     ".nii.gz",


### PR DESCRIPTION
# Problem
darwin-py currently forbids the upload of `.mkv`, `.hevc`, `.qtiff` and `.rvg` files, despite being supported by the Darwin platform

# Solution
Allow the upload of these filetypes

# Changelog
Allowed the upload of `.mkv`, `.hevc`, `.qtiff`, `.rvg` video filetypes with darwin-py
