### PR TITLE
[DAR-3984][External] Improved HTTP error code verbosity

### DIFF
--- a/darwin/future/core/client.py
+++ b/darwin/future/core/client.py
@@ -263,10 +263,10 @@ def raise_for_darwin_exception(response: requests.Response) -> None:
     if response.status_code == 200:
         return
     if response.status_code == 400:
-        raise BadRequest(response)
+        raise BadRequest(response, response.text)
     if response.status_code == 401:
-        raise Unauthorized(response)
+        raise Unauthorized(response, response.text)
     if response.status_code == 404:
-        raise NotFound(response)
+        raise NotFound(response, response.text)
     if response.status_code == 422:
-        raise UnprocessibleEntity(response)
+        raise UnprocessibleEntity(response, response.text)


### PR DESCRIPTION
# Problem
Whenever darwin-py makes an API call, it raises various exceptions in the `raise_for_darwin_exception()` function if the `response` object has an error code that needs to be raised. However, it simply raises the object itself which shows only the error code. It would be very helpful (especially for 422s) if the error text was also displayed

# Solution
Display `response.text` as well as `response` when raising HTTP error codes

# Changelog
Increased detail of error handling in darwin-py