### PR TITLE
[DAR-3431][External] Adding passing E2E tests as a requirement to release

### DIFF
--- a/.github/workflows/EVENT_release.yml
+++ b/.github/workflows/EVENT_release.yml
@@ -47,8 +47,12 @@ jobs:
     needs: validate_tag
     uses: ./.github/workflows/JOB_tests.yml
 
+  run_e2e:
+    needs: run_tests
+    uses: ./.github/workflows/JOB_e2e.yml
+
   release:
-    needs: [run_tests]
+    needs: [run_tests, run_e2e]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
@@ -74,7 +78,7 @@ jobs:
           poetry publish --build
 
   test_release:
-    needs: [run_tests]
+    needs: [run_tests, run_e2e]
     if: startsWith(github.ref, 'refs/tags/test-')
     runs-on: ubuntu-latest
     steps:
@@ -108,8 +112,6 @@ jobs:
 
           poetry publish --build --repository test-pypi
           python ./deploy/revert_nightly_setup.py
-
-  # Linear tickets update
 
   notify_release:
     needs: [release]

--- a/.github/workflows/JOB_e2e.yml
+++ b/.github/workflows/JOB_e2e.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - "e2e_tests/**"
+  workflow_call:
 jobs:
   e2e:
     name: End to End Testing

--- a/.github/workflows/JOB_e2e.yml
+++ b/.github/workflows/JOB_e2e.yml
@@ -42,14 +42,10 @@ jobs:
           E2E_ENVIRONMENT: ${{ secrets.E2E_ENVIRONMENT }}
           E2E_TEAM: ${{ secrets.E2E_TEAM }}
 
-      # Add this step to force a failure
-      - name: Force Failure for Testing
-        run: exit 1
-
   slack-notifier:
     name: Slack Notifier Bot
     needs: e2e
-    if: failure()
+    if: failure() && github.event_name == 'schedule'
     uses: ./.github/workflows/JOB_slack_message.yml
     with:
       message: |

--- a/.github/workflows/JOB_e2e.yml
+++ b/.github/workflows/JOB_e2e.yml
@@ -41,22 +41,23 @@ jobs:
           E2E_API_KEY: ${{ secrets.E2E_API_KEY }}
           E2E_ENVIRONMENT: ${{ secrets.E2E_ENVIRONMENT }}
           E2E_TEAM: ${{ secrets.E2E_TEAM }}
+
+      # Add this step to force a failure
+      - name: Force Failure for Testing
+        run: exit 1
+
   slack-notifier:
     name: Slack Notifier Bot
     needs: e2e
-    if: failure() && github.event_name == 'schedule'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Notify Slack
-        uses: ./.github/workflows/JOB_slack_message.yml
-        with:
-          secrets: inherit
-          icon: ":warning:"
-          at_team: true
-          message: |
-            *Nightly E2E run failed*
+    if: failure()
+    uses: ./.github/workflows/JOB_slack_message.yml
+    with:
+      message: |
+        *Nightly E2E run failed*
 
-            :link:
-              - https://github.com/v7labs/darwin-py/actions/runs/${{ github.run_id }}
-            :warning: ${{ github.workflow }} failed.
-
+        :link:
+          - https://github.com/v7labs/darwin-py/actions/runs/${{ github.run_id }}
+        :warning: ${{ github.workflow }} failed.
+      icon: ":warning:"
+      at_team: true
+    secrets: inherit

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -957,7 +957,7 @@ def import_annotations(  # noqa: C901
 
     def import_annotation(parsed_file):
         image_id = remote_files[parsed_file.full_path]["item_id"]
-        default_slot_name = remote_files[parsed_file.full_path]["slot_names"]
+        default_slot_name = remote_files[parsed_file.full_path]["slot_names"][0]
         if parsed_file.slots and parsed_file.slots[0].name:
             default_slot_name = parsed_file.slots[0].name
 


### PR DESCRIPTION
# Problem
We've recently had a couple annotation import bugs that would have been caught by E2E tests. However:
- The Slack bot we have configured to notify us of failing nightly E2Es is broken
- Passing E2Es are not a requirement to release new darwin-py versions

# Solution
This PR:
- 1: Fixes the Slack bot that notifies us when nightly E2E runs fail
- 2: Introduces an E2E test run that needs to pass during the release process for it to succeed

# Changelog
Introduced a requirement for E2E tests to pass before new darwin-py versions can be released