### PR TITLE
[DAR-2045][External] Multi-threaded annotation imports

### DIFF
--- a/darwin/cli_functions.py
+++ b/darwin/cli_functions.py
@@ -899,6 +899,9 @@ def dataset_import(
             dataset_identifier=dataset_slug
         )
 
+        if cpu_limit is not None:
+            use_multi_cpu = True
+
         import_annotations(
             dataset,
             importer,

--- a/darwin/dataset/release.py
+++ b/darwin/dataset/release.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 import requests
+
 from darwin.dataset.identifier import DatasetIdentifier
 
 
@@ -22,6 +23,8 @@ class Release:
         The version of the ``Release``.
     name : str
         The name of the ``Release``.
+    status : str
+        The status of the ``Release``.
     url : Optional[str]
         The full url used to download the ``Release``.
     export_date : datetime.datetime
@@ -47,6 +50,8 @@ class Release:
         The version of the ``Release``.
     name : str
         The name of the ``Release``.
+    status : str
+        The status of the ``Release``.
     url : Optional[str]
         The full url used to download the ``Release``.
     export_date : datetime.datetime
@@ -69,6 +74,7 @@ class Release:
         team_slug: str,
         version: str,
         name: str,
+        status: str,
         url: Optional[str],
         export_date: datetime.datetime,
         image_count: Optional[int],
@@ -81,6 +87,7 @@ class Release:
         self.team_slug = team_slug
         self.version = version
         self.name = name
+        self.status = status
         self.url = url
         self.export_date = export_date
         self.image_count = image_count
@@ -155,6 +162,7 @@ class Release:
                 team_slug=team_slug,
                 version=payload["version"],
                 name=payload["name"],
+                status=payload["status"],
                 export_date=export_date,
                 url=None,
                 available=False,
@@ -169,6 +177,7 @@ class Release:
             team_slug=team_slug,
             version=payload["version"],
             name=payload["name"],
+            status=payload["status"],
             image_count=payload["metadata"]["num_images"],
             class_count=len(payload["metadata"]["annotation_classes"]),
             export_date=export_date,

--- a/darwin/dataset/remote_dataset.py
+++ b/darwin/dataset/remote_dataset.py
@@ -261,6 +261,13 @@ class RemoteDataset(ABC):
         if release.format != "json" and release.format != "darwin_json_2":
             raise UnsupportedExportFormat(release.format)
 
+        # Check if the release is ready
+        if release.status == "processing":
+            if retry:
+                pass  # Implment retry logic
+            else:
+                pass  # Raise error letting user know that the release is still processing and that they can use retry if they want to poll
+
         release_dir = self.local_releases_path / release.name
         release_dir.mkdir(parents=True, exist_ok=True)
 

--- a/darwin/dataset/remote_dataset_v2.py
+++ b/darwin/dataset/remote_dataset_v2.py
@@ -136,7 +136,7 @@ class RemoteDatasetV2(RemoteDataset):
             for payload in releases_json
         ]
         return sorted(
-            filter(lambda x: x.available, releases),
+            releases,
             key=lambda x: x.version,
             reverse=True,
         )

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -928,7 +928,7 @@ def import_annotations(  # noqa: C901
                     for _ in tqdm(
                         concurrent.futures.as_completed(futures),
                         total=len(futures),
-                        desc="Importing files",
+                        desc="Importing annotations from local file",
                     ):
                         future = next(concurrent.futures.as_completed(futures))
                         try:
@@ -938,7 +938,9 @@ def import_annotations(  # noqa: C901
                                 f"Generated an exception: {exc}", style="error"
                             )
             else:
-                for file in tqdm(files_to_track, desc="Importing files"):
+                for file in tqdm(
+                    files_to_track, desc="Importing annotations from local file"
+                ):
                     import_annotation(file)
 
     if use_multi_cpu:
@@ -950,7 +952,7 @@ def import_annotations(  # noqa: C901
             for _ in tqdm(
                 concurrent.futures.as_completed(futures),
                 total=len(futures),
-                desc="Processing local files",
+                desc="Processing local annotation files",
             ):
                 future = next(concurrent.futures.as_completed(futures))
                 try:
@@ -960,7 +962,7 @@ def import_annotations(  # noqa: C901
     else:
         for local_path in tqdm(
             {local_file.path for local_file in local_files},
-            desc="Processing local files",
+            desc="Processing local annotation files",
         ):
             process_local_file(local_path)
 

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 import uuid
 from collections import defaultdict
 from logging import getLogger
@@ -37,7 +38,6 @@ if TYPE_CHECKING:
     from darwin.dataset.remote_dataset import RemoteDataset
 
 from rich.console import Console
-from rich.progress import track
 from rich.theme import Theme
 
 import darwin.datatypes as dt
@@ -675,64 +675,9 @@ def import_annotations(  # noqa: C901
     import_annotators: bool = False,
     import_reviewers: bool = False,
     overwrite: bool = False,
-    use_multi_cpu: bool = False,  # Set to False to give time to resolve MP behaviours
-    cpu_limit: Optional[int] = None,  # 0 because it's set later in logic
+    use_multi_cpu: bool = False,
+    cpu_limit: Optional[int] = None,
 ) -> None:
-    """
-    Imports the given given Annotations into the given Dataset.
-
-    Parameters
-    ----------
-    dataset : RemoteDataset
-        Dataset where the Annotations will be imported to.
-    importer : Callable[[Path], Union[List[dt.AnnotationFile], dt.AnnotationFile, None]]
-        Parsing module containing the logic to parse the given Annotation files given in
-        ``files_path``. See ``importer/format`` for a list of out of supported parsers.
-    file_paths : List[PathLike]
-        A list of ``Path``'s or strings containing the Annotations we wish to import.
-    append : bool
-        If ``True`` appends the given annotations to the datasets. If ``False`` will override them.
-        Incompatible with ``delete-for-empty``.
-    class_prompt : bool
-        If ``False`` classes will be created and added to the datasets without requiring a user's prompt.
-    delete_for_empty : bool, default: False
-        If ``True`` will use empty annotation files to delete all annotations from the remote file.
-        If ``False``, empty annotation files will simply be skipped.
-        Only works for V2 datasets.
-        Incompatible with ``append``.
-    import_annotators : bool, default: False
-        If ``True`` it will import the annotators from the files to the dataset, if available.
-        If ``False`` it will not import the annotators.
-    import_reviewers : bool, default: False
-        If ``True`` it will import the reviewers from the files to the dataset, if .
-        If ``False`` it will not import the reviewers.
-    overwrite : bool, default: False
-        If ``True`` it will bypass a warning that the import will overwrite the current annotations if any are present.
-        If ``False`` this warning will be skipped and the import will overwrite the current annotations without warning.
-    use_multi_cpu : bool, default: True
-        If ``True`` will use multiple available CPU cores to parse the annotation files.
-        If ``False`` will use only the current Python process, which runs in one core.
-        Processing using multiple cores is faster, but may slow down a machine also running other processes.
-        Processing with one core is slower, but will run well alongside other processes.
-    cpu_limit : int, default: 2 less than total cpu count
-        The maximum number of CPU cores to use when ``use_multi_cpu`` is ``True``.
-        If ``cpu_limit`` is greater than the number of available CPU cores, it will be set to the number of available cores.
-        If ``cpu_limit`` is less than 1, it will be set to CPU count - 2.
-        If ``cpu_limit`` is omitted, it will be set to CPU count - 2.
-
-    Raises
-    -------
-    ValueError
-
-        - If ``file_paths`` is not a list.
-        - If the application is unable to fetch any remote classes.
-        - If the application was unable to find/parse any annotation files.
-        - If the application was unable to fetch remote file list.
-
-    IncompatibleOptions
-
-        - If both ``append`` and ``delete_for_empty`` are specified as ``True``.
-    """
     console = Console(theme=_console_theme())
 
     if append and delete_for_empty:
@@ -778,7 +723,6 @@ def import_annotations(  # noqa: C901
     local_files = []
     local_files_missing_remotely = []
 
-    # ! Other place we can use multiprocessing - hard to pass in the importer though
     maybe_parsed_files: Optional[Iterable[dt.AnnotationFile]] = _find_and_parse(
         importer, file_paths, console, use_multi_cpu, cpu_limit
     )
@@ -793,12 +737,8 @@ def import_annotations(  # noqa: C901
     ]
 
     console.print("Fetching remote file list...", style="info")
-    # This call will only filter by filename; so can return a superset of matched files across different paths
-    # There is logic in this function to then include paths to narrow down to the single correct matching file
     remote_files: Dict[str, Tuple[str, str]] = {}
 
-    # Try to fetch files in large chunks; in case the filenames are too large and exceed the url size
-    # retry in smaller chunks
     chunk_size = 100
     while chunk_size > 0:
         try:
@@ -885,7 +825,6 @@ def import_annotations(  # noqa: C901
         for cls in local_classes_not_in_dataset:
             dataset.add_annotation_class(cls)
 
-    # Refetch classes to update mappings
     if local_classes_not_in_team or local_classes_not_in_dataset:
         maybe_remote_classes: List[dt.DictFreeForm] = dataset.fetch_remote_classes()
         if not maybe_remote_classes:
@@ -913,8 +852,34 @@ def import_annotations(  # noqa: C901
         if not continue_to_overwrite:
             return
 
-    # Need to re parse the files since we didn't save the annotations in memory
-    for local_path in set(local_file.path for local_file in local_files):  # noqa: C401
+    def import_annotation(parsed_file):
+        image_id, default_slot_name = remote_files[parsed_file.full_path]
+        if parsed_file.slots and parsed_file.slots[0].name:
+            default_slot_name = parsed_file.slots[0].name
+
+        metadata_path = is_properties_enabled(parsed_file.path)
+
+        errors, _ = _import_annotations(
+            dataset.client,
+            image_id,
+            remote_classes,
+            attributes,
+            parsed_file.annotations,
+            default_slot_name,
+            dataset,
+            append,
+            delete_for_empty,
+            import_annotators,
+            import_reviewers,
+            metadata_path,
+        )
+
+        if errors:
+            console.print(f"Errors importing {parsed_file.filename}", style="error")
+            for error in errors:
+                console.print(f"\t{error}", style="error")
+
+    def process_local_file(local_path):
         imported_files: Union[List[dt.AnnotationFile], dt.AnnotationFile, None] = (
             importer(local_path)
         )
@@ -925,7 +890,6 @@ def import_annotations(  # noqa: C901
         else:
             parsed_files = imported_files
 
-        # remove files missing on the server
         missing_files = [
             missing_file.full_path for missing_file in local_files_missing_remotely
         ]
@@ -952,36 +916,53 @@ def import_annotations(  # noqa: C901
         ]
         if files_to_track:
             _warn_unsupported_annotations(files_to_track)
-            for parsed_file in track(files_to_track):
-                image_id, default_slot_name = remote_files[parsed_file.full_path]
-                # We need to check if name is not-None as Darwin JSON 1.0
-                # defaults to name=None
-                if parsed_file.slots and parsed_file.slots[0].name:
-                    default_slot_name = parsed_file.slots[0].name
 
-                metadata_path = is_properties_enabled(parsed_file.path)
+            if use_multi_cpu:
+                with concurrent.futures.ThreadPoolExecutor(
+                    max_workers=cpu_limit
+                ) as executor:
+                    futures = [
+                        executor.submit(import_annotation, file)
+                        for file in files_to_track
+                    ]
+                    for _ in tqdm(
+                        concurrent.futures.as_completed(futures),
+                        total=len(futures),
+                        desc="Importing files",
+                    ):
+                        future = next(concurrent.futures.as_completed(futures))
+                        try:
+                            future.result()
+                        except Exception as exc:
+                            console.print(
+                                f"Generated an exception: {exc}", style="error"
+                            )
+            else:
+                for file in tqdm(files_to_track, desc="Importing files"):
+                    import_annotation(file)
 
-                errors, _ = _import_annotations(
-                    dataset.client,
-                    image_id,
-                    remote_classes,
-                    attributes,
-                    parsed_file.annotations,  # type: ignore
-                    default_slot_name,
-                    dataset,
-                    append,
-                    delete_for_empty,
-                    import_annotators,
-                    import_reviewers,
-                    metadata_path,
-                )
-
-                if errors:
-                    console.print(
-                        f"Errors importing {parsed_file.filename}", style="error"
-                    )
-                    for error in errors:
-                        console.print(f"\t{error}", style="error")
+    if use_multi_cpu:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=cpu_limit) as executor:
+            futures = [
+                executor.submit(process_local_file, local_path)
+                for local_path in {local_file.path for local_file in local_files}
+            ]
+            for _ in tqdm(
+                concurrent.futures.as_completed(futures),
+                total=len(futures),
+                desc="Processing local files",
+            ):
+                future = next(concurrent.futures.as_completed(futures))
+                try:
+                    future.result()
+                except Exception as exc:
+                    console.print(f"Generated an exception: {exc}", style="error")
+    else:
+        for local_path in tqdm(
+            {local_file.path for local_file in local_files},
+            desc="Processing local files",
+        ):
+            process_local_file(local_path)
 
 
 def _get_multi_cpu_settings(


### PR DESCRIPTION
# Problem
Importing annotations only works in a single-threaded fashion. This results in a significant bottleneck when sending import API requests in series

# Solution
Add optional multi-threading to significantly improve speed when importing annotations. Pass the `use_multi_cpu` flag as `True` to enable multi-threading

# Changelog
Added option to import annotations with multi-threading, resulting in significant speed gains
