### PR TITLE
[DAR-3920][External] Bug fix for importing property values to identically named properties during property creation

### DIFF
--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -671,12 +671,23 @@ def _import_properties(
         if not annotation_id_map.get(annotation_id):
             continue
         annotation = annotation_id_map[annotation_id]
-
+        annotation_class = annotation.annotation_class
+        annotation_class_name = annotation_class.name
+        annotation_type = (
+            annotation_class.annotation_internal_type
+            or annotation_class.annotation_type
+        )
+        annotation_class_id = annotation_class_ids_map[
+            (annotation_class_name, annotation_type)
+        ]
         for a_prop in annotation.properties or []:
             frame_index = str(a_prop.frame_index)
 
             for prop in created_properties + updated_properties:
-                if prop.name == a_prop.name:
+                if (
+                    prop.name == a_prop.name
+                    and annotation_class_id == prop.annotation_class_id
+                ):
                     if a_prop.value is None:
                         if not annotation_property_map[annotation_id][frame_index][
                             prop.id

--- a/tests/darwin/data/metadata_identical_properties_different_classes.json
+++ b/tests/darwin/data/metadata_identical_properties_different_classes.json
@@ -1,0 +1,53 @@
+{
+    "version": "1.0",
+    "schema_ref": "https://darwin-public.s3.eu-west-1.amazonaws.com/darwin_json/metadata/1.0/schema.json",
+    "classes": [
+      {
+        "name": "test_class_1",
+        "type": "bounding_box",
+        "description": null,
+        "color": "rgba(255,46,0,1.0)",
+        "sub_types": [
+          "inference"
+        ],
+        "properties": [
+          {
+            "name": "existing_property_single_select",
+            "type": "single_select",
+            "description": "",
+            "required": false,
+            "property_values": [
+              {
+                "value": "1",
+                "color": "rgba(255,46,0,1.0)"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "test_class_2",
+        "type": "bounding_box",
+        "description": null,
+        "color": "rgba(255,46,0,1.0)",
+        "sub_types": [
+          "inference"
+        ],
+        "properties": [
+          {
+            "name": "existing_property_single_select",
+            "type": "single_select",
+            "description": "",
+            "required": false,
+            "property_values": [
+              {
+                "value": "1",
+                "color": "rgba(255,46,0,1.0)"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "properties": []
+  }


### PR DESCRIPTION
# Problem
This PR address an issue that occurs when creating two identically named properties on separate classes **and** then importing values of those properties in the same import action. In this scenario, we get this type of error:
```
Errors importing 000000580635.jpg
        {'errors': {'annotations': [{}, {}, {}, {}, {'annotation_properties': ["index '0', property 'bc5b7760-7786-4a0c-af89-8fdace15a0bf': property is not linked to the annotation's class"]}, {'annotation_properties': ["index '0', 
property 'bc5b7760-7786-4a0c-af89-8fdace15a0bf': property is not linked to the annotation's class"]}]}}
```
However: The import does successfully create the properties & their values. Additionally, a 2nd import will import the annotations without error

The problem is that the `annotation_property_map` returned from `_import_properties` is constructed incorrectly in this scenario. Specifically, we only used to check that the name of a property matched the name of the property to be imported. If importing annotations containing multiple identically named properties, this logic allows for mis-matching

# Solution
In addition to checking that the property names match, check that the annotation classes match too

# Changelog
Fixed an edge case when importing property values during property creation
