### PR TITLE
[DAR-4298][External] Skip item-properties import for non-Darwin JSON 2.0 formats

### DIFF
--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -962,10 +962,11 @@ def _normalize_item_properties(
         return item_properties
 
     normalized_properties = defaultdict(lambda: {"property_values": []})
-    for item_prop in item_properties:
-        name = item_prop["name"]
-        value = item_prop["value"]
-        normalized_properties[name]["property_values"].append({"value": value})
+    if item_properties:
+        for item_prop in item_properties:
+            name = item_prop["name"]
+            value = item_prop["value"]
+            normalized_properties[name]["property_values"].append({"value": value})
 
     return normalized_properties
 


### PR DESCRIPTION
# Problem
darwin-py 1.0.9 introduced the ability to import item-level properties. Unfortunately, the item-level properties importer was written in a way that breaks the import flow of other formats with this error:
```
Importing annotations from local file:   0%|                                                                                                                                                                              | 0/1 [00:00<?, ?it/s]
Processing local annotation files:   0%|                                                                                                                                                                                  | 0/1 [00:00<?, ?it/s]
Traceback (most recent call last):
  File "test.py", line 13, in <module>
    importer.import_annotations(dataset, parser, ANNOTATION_PATHS, append=True)
  File "/Users/john/Documents/code/development/darwin-py/darwin/importer/importer.py", line 1480, in import_annotations
    process_local_file(local_file)
  File "/Users/john/Documents/code/development/darwin-py/darwin/importer/importer.py", line 1460, in process_local_file
    import_annotation(file)
  File "/Users/john/Documents/code/development/darwin-py/darwin/importer/importer.py", line 1379, in import_annotation
    errors, _ = _import_annotations(
  File "/Users/john/Documents/code/development/darwin-py/darwin/importer/importer.py", line 1852, in _import_annotations
    annotation_id_property_map = _import_properties(
  File "/Users/john/Documents/code/development/darwin-py/darwin/importer/importer.py", line 804, in _import_properties
    _normalize_item_properties(item_properties),
  File "/Users/john/Documents/code/development/darwin-py/darwin/importer/importer.py", line 965, in _normalize_item_properties
    for item_prop in item_properties:
TypeError: 'NoneType' object is not iterable
```

This happens because the importer tries to iterate on item-level properties to be imported before checking if they exist. For all formats but Darwin JSON 2.0.

# Solution
Before iterating on item-level properties to import, first check if they exist

We will be adding E2E import tests for all supported annotation formats in the near future, which will prevent issues such as this one

# Changelog
Bug fix for importing non-Darwin JSON 2.0 annotations