### PR TITLE
[DAR-3430][External] Fixed annotation import issue with changed `remote_files` structure

### DIFF
--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -1482,7 +1482,7 @@ def _overwrite_warning(
     """
     files_to_overwrite = []
     for local_file in local_files:
-        item_id = remote_files.get(local_file.full_path)[0]
+        item_id = remote_files.get(local_file.full_path)["item_id"]
         remote_annotations = client.api_v2._get_remote_annotations(
             item_id,
             dataset.team,

--- a/tests/darwin/importer/importer_test.py
+++ b/tests/darwin/importer/importer_test.py
@@ -843,7 +843,18 @@ def test_overwrite_warning_proceeds_with_import():
             remote_path="/",
         ),
     ]
-    remote_files = {"/file1": ("id1", "path1"), "/file2": ("id2", "path2")}
+    remote_files = {
+        "/file1": {
+            "item_id": "id1",
+            "slot_names": ["0"],
+            "layout": {"type": "simple", "version": 1, "slots": ["0"]},
+        },
+        "/file2": {
+            "item_id": "id2",
+            "slot_names": ["0"],
+            "layout": {"type": "simple", "version": 1, "slots": ["0"]},
+        },
+    }
     console = MagicMock()
 
     with patch("builtins.input", return_value="y"):
@@ -887,7 +898,18 @@ def test_overwrite_warning_aborts_import():
             remote_path="/",
         ),
     ]
-    remote_files = {"/file1": ("id1", "path1"), "/file2": ("id2", "path2")}
+    remote_files = {
+        "/file1": {
+            "item_id": "id1",
+            "slot_names": ["0"],
+            "layout": {"type": "simple", "version": 1, "slots": ["0"]},
+        },
+        "/file2": {
+            "item_id": "id2",
+            "slot_names": ["0"],
+            "layout": {"type": "simple", "version": 1, "slots": ["0"]},
+        },
+    }
     console = MagicMock()
 
     with patch("builtins.input", return_value="n"):


### PR DESCRIPTION
# Problem
Version 1.0.4 introduced a bug with the annotation importer that causes it to fail with a syntax error if `append=False`, which is the default behaviour

# Solution
The root cause is that 1.0.4 changed the structure of the `remote_files` object to work with annotation & slot alignment, but this broke the overwrite warning checker, which was expecting the old structure

To resolve, this PR updates the structure that the overwrite warning checker expects

# Changelog
Resolved bug with importing annotations when not appending
