### PR TITLE
Granted write access to EVENT_tag so it can create releases

### DIFF
--- a/.github/workflows/EVENT_tag.yml
+++ b/.github/workflows/EVENT_tag.yml
@@ -15,7 +15,7 @@ env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   create_release:


### PR DESCRIPTION
# Problem
`EVENT_tag.yml` needs `write` permission to create releases, but it only has `read` permissions

# Solution
Grant it `write` permissions instead