### PR TITLE
[DAR-3333][External] Import raster layer annotations even if classes are created or updated

### DIFF
--- a/darwin/dataset/remote_dataset.py
+++ b/darwin/dataset/remote_dataset.py
@@ -691,6 +691,8 @@ class RemoteDataset(ABC):
             cls["available"] = belongs_to_current_dataset
             if team_wide or belongs_to_current_dataset:
                 classes_to_return.append(cls)
+            elif cls["annotation_types"] == ["raster_layer"]:
+                classes_to_return.append(cls)
         return classes_to_return
 
     def fetch_remote_attributes(self) -> List[Dict[str, Any]]:

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -1351,8 +1351,10 @@ def _import_annotations(
         )
 
         if (
-            annotation_type not in remote_classes
-            or annotation_class.name not in remote_classes[annotation_type]
+            (
+                annotation_type not in remote_classes
+                or annotation_class.name not in remote_classes[annotation_type]
+            )
             and annotation_type
             != "raster_layer"  # We do not skip raster layers as they are always available.
         ):

--- a/tests/darwin/dataset/remote_dataset_test.py
+++ b/tests/darwin/dataset/remote_dataset_test.py
@@ -196,18 +196,6 @@ def create_annotation_file(
         f.write(op)
 
 
-@pytest.fixture
-def mock_remote_dataset():
-    client = MagicMock()
-    return RemoteDatasetV2(
-        client=client,
-        team="test_team",
-        name="test_dataset",
-        slug="test-dataset",
-        dataset_id=1,
-    )
-
-
 @pytest.fixture()
 def files_content() -> Dict[str, Any]:
     return {
@@ -597,6 +585,36 @@ class TestFetchRemoteFiles:
 
 @pytest.mark.usefixtures("file_read_write_test")
 class TestFetchRemoteClasses:
+    def setup_method(self):
+        self.mock_classes = [
+            {
+                "name": "class1",
+                "datasets": [{"id": 1}],
+                "annotation_types": ["type1"],
+            },
+            {
+                "name": "class2",
+                "datasets": [{"id": 2}],
+                "annotation_types": ["type2"],
+            },
+            {
+                "name": "raster_class",
+                "datasets": [],
+                "annotation_types": ["raster_layer"],
+            },
+        ]
+
+    def create_remote_dataset(
+        self, darwin_client, dataset_name, dataset_slug, team_slug_darwin_json_v2
+    ):
+        return RemoteDatasetV2(
+            client=darwin_client,
+            team=team_slug_darwin_json_v2,
+            name=dataset_name,
+            slug=dataset_slug,
+            dataset_id=1,
+        )
+
     @responses.activate
     def test_fetch_remote_classes_team_wide(
         self,
@@ -605,33 +623,13 @@ class TestFetchRemoteClasses:
         dataset_slug: str,
         team_slug_darwin_json_v2: str,
     ):
-        remote_dataset = RemoteDatasetV2(
-            client=darwin_client,
-            team=team_slug_darwin_json_v2,
-            name=dataset_name,
-            slug=dataset_slug,
-            dataset_id=1,
+        remote_dataset = self.create_remote_dataset(
+            darwin_client, dataset_name, dataset_slug, team_slug_darwin_json_v2
         )
         with patch.object(
             remote_dataset.client,
             "fetch_remote_classes",
-            return_value=[
-                {
-                    "name": "class1",
-                    "datasets": [{"id": 1}],
-                    "annotation_types": ["type1"],
-                },
-                {
-                    "name": "class2",
-                    "datasets": [{"id": 2}],
-                    "annotation_types": ["type2"],
-                },
-                {
-                    "name": "raster_class",
-                    "datasets": [],
-                    "annotation_types": ["raster_layer"],
-                },
-            ],
+            return_value=self.mock_classes,
         ):
             result = remote_dataset.fetch_remote_classes(team_wide=True)
             assert len(result) == 3
@@ -645,33 +643,13 @@ class TestFetchRemoteClasses:
         dataset_slug: str,
         team_slug_darwin_json_v2: str,
     ):
-        remote_dataset = RemoteDatasetV2(
-            client=darwin_client,
-            team=team_slug_darwin_json_v2,
-            name=dataset_name,
-            slug=dataset_slug,
-            dataset_id=1,
+        remote_dataset = self.create_remote_dataset(
+            darwin_client, dataset_name, dataset_slug, team_slug_darwin_json_v2
         )
         with patch.object(
             remote_dataset.client,
             "fetch_remote_classes",
-            return_value=[
-                {
-                    "name": "class1",
-                    "datasets": [{"id": 1}],
-                    "annotation_types": ["type1"],
-                },
-                {
-                    "name": "class2",
-                    "datasets": [{"id": 2}],
-                    "annotation_types": ["type2"],
-                },
-                {
-                    "name": "raster_class",
-                    "datasets": [],
-                    "annotation_types": ["raster_layer"],
-                },
-            ],
+            return_value=self.mock_classes,
         ):
             result = remote_dataset.fetch_remote_classes(team_wide=False)
             assert len(result) == 2


### PR DESCRIPTION
# Problem
When importing annotations, if any class needs to be created or assigned to the target dataset (not just masks), no raster layer annotations are actually imported

This is because if this happens, we create / update the classes as needed, then we re-fetch them [here](https://github.com/v7labs/darwin-py/blob/ad35478030eb7bc501a72a1beba84620a61c52ee/darwin/importer/importer.py#L931)

The problem is when we re-fetch the classes, we only fetch classes assigned to the dataset with `dataset.fetch_remote_classes()`

[Previously we were looking at team-wide classes](https://github.com/v7labs/darwin-py/blob/ad35478030eb7bc501a72a1beba84620a61c52ee/darwin/importer/importer.py#L791) with `dataset.fetch_remote_classes(team_wide=True)`. It seems that the ` __raster_layer__` class is never assigned to any dataset. This is a problem because despite containing the actual annotation data, it's not assigned to the dataset so we skip importing it

# Solution
Always return the `__raster_layer__` class when fetching remote classes, because it's always available in every dataset

# Changelog
Remove the need for a 2nd import to import mask annotations when classes are created or updated during import
