### PR TITLE
[DAR-3846][External] Prevent upload of dataset items where the `{item_path}/{item_name}` already exists in the dataset

### DIFF
--- a/tests/darwin/cli_functions_test.py
+++ b/tests/darwin/cli_functions_test.py
@@ -112,35 +112,38 @@ class TestUploadData:
         with patch.object(
             Client, "get_remote_dataset", return_value=remote_dataset
         ) as get_remote_dataset_mock:
-            with patch.object(Console, "print", return_value=None) as print_mock:
-                upload_data(
-                    f"{team_slug_darwin_json_v2}/{dataset_slug}",
-                    ["test_1.jpg", "test_2.jpg", "test_3.jpg"],
-                    [],
-                    0,
-                    None,
-                    False,
-                    False,
-                    False,
-                    False,
-                )
-                get_remote_dataset_mock.assert_called_once()
-
-                assert (
-                    call("Skipped 1 files already in the dataset.\n", style="warning")
-                    in print_mock.call_args_list
-                )
-                assert (
-                    call(
-                        "2 files couldn't be uploaded because an error occurred.\n",
-                        style="error",
+            with patch.object(remote_dataset, "fetch_remote_files", return_value=[]):
+                with patch.object(Console, "print", return_value=None) as print_mock:
+                    upload_data(
+                        f"{team_slug_darwin_json_v2}/{dataset_slug}",
+                        ["test_1.jpg", "test_2.jpg", "test_3.jpg"],
+                        [],
+                        0,
+                        None,
+                        False,
+                        False,
+                        False,
+                        False,
                     )
-                    in print_mock.call_args_list
-                )
-                assert (
-                    call('Re-run with "--verbose" for further details')
-                    in print_mock.call_args_list
-                )
+                    get_remote_dataset_mock.assert_called_once()
+
+                    assert (
+                        call(
+                            "Skipped 1 files already in the dataset.\n", style="warning"
+                        )
+                        in print_mock.call_args_list
+                    )
+                    assert (
+                        call(
+                            "2 files couldn't be uploaded because an error occurred.\n",
+                            style="error",
+                        )
+                        in print_mock.call_args_list
+                    )
+                    assert (
+                        call('Re-run with "--verbose" for further details')
+                        in print_mock.call_args_list
+                    )
 
     @pytest.mark.usefixtures("file_read_write_test")
     @responses.activate
@@ -215,35 +218,38 @@ class TestUploadData:
         with patch.object(
             Client, "get_remote_dataset", return_value=remote_dataset
         ) as get_remote_dataset_mock:
-            with patch.object(Console, "print", return_value=None) as print_mock:
-                upload_data(
-                    f"{team_slug_darwin_json_v2}/{dataset_slug}",
-                    ["test_1.jpg", "test_2.jpg", "test_3.jpg"],
-                    [],
-                    0,
-                    None,
-                    None,
-                    False,
-                    False,
-                    True,
-                )
-                get_remote_dataset_mock.assert_called_once()
-
-                assert (
-                    call("Skipped 1 files already in the dataset.\n", style="warning")
-                    in print_mock.call_args_list
-                )
-                assert (
-                    call(
-                        "2 files couldn't be uploaded because an error occurred.\n",
-                        style="error",
+            with patch.object(remote_dataset, "fetch_remote_files", return_value=[]):
+                with patch.object(Console, "print", return_value=None) as print_mock:
+                    upload_data(
+                        f"{team_slug_darwin_json_v2}/{dataset_slug}",
+                        ["test_1.jpg", "test_2.jpg", "test_3.jpg"],
+                        [],
+                        0,
+                        None,
+                        None,
+                        False,
+                        False,
+                        True,
                     )
-                    in print_mock.call_args_list
-                )
-                assert (
-                    call('Re-run with "--verbose" for further details')
-                    not in print_mock.call_args_list
-                )
+                    get_remote_dataset_mock.assert_called_once()
+
+                    assert (
+                        call(
+                            "Skipped 1 files already in the dataset.\n", style="warning"
+                        )
+                        in print_mock.call_args_list
+                    )
+                    assert (
+                        call(
+                            "2 files couldn't be uploaded because an error occurred.\n",
+                            style="error",
+                        )
+                        in print_mock.call_args_list
+                    )
+                    assert (
+                        call('Re-run with "--verbose" for further details')
+                        not in print_mock.call_args_list
+                    )
 
 
 class TestSetFileStatus:

--- a/tests/darwin/dataset/remote_dataset_test.py
+++ b/tests/darwin/dataset/remote_dataset_test.py
@@ -714,15 +714,18 @@ class TestPush:
             remote_dataset.push([LocalFile("test.jpg")], as_frames=True)
 
     def test_works_with_local_files_list(self, remote_dataset: RemoteDataset):
-        assert_upload_mocks_are_correctly_called(
-            remote_dataset, [LocalFile("test.jpg")]
-        )
+        with patch.object(remote_dataset, "fetch_remote_files", return_value=[]):
+            assert_upload_mocks_are_correctly_called(
+                remote_dataset, [LocalFile("test.jpg")]
+            )
 
     def test_works_with_path_list(self, remote_dataset: RemoteDataset):
-        assert_upload_mocks_are_correctly_called(remote_dataset, [Path("test.jpg")])
+        with patch.object(remote_dataset, "fetch_remote_files", return_value=[]):
+            assert_upload_mocks_are_correctly_called(remote_dataset, [Path("test.jpg")])
 
     def test_works_with_str_list(self, remote_dataset: RemoteDataset):
-        assert_upload_mocks_are_correctly_called(remote_dataset, ["test.jpg"])
+        with patch.object(remote_dataset, "fetch_remote_files", return_value=[]):
+            assert_upload_mocks_are_correctly_called(remote_dataset, ["test.jpg"])
 
     def test_works_with_supported_files(self, remote_dataset: RemoteDataset):
         supported_extensions = [
@@ -743,7 +746,8 @@ class TestPush:
             ".ndpi",
         ]
         filenames = [f"test{extension}" for extension in supported_extensions]
-        assert_upload_mocks_are_correctly_called(remote_dataset, filenames)
+        with patch.object(remote_dataset, "fetch_remote_files", return_value=[]):
+            assert_upload_mocks_are_correctly_called(remote_dataset, filenames)
 
     def test_raises_with_unsupported_files(self, remote_dataset: RemoteDataset):
         with pytest.raises(UnsupportedFileType):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -7,7 +7,9 @@ from zipfile import ZipFile
 import pytest
 
 from darwin.config import Config
+from darwin.client import Client
 from darwin.dataset.release import Release, ReleaseStatus
+from darwin.dataset.remote_dataset_v2 import RemoteDatasetV2
 
 
 @pytest.fixture
@@ -167,3 +169,19 @@ def releases_api_response() -> List[dict]:
             "download_url": None,
         },
     ]
+
+
+@pytest.fixture
+def remote_dataset(
+    darwin_client: Client,
+    dataset_name: str,
+    dataset_slug: str,
+    team_slug_darwin_json_v2: str,
+):
+    return RemoteDatasetV2(
+        client=darwin_client,
+        team=team_slug_darwin_json_v2,
+        name=dataset_name,
+        slug=dataset_slug,
+        dataset_id=1,
+    )


### PR DESCRIPTION
# Problem
Recently, I discovered that it's possible to add slots to existing items. The ability to upload multi-file items with `push` was built on the assumption that this was impossible, and has led to the following behaviour (because we name slots differently based on the merge mode):

1: Upload some files as one merge mode --> No error
2: Upload the same files a different merge mode --> No error
3: Upload the same files as the same merge mode as step 2 again --> You get an error about skipping files

We've decided that this type of scenario should be blocked in darwin-py, as most users would expect deduplication validation to take place on the item-name level

# Solution
Add a function to the `UploadHandler` constructor that runs the following before beginning the upload:
- 1: Gets a full list of full remote filepaths from the target dataset
- 2: Checks each planned full remote path against this list. If any path matches, we remove that file from the files to be uploaded and print a warning to the console

# Changelog
Prevent upload of dataset items where the `{item_path}/{item_name}` already exists in the dataset