### PR TITLE
[DAR-3579][External] Resolved legacy NifTI annotation import blocker

### DIFF
--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -1518,6 +1518,9 @@ def _get_annotation_format(
     annotation_format : str
         The annotation format of the importer used to parse local files
     """
+    # This `if` block is temporary, but necessary while we migrate NifTI imports between the legacy method & the new method
+    if isinstance(importer, partial):
+        return importer.func.__module__.split(".")[3]
     return importer.__module__.split(".")[3]
 
 

--- a/tests/darwin/importer/importer_test.py
+++ b/tests/darwin/importer/importer_test.py
@@ -1,5 +1,6 @@
 import json
 import tempfile
+from functools import partial
 from pathlib import Path
 from typing import List, Tuple
 from unittest.mock import MagicMock, Mock, _patch, patch
@@ -927,6 +928,12 @@ def test__get_annotation_format():
     assert _get_annotation_format(get_importer("nifti")) == "nifti"
     assert _get_annotation_format(get_importer("pascal_voc")) == "pascal_voc"
     assert _get_annotation_format(get_importer("superannotate")) == "superannotate"
+
+
+def test__get_annotation_format_with_partial():
+    nifti_importer = get_importer("nifti")
+    legacy_nifti_importer = partial(nifti_importer, legacy=True)
+    assert _get_annotation_format(legacy_nifti_importer) == "nifti"
 
 
 def test_no_verify_warning_for_single_slotted_items():


### PR DESCRIPTION
# Problem
Work introduced in darwin-py 1.0.4 introduced a bug when importing NifTI annotations in the using the legacy method. When doing this, we turn the importer into a partial function. In 1.0.4 we introduced a function that checks the format of the importer. However, it does not work with partial functions, resulting in:
```
Traceback (most recent call last):   File "test.py", line 12, in <module>     importer.import_annotations(dataset, parser, ANNOTATION_PATHS, append=True)   File "/Users/john/Documents/code/development/darwin-py/darwin/importer/importer.py", line 851, in import_annotations     annotation_format = _get_annotation_format(importer)   File "/Users/john/Documents/code/development/darwin-py/darwin/importer/importer.py", line 1521, in _get_annotation_format     return importer.__module__.split(".")[3] AttributeError: 'functools.partial' object has no attribute '__module__'
```

# Solution
Allow `_get_annotation_format()` to work with partial functions. This is temporary, and we can remove it in a future version when we have finished migrating NifTI annotation imports from the legacy method to the new method

# Changelog
Resolved bug with legacy NifTI annotation imports
