### PR TITLE
[DAR-4064][External] Annotation import E2E test for warning about importing multi-value instance IDs

### DIFF
--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -2170,6 +2170,7 @@ def _warn_for_annotations_with_multiple_instance_ids(
             unique_instance_ids = []
             for frame_idx in annotation.frames:  # type: ignore
                 for subannotation in annotation.frames[frame_idx].subs:  # type: ignore
+                    print(subannotation)
                     if subannotation.annotation_type == "instance_id":
                         instance_id = subannotation.data
                         if instance_id not in unique_instance_ids:

--- a/e2e_tests/cli/test_import.py
+++ b/e2e_tests/cli/test_import.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 
 from e2e_tests.helpers import (
-    assert_cli,
     run_cli_command,
     export_and_download_annotations,
     delete_annotation_uuids,
@@ -238,7 +237,6 @@ def run_import_test(
     result = run_cli_command(
         f"darwin dataset import {local_dataset.name} darwin {expected_annotations_dir} {additional_flags}"
     )
-    assert_cli(result, exit_code)
 
     if expect_warning:
         assert expect_warning in result.stdout
@@ -464,4 +462,17 @@ def test_import_annotations_with_subtypes_to_videos(
         config_values,
         item_type="single_slotted_video",
         annotations_subdir="video_annotations_with_subtypes",
+    )
+
+
+# For this test to succeed, the `e2e-testing` Darwin team must have the `STATIC_INSTANCE_ID` feature flag enabled
+def test_importing_multiple_instance_id_values_per_annotation_generates_a_warning(
+    local_dataset: E2EDataset, config_values: ConfigValues
+) -> None:
+    run_import_test(
+        local_dataset,
+        config_values,
+        item_type="single_slotted_video",
+        annotations_subdir="video_annotation_with_multiple_instance_ids",
+        expect_error="multiple instance ID values",
     )

--- a/e2e_tests/data/import/video_annotation_with_multiple_instance_ids/mini_uct.json
+++ b/e2e_tests/data/import/video_annotation_with_multiple_instance_ids/mini_uct.json
@@ -1,0 +1,133 @@
+{
+  "version": "2.0",
+  "schema_ref": "https://darwin-public.s3.eu-west-1.amazonaws.com/darwin_json/2.0/schema.json",
+  "item": {
+    "name": "mini_uct.mp4",
+    "path": "/",
+    "source_info": {
+      "item_id": "0192788d-f84c-3e47-3ed9-5801e3073ae1",
+      "dataset": {
+        "name": "test_dataset_50ea2a66-d526-4212-928a-eac3745da30a",
+        "slug": "test_dataset_50ea2a66-d526-4212-928a-eac3745da30a",
+        "dataset_management_url": "https://staging.v7labs.com/datasets/386274/dataset-management"
+      },
+      "team": {
+        "name": "E2E Testing",
+        "slug": "e2e-testing"
+      },
+      "workview_url": "https://staging.v7labs.com/workview?dataset=386274&item=0192788d-f84c-3e47-3ed9-5801e3073ae1"
+    },
+    "slots": [
+      {
+        "type": "video",
+        "slot_name": "0",
+        "width": 1920,
+        "height": 1080,
+        "fps": 1,
+        "thumbnail_url": "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/65750b55-ccfc-4a01-b9a5-ab3f1d6a0a64/thumbnail",
+        "source_files": [
+          {
+            "file_name": "mini_uct.mp4",
+            "storage_key": "darwin-py/videos/mini_uct.mp4",
+            "url": "https://staging.v7labs.com/api/v2/teams/e2e-testing/uploads/78f2a1ac-210d-43f9-bb48-d0d0c9ca17b8"
+          }
+        ],
+        "frame_count": 10,
+        "frame_urls": [
+          "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/65750b55-ccfc-4a01-b9a5-ab3f1d6a0a64/sections/0",
+          "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/65750b55-ccfc-4a01-b9a5-ab3f1d6a0a64/sections/1",
+          "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/65750b55-ccfc-4a01-b9a5-ab3f1d6a0a64/sections/2",
+          "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/65750b55-ccfc-4a01-b9a5-ab3f1d6a0a64/sections/3",
+          "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/65750b55-ccfc-4a01-b9a5-ab3f1d6a0a64/sections/4",
+          "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/65750b55-ccfc-4a01-b9a5-ab3f1d6a0a64/sections/5",
+          "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/65750b55-ccfc-4a01-b9a5-ab3f1d6a0a64/sections/6",
+          "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/65750b55-ccfc-4a01-b9a5-ab3f1d6a0a64/sections/7",
+          "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/65750b55-ccfc-4a01-b9a5-ab3f1d6a0a64/sections/8",
+          "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/65750b55-ccfc-4a01-b9a5-ab3f1d6a0a64/sections/9"
+        ]
+      }
+    ]
+  },
+  "annotations": [
+    {
+      "frames": {
+        "0": {
+          "bounding_box": {
+            "h": 3.8235,
+            "w": 6.1275,
+            "x": 7.9412,
+            "y": 8.6765
+          },
+          "instance_id": {
+            "value": 20
+          },
+          "keyframe": true
+        },
+        "1": {
+          "bounding_box": {
+            "h": 3.8235,
+            "w": 6.1275,
+            "x": 7.9412,
+            "y": 8.6765
+          },
+          "instance_id": {
+            "value": 21
+          },
+          "keyframe": false
+        },
+        "2": {
+          "bounding_box": {
+            "h": 3.8235,
+            "w": 6.1275,
+            "x": 7.9412,
+            "y": 8.6765
+          },
+          "instance_id": {
+            "value": 22
+          },
+          "keyframe": false
+        },
+        "3": {
+          "bounding_box": {
+            "h": 3.8235,
+            "w": 6.1275,
+            "x": 7.9412,
+            "y": 8.6765
+          },
+          "instance_id": {
+            "value": 23
+          },
+          "keyframe": false
+        },
+        "4": {
+          "bounding_box": {
+            "h": 3.8235,
+            "w": 6.1275,
+            "x": 7.9412,
+            "y": 8.6765
+          },
+          "instance_id": {
+            "value": 24
+          },
+          "keyframe": true
+        }
+      },
+      "global_sub_types": {},
+      "id": "c92972c6-41a5-48b6-8c4a-9e8062d06d61",
+      "interpolate_algorithm": "linear-1.1",
+      "interpolated": true,
+      "name": "test_bounding_box_with_subtypes_and_properties",
+      "properties": [],
+      "ranges": [
+        [
+          0,
+          5
+        ]
+      ],
+      "slot_names": [
+        "0"
+      ]
+    }
+  ],
+  "properties": []
+}

--- a/e2e_tests/data/import/video_annotations_with_subtypes/mini_uct.json
+++ b/e2e_tests/data/import/video_annotations_with_subtypes/mini_uct.json
@@ -1,0 +1,904 @@
+{
+  "version": "2.0",
+  "schema_ref": "https://darwin-public.s3.eu-west-1.amazonaws.com/darwin_json/2.0/schema.json",
+  "item": {
+    "name": "mini_uct.mp4",
+    "path": "/",
+    "source_info": {
+      "item_id": "01927880-0b20-0006-97b0-4f41cfbd0ebd",
+      "dataset": {
+        "name": "test_dataset_3ccaab8e-3de2-467d-b75f-7b7b5776bd8a",
+        "slug": "test_dataset_3ccaab8e-3de2-467d-b75f-7b7b5776bd8a",
+        "dataset_management_url": "https://staging.v7labs.com/datasets/386252/dataset-management"
+      },
+      "team": {
+        "name": "E2E Testing",
+        "slug": "e2e-testing"
+      },
+      "workview_url": "https://staging.v7labs.com/workview?dataset=386252&item=01927880-0b20-0006-97b0-4f41cfbd0ebd"
+    },
+    "slots": [
+      {
+        "type": "video",
+        "slot_name": "0",
+        "width": 1920,
+        "height": 1080,
+        "fps": 1,
+        "thumbnail_url": "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/8a6d5f0a-dd31-44bc-b719-5a9a0c2febbd/thumbnail",
+        "source_files": [
+          {
+            "file_name": "mini_uct.mp4",
+            "storage_key": "darwin-py/videos/mini_uct.mp4",
+            "url": "https://staging.v7labs.com/api/v2/teams/e2e-testing/uploads/18e0b4da-bb5f-4b24-beac-f2520bd4cf23"
+          }
+        ],
+        "frame_count": 10,
+        "frame_urls": [
+          "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/8a6d5f0a-dd31-44bc-b719-5a9a0c2febbd/sections/0",
+          "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/8a6d5f0a-dd31-44bc-b719-5a9a0c2febbd/sections/1",
+          "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/8a6d5f0a-dd31-44bc-b719-5a9a0c2febbd/sections/2",
+          "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/8a6d5f0a-dd31-44bc-b719-5a9a0c2febbd/sections/3",
+          "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/8a6d5f0a-dd31-44bc-b719-5a9a0c2febbd/sections/4",
+          "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/8a6d5f0a-dd31-44bc-b719-5a9a0c2febbd/sections/5",
+          "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/8a6d5f0a-dd31-44bc-b719-5a9a0c2febbd/sections/6",
+          "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/8a6d5f0a-dd31-44bc-b719-5a9a0c2febbd/sections/7",
+          "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/8a6d5f0a-dd31-44bc-b719-5a9a0c2febbd/sections/8",
+          "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/8a6d5f0a-dd31-44bc-b719-5a9a0c2febbd/sections/9"
+        ]
+      }
+    ]
+  },
+  "annotations": [
+    {
+      "frames": {
+        "1": {
+          "instance_id": {
+            "value": 14
+          },
+          "keyframe": true,
+          "skeleton": {
+            "nodes": [
+              {
+                "name": "node",
+                "occluded": false,
+                "x": 14.7549,
+                "y": 12.402
+              },
+              {
+                "name": "2",
+                "occluded": false,
+                "x": 10.1667,
+                "y": 9.3824
+              }
+            ]
+          },
+          "text": {
+            "text": "test_text"
+          }
+        },
+        "2": {
+          "instance_id": {
+            "value": 14
+          },
+          "keyframe": false,
+          "skeleton": {
+            "nodes": [
+              {
+                "name": "node",
+                "occluded": false,
+                "x": 14.7549,
+                "y": 12.402
+              },
+              {
+                "name": "2",
+                "occluded": false,
+                "x": 10.1667,
+                "y": 9.3824
+              }
+            ]
+          },
+          "text": {
+            "text": "test_text"
+          }
+        },
+        "3": {
+          "instance_id": {
+            "value": 14
+          },
+          "keyframe": true,
+          "skeleton": {
+            "nodes": [
+              {
+                "name": "node",
+                "occluded": false,
+                "x": 14.7549,
+                "y": 12.402
+              },
+              {
+                "name": "2",
+                "occluded": false,
+                "x": 10.1667,
+                "y": 9.3824
+              }
+            ]
+          },
+          "text": {
+            "text": "test_text"
+          }
+        }
+      },
+      "global_sub_types": {},
+      "id": "5a00aa6d-64ee-47ba-a030-9b8bb6129fa9",
+      "interpolate_algorithm": "linear-1.1",
+      "interpolated": true,
+      "name": "test_skeleton_with_subtypes_and_properties",
+      "properties": [
+        {
+          "frame_index": 1,
+          "name": "multi_select-1",
+          "value": "2"
+        },
+        {
+          "frame_index": 1,
+          "name": "multi_select-1",
+          "value": "1"
+        },
+        {
+          "frame_index": 1,
+          "name": "single_select-1",
+          "value": "2"
+        }
+      ],
+      "ranges": [
+        [
+          1,
+          4
+        ]
+      ],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "frames": {
+        "8": {
+          "instance_id": {
+            "value": 15
+          },
+          "keyframe": true,
+          "line": {
+            "path": [
+              {
+                "x": 8.4804,
+                "y": 9.0196
+              },
+              {
+                "x": 13.0882,
+                "y": 5.1471
+              },
+              {
+                "x": 12.451,
+                "y": 13.4804
+              }
+            ]
+          },
+          "text": {
+            "text": "test_text"
+          }
+        },
+        "9": {
+          "instance_id": {
+            "value": 15
+          },
+          "keyframe": true,
+          "line": {
+            "path": [
+              {
+                "x": 8.4804,
+                "y": 9.0196
+              },
+              {
+                "x": 13.0882,
+                "y": 5.1471
+              },
+              {
+                "x": 12.451,
+                "y": 13.4804
+              }
+            ]
+          },
+          "text": {
+            "text": "test_text"
+          }
+        }
+      },
+      "global_sub_types": {},
+      "id": "cae4fce9-50bc-46db-a71a-1e76b43edc92",
+      "interpolate_algorithm": "linear-1.1",
+      "interpolated": true,
+      "name": "test_line_with_subtypes_and_properties",
+      "properties": [
+        {
+          "frame_index": 8,
+          "name": "multi_select-1",
+          "value": "2"
+        },
+        {
+          "frame_index": 8,
+          "name": "multi_select-1",
+          "value": "1"
+        },
+        {
+          "frame_index": 8,
+          "name": "single_select-1",
+          "value": "1"
+        }
+      ],
+      "ranges": [
+        [
+          8,
+          10
+        ]
+      ],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "frames": {
+        "8": {
+          "instance_id": {
+            "value": 16
+          },
+          "keyframe": true,
+          "keypoint": {
+            "x": 8.2353,
+            "y": 19.951
+          },
+          "text": {
+            "text": "test_text"
+          }
+        },
+        "9": {
+          "instance_id": {
+            "value": 16
+          },
+          "keyframe": true,
+          "keypoint": {
+            "x": 8.2353,
+            "y": 19.951
+          },
+          "text": {
+            "text": "test_text"
+          }
+        }
+      },
+      "global_sub_types": {},
+      "id": "1538874f-fe2e-4a65-8f42-7ce31339842c",
+      "interpolate_algorithm": "linear-1.1",
+      "interpolated": true,
+      "name": "test_keypoint_with_subtypes_and_properties",
+      "properties": [
+        {
+          "frame_index": 8,
+          "name": "multi_select-1",
+          "value": "2"
+        },
+        {
+          "frame_index": 8,
+          "name": "multi_select-1",
+          "value": "1"
+        },
+        {
+          "frame_index": 8,
+          "name": "single_select-1",
+          "value": "2"
+        }
+      ],
+      "ranges": [
+        [
+          8,
+          10
+        ]
+      ],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "frames": {
+        "5": {
+          "ellipse": {
+            "angle": 0.2019,
+            "center": {
+              "x": 8.799,
+              "y": 6.8627
+            },
+            "radius": {
+              "x": 5.3788,
+              "y": 5.3788
+            }
+          },
+          "instance_id": {
+            "value": 17
+          },
+          "keyframe": true,
+          "text": {
+            "text": "test_text"
+          }
+        },
+        "6": {
+          "ellipse": {
+            "angle": 0.2019,
+            "center": {
+              "x": 8.799,
+              "y": 6.8627
+            },
+            "radius": {
+              "x": 5.3788,
+              "y": 5.3788
+            }
+          },
+          "instance_id": {
+            "value": 17
+          },
+          "keyframe": false,
+          "text": {
+            "text": "test_text"
+          }
+        },
+        "7": {
+          "ellipse": {
+            "angle": 0.2019,
+            "center": {
+              "x": 8.799,
+              "y": 6.8627
+            },
+            "radius": {
+              "x": 5.3788,
+              "y": 5.3788
+            }
+          },
+          "instance_id": {
+            "value": 17
+          },
+          "keyframe": true,
+          "text": {
+            "text": "test_text"
+          }
+        }
+      },
+      "global_sub_types": {},
+      "id": "1a50ad19-6516-4bfb-aba9-81d4313f242a",
+      "interpolate_algorithm": "linear-1.1",
+      "interpolated": true,
+      "name": "test_ellipse_with_subtypes_and_properties",
+      "properties": [
+        {
+          "frame_index": 5,
+          "name": "single_select-1",
+          "value": "1"
+        }
+      ],
+      "ranges": [
+        [
+          5,
+          8
+        ]
+      ],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "frames": {
+        "5": {
+          "bounding_box": {
+            "h": 4.607799999999999,
+            "w": 6.0783999999999985,
+            "x": 16.2255,
+            "y": 3.3824
+          },
+          "instance_id": {
+            "value": 18
+          },
+          "keyframe": true,
+          "polygon": {
+            "paths": [
+              [
+                {
+                  "x": 18.4804,
+                  "y": 3.3824
+                },
+                {
+                  "x": 16.2255,
+                  "y": 7.451
+                },
+                {
+                  "x": 22.3039,
+                  "y": 7.9902
+                },
+                {
+                  "x": 21.8137,
+                  "y": 7.3529
+                }
+              ]
+            ]
+          },
+          "text": {
+            "text": "test_text"
+          }
+        },
+        "6": {
+          "bounding_box": {
+            "h": 4.607799999999999,
+            "w": 6.0783999999999985,
+            "x": 16.2255,
+            "y": 3.3824
+          },
+          "instance_id": {
+            "value": 18
+          },
+          "keyframe": false,
+          "polygon": {
+            "paths": [
+              [
+                {
+                  "x": 18.4804,
+                  "y": 3.3824
+                },
+                {
+                  "x": 16.2255,
+                  "y": 7.451
+                },
+                {
+                  "x": 22.3039,
+                  "y": 7.9902
+                },
+                {
+                  "x": 21.8137,
+                  "y": 7.3529
+                }
+              ]
+            ]
+          },
+          "text": {
+            "text": "test_text"
+          }
+        },
+        "7": {
+          "bounding_box": {
+            "h": 4.607799999999999,
+            "w": 6.0783999999999985,
+            "x": 16.2255,
+            "y": 3.3824
+          },
+          "instance_id": {
+            "value": 18
+          },
+          "keyframe": true,
+          "polygon": {
+            "paths": [
+              [
+                {
+                  "x": 18.4804,
+                  "y": 3.3824
+                },
+                {
+                  "x": 16.2255,
+                  "y": 7.451
+                },
+                {
+                  "x": 22.3039,
+                  "y": 7.9902
+                },
+                {
+                  "x": 21.8137,
+                  "y": 7.3529
+                }
+              ]
+            ]
+          },
+          "text": {
+            "text": "test_text"
+          }
+        }
+      },
+      "global_sub_types": {},
+      "id": "7642a105-42d5-4b2c-ac07-f5230da1afb2",
+      "interpolate_algorithm": "linear-1.1",
+      "interpolated": true,
+      "name": "test_polygon_with_subtypes_and_properties",
+      "properties": [
+        {
+          "frame_index": 5,
+          "name": "multi_select-1",
+          "value": "1"
+        },
+        {
+          "frame_index": 5,
+          "name": "multi_select-1",
+          "value": "2"
+        },
+        {
+          "frame_index": 5,
+          "name": "single_select-1",
+          "value": "2"
+        }
+      ],
+      "ranges": [
+        [
+          5,
+          8
+        ]
+      ],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "frames": {
+        "5": {
+          "bounding_box": {
+            "h": 2.402,
+            "w": 3.3824,
+            "x": 20.4902,
+            "y": 12.1569
+          },
+          "instance_id": {
+            "value": 19
+          },
+          "keyframe": true,
+          "text": {
+            "text": "test_text"
+          }
+        },
+        "6": {
+          "bounding_box": {
+            "h": 2.402,
+            "w": 3.3824,
+            "x": 20.4902,
+            "y": 12.1569
+          },
+          "instance_id": {
+            "value": 19
+          },
+          "keyframe": false,
+          "text": {
+            "text": "test_text"
+          }
+        },
+        "7": {
+          "bounding_box": {
+            "h": 2.402,
+            "w": 3.3824,
+            "x": 20.4902,
+            "y": 12.1569
+          },
+          "instance_id": {
+            "value": 19
+          },
+          "keyframe": true,
+          "text": {
+            "text": "test_text"
+          }
+        }
+      },
+      "global_sub_types": {},
+      "id": "57e9c6dc-50d2-44a6-8dc1-f7ce0ef422ee",
+      "interpolate_algorithm": "linear-1.1",
+      "interpolated": true,
+      "name": "test_bounding_box_with_subtypes_and_properties",
+      "properties": [
+        {
+          "frame_index": 5,
+          "name": "multi_select-1",
+          "value": null
+        },
+        {
+          "frame_index": 5,
+          "name": "single_select-1",
+          "value": "2"
+        }
+      ],
+      "ranges": [
+        [
+          5,
+          8
+        ]
+      ],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "frames": {
+        "4": {
+          "keyframe": true,
+          "mask": {}
+        },
+        "5": {
+          "keyframe": true,
+          "mask": {},
+          "text": {
+            "text": "test_text"
+          }
+        },
+        "6": {
+          "keyframe": true,
+          "mask": {}
+        }
+      },
+      "id": "54e70102-7c0f-46b8-ac39-9fb4960fbc6d",
+      "interpolate_algorithm": "linear-1.1",
+      "name": "test_mask_with_subtypes_and_properties",
+      "only_keyframes": true,
+      "properties": [
+        {
+          "frame_index": 4,
+          "name": "multi_select-1",
+          "value": null
+        },
+        {
+          "frame_index": 4,
+          "name": "single_select-1",
+          "value": null
+        },
+        {
+          "frame_index": 5,
+          "name": "multi_select-1",
+          "value": "1"
+        },
+        {
+          "frame_index": 5,
+          "name": "multi_select-1",
+          "value": "2"
+        },
+        {
+          "frame_index": 5,
+          "name": "single_select-1",
+          "value": "2"
+        }
+      ],
+      "ranges": [
+        [
+          4,
+          7
+        ]
+      ],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "frames": {
+        "0": {
+          "keyframe": true,
+          "tag": {},
+          "text": {
+            "text": "test_text"
+          }
+        },
+        "1": {
+          "keyframe": false,
+          "tag": {},
+          "text": {
+            "text": "test_text"
+          }
+        },
+        "2": {
+          "keyframe": true,
+          "tag": {},
+          "text": {
+            "text": "test_text"
+          }
+        }
+      },
+      "id": "49d7eb79-4c71-45ee-b518-99c1f90c4be4",
+      "name": "test_tag_with_subtypes_and_properties",
+      "properties": [
+        {
+          "frame_index": 0,
+          "name": "multi_select-1",
+          "value": "1"
+        },
+        {
+          "frame_index": 0,
+          "name": "multi_select-1",
+          "value": "2"
+        },
+        {
+          "frame_index": 0,
+          "name": "single_select-1",
+          "value": "2"
+        }
+      ],
+      "ranges": [
+        [
+          0,
+          3
+        ]
+      ],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "frames": {
+        "4": {
+          "keyframe": true,
+          "raster_layer": {
+            "dense_rle": [
+              0,
+              24970,
+              1,
+              4,
+              0,
+              1914,
+              1,
+              8,
+              0,
+              1912,
+              1,
+              8,
+              0,
+              1911,
+              1,
+              10,
+              0,
+              1910,
+              1,
+              10,
+              0,
+              1910,
+              1,
+              10,
+              0,
+              1910,
+              1,
+              10,
+              0,
+              1911,
+              1,
+              8,
+              0,
+              1912,
+              1,
+              8,
+              0,
+              1914,
+              1,
+              4,
+              0,
+              2031346
+            ],
+            "mask_annotation_ids_mapping": {
+              "54e70102-7c0f-46b8-ac39-9fb4960fbc6d": 1
+            },
+            "total_pixels": 2073600
+          }
+        },
+        "5": {
+          "keyframe": true,
+          "raster_layer": {
+            "dense_rle": [
+              0,
+              24970,
+              1,
+              4,
+              0,
+              1914,
+              1,
+              8,
+              0,
+              1912,
+              1,
+              8,
+              0,
+              1911,
+              1,
+              10,
+              0,
+              1910,
+              1,
+              10,
+              0,
+              1910,
+              1,
+              10,
+              0,
+              1910,
+              1,
+              10,
+              0,
+              1911,
+              1,
+              8,
+              0,
+              1912,
+              1,
+              8,
+              0,
+              1914,
+              1,
+              4,
+              0,
+              2031346
+            ],
+            "mask_annotation_ids_mapping": {
+              "54e70102-7c0f-46b8-ac39-9fb4960fbc6d": 1
+            },
+            "total_pixels": 2073600
+          }
+        },
+        "6": {
+          "keyframe": true,
+          "raster_layer": {
+            "dense_rle": [
+              0,
+              24970,
+              1,
+              4,
+              0,
+              1914,
+              1,
+              8,
+              0,
+              1912,
+              1,
+              8,
+              0,
+              1911,
+              1,
+              10,
+              0,
+              1910,
+              1,
+              10,
+              0,
+              1910,
+              1,
+              10,
+              0,
+              1910,
+              1,
+              10,
+              0,
+              1911,
+              1,
+              8,
+              0,
+              1912,
+              1,
+              8,
+              0,
+              1914,
+              1,
+              4,
+              0,
+              2031346
+            ],
+            "mask_annotation_ids_mapping": {
+              "54e70102-7c0f-46b8-ac39-9fb4960fbc6d": 1
+            },
+            "total_pixels": 2073600
+          }
+        }
+      },
+      "id": "d87c4c88-5fc4-4fb4-ae93-e88c38c4bf34",
+      "name": "__raster_layer__",
+      "only_keyframes": true,
+      "properties": [],
+      "ranges": [
+        [
+          0,
+          10
+        ]
+      ],
+      "slot_names": [
+        "0"
+      ]
+    }
+  ],
+  "properties": []
+}

--- a/e2e_tests/data/import/video_annotations_without_subtypes/mini_uct.json
+++ b/e2e_tests/data/import/video_annotations_without_subtypes/mini_uct.json
@@ -1,0 +1,736 @@
+{
+  "version": "2.0",
+  "schema_ref": "https://darwin-public.s3.eu-west-1.amazonaws.com/darwin_json/2.0/schema.json",
+  "item": {
+    "name": "mini_uct.mp4",
+    "path": "/",
+    "source_info": {
+      "item_id": "0192785c-3db6-f058-4c73-3a0b044b03f1",
+      "dataset": {
+        "name": "test_dataset_d3d38fef-aad5-439f-afd6-8360a25e84c8",
+        "slug": "test_dataset_d3d38fef-aad5-439f-afd6-8360a25e84c8",
+        "dataset_management_url": "https://staging.v7labs.com/datasets/386213/dataset-management"
+      },
+      "team": {
+        "name": "E2E Testing",
+        "slug": "e2e-testing"
+      },
+      "workview_url": "https://staging.v7labs.com/workview?dataset=386213&item=0192785c-3db6-f058-4c73-3a0b044b03f1"
+    },
+    "slots": [
+      {
+        "type": "video",
+        "slot_name": "0",
+        "width": 1920,
+        "height": 1080,
+        "fps": 1,
+        "thumbnail_url": "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/aa67036a-d93b-4f3d-9e23-1888331f689c/thumbnail",
+        "source_files": [
+          {
+            "file_name": "mini_uct.mp4",
+            "storage_key": "darwin-py/videos/mini_uct.mp4",
+            "url": "https://staging.v7labs.com/api/v2/teams/e2e-testing/uploads/3610aa16-6b40-492c-8a43-905839c06fde"
+          }
+        ],
+        "frame_count": 10,
+        "frame_urls": [
+          "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/aa67036a-d93b-4f3d-9e23-1888331f689c/sections/0",
+          "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/aa67036a-d93b-4f3d-9e23-1888331f689c/sections/1",
+          "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/aa67036a-d93b-4f3d-9e23-1888331f689c/sections/2",
+          "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/aa67036a-d93b-4f3d-9e23-1888331f689c/sections/3",
+          "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/aa67036a-d93b-4f3d-9e23-1888331f689c/sections/4",
+          "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/aa67036a-d93b-4f3d-9e23-1888331f689c/sections/5",
+          "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/aa67036a-d93b-4f3d-9e23-1888331f689c/sections/6",
+          "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/aa67036a-d93b-4f3d-9e23-1888331f689c/sections/7",
+          "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/aa67036a-d93b-4f3d-9e23-1888331f689c/sections/8",
+          "https://staging.v7labs.com/api/v2/teams/e2e-testing/files/aa67036a-d93b-4f3d-9e23-1888331f689c/sections/9"
+        ]
+      }
+    ]
+  },
+  "annotations": [
+    {
+      "frames": {
+        "5": {
+          "keyframe": true,
+          "skeleton": {
+            "nodes": [
+              {
+                "name": "node",
+                "occluded": false,
+                "x": 13.1373,
+                "y": 14.3627
+              },
+              {
+                "name": "2",
+                "occluded": false,
+                "x": 10.9804,
+                "y": 12.8333
+              }
+            ]
+          }
+        },
+        "6": {
+          "keyframe": false,
+          "skeleton": {
+            "nodes": [
+              {
+                "name": "node",
+                "occluded": false,
+                "x": 13.1373,
+                "y": 14.3627
+              },
+              {
+                "name": "2",
+                "occluded": false,
+                "x": 10.9804,
+                "y": 12.8333
+              }
+            ]
+          }
+        },
+        "7": {
+          "keyframe": true,
+          "skeleton": {
+            "nodes": [
+              {
+                "name": "node",
+                "occluded": false,
+                "x": 13.1373,
+                "y": 14.3627
+              },
+              {
+                "name": "2",
+                "occluded": false,
+                "x": 10.9804,
+                "y": 12.8333
+              }
+            ]
+          }
+        }
+      },
+      "global_sub_types": {},
+      "id": "361168f4-0d86-4bd5-b6d1-0c686cdabff1",
+      "interpolate_algorithm": "linear-1.1",
+      "interpolated": true,
+      "name": "test_skeleton_basic",
+      "properties": [],
+      "ranges": [
+        [
+          5,
+          8
+        ]
+      ],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "frames": {
+        "3": {
+          "bounding_box": {
+            "h": 10.0,
+            "w": 10.0,
+            "x": 3.6275,
+            "y": 6.1275
+          },
+          "keyframe": true,
+          "polygon": {
+            "paths": [
+              [
+                {
+                  "x": 12.9575,
+                  "y": 13.6275
+                },
+                {
+                  "x": 11.1275,
+                  "y": 15.4575
+                },
+                {
+                  "x": 8.6275,
+                  "y": 16.1275
+                },
+                {
+                  "x": 6.1275,
+                  "y": 15.4575
+                },
+                {
+                  "x": 4.2975,
+                  "y": 13.6275
+                },
+                {
+                  "x": 3.6275,
+                  "y": 11.1275
+                },
+                {
+                  "x": 4.2975,
+                  "y": 8.6275
+                },
+                {
+                  "x": 6.1275,
+                  "y": 6.7975
+                },
+                {
+                  "x": 8.6275,
+                  "y": 6.1275
+                },
+                {
+                  "x": 11.1275,
+                  "y": 6.7975
+                },
+                {
+                  "x": 12.9575,
+                  "y": 8.6275
+                },
+                {
+                  "x": 13.6275,
+                  "y": 11.1275
+                }
+              ]
+            ]
+          }
+        },
+        "4": {
+          "bounding_box": {
+            "h": 10.0,
+            "w": 10.0,
+            "x": 3.6275,
+            "y": 6.1275
+          },
+          "keyframe": false,
+          "polygon": {
+            "paths": [
+              [
+                {
+                  "x": 12.9575,
+                  "y": 13.6275
+                },
+                {
+                  "x": 11.1275,
+                  "y": 15.4575
+                },
+                {
+                  "x": 8.6275,
+                  "y": 16.1275
+                },
+                {
+                  "x": 6.1275,
+                  "y": 15.4575
+                },
+                {
+                  "x": 4.2975,
+                  "y": 13.6275
+                },
+                {
+                  "x": 3.6275,
+                  "y": 11.1275
+                },
+                {
+                  "x": 4.2975,
+                  "y": 8.6275
+                },
+                {
+                  "x": 6.1275,
+                  "y": 6.7975
+                },
+                {
+                  "x": 8.6275,
+                  "y": 6.1275
+                },
+                {
+                  "x": 11.1275,
+                  "y": 6.7975
+                },
+                {
+                  "x": 12.9575,
+                  "y": 8.6275
+                },
+                {
+                  "x": 13.6275,
+                  "y": 11.1275
+                }
+              ]
+            ]
+          }
+        },
+        "5": {
+          "bounding_box": {
+            "h": 10.0,
+            "w": 10.0,
+            "x": 3.6275,
+            "y": 6.1275
+          },
+          "keyframe": true,
+          "polygon": {
+            "paths": [
+              [
+                {
+                  "x": 12.9575,
+                  "y": 13.6275
+                },
+                {
+                  "x": 11.1275,
+                  "y": 15.4575
+                },
+                {
+                  "x": 8.6275,
+                  "y": 16.1275
+                },
+                {
+                  "x": 6.1275,
+                  "y": 15.4575
+                },
+                {
+                  "x": 4.2975,
+                  "y": 13.6275
+                },
+                {
+                  "x": 3.6275,
+                  "y": 11.1275
+                },
+                {
+                  "x": 4.2975,
+                  "y": 8.6275
+                },
+                {
+                  "x": 6.1275,
+                  "y": 6.7975
+                },
+                {
+                  "x": 8.6275,
+                  "y": 6.1275
+                },
+                {
+                  "x": 11.1275,
+                  "y": 6.7975
+                },
+                {
+                  "x": 12.9575,
+                  "y": 8.6275
+                },
+                {
+                  "x": 13.6275,
+                  "y": 11.1275
+                }
+              ]
+            ]
+          }
+        }
+      },
+      "global_sub_types": {},
+      "id": "8c7e0c9a-987d-453c-adf5-9fb0db10fd90",
+      "interpolate_algorithm": "linear-1.1",
+      "interpolated": true,
+      "name": "test_polygon_basic",
+      "properties": [],
+      "ranges": [
+        [
+          3,
+          6
+        ]
+      ],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "frames": {
+        "0": {
+          "keyframe": true,
+          "line": {
+            "path": [
+              {
+                "x": 6.1275,
+                "y": 5.098
+              },
+              {
+                "x": 0.098,
+                "y": 14.2157
+              },
+              {
+                "x": 14.4118,
+                "y": 16.3725
+              },
+              {
+                "x": 15.3431,
+                "y": 8.5784
+              }
+            ]
+          }
+        },
+        "1": {
+          "keyframe": false,
+          "line": {
+            "path": [
+              {
+                "x": 6.1275,
+                "y": 5.098
+              },
+              {
+                "x": 0.098,
+                "y": 14.2157
+              },
+              {
+                "x": 14.4118,
+                "y": 16.3725
+              },
+              {
+                "x": 15.3431,
+                "y": 8.5784
+              }
+            ]
+          }
+        },
+        "2": {
+          "keyframe": true,
+          "line": {
+            "path": [
+              {
+                "x": 6.1275,
+                "y": 5.098
+              },
+              {
+                "x": 0.098,
+                "y": 14.2157
+              },
+              {
+                "x": 14.4118,
+                "y": 16.3725
+              },
+              {
+                "x": 15.3431,
+                "y": 8.5784
+              }
+            ]
+          }
+        }
+      },
+      "global_sub_types": {},
+      "id": "506f67d6-4cc1-44b5-af87-6b774c8f6ff2",
+      "interpolate_algorithm": "linear-1.1",
+      "interpolated": true,
+      "name": "test_line_basic",
+      "properties": [],
+      "ranges": [
+        [
+          0,
+          3
+        ]
+      ],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "frames": {
+        "9": {
+          "keyframe": true,
+          "keypoint": {
+            "x": 18.4314,
+            "y": 6.2255
+          }
+        }
+      },
+      "global_sub_types": {},
+      "id": "04a2302b-d946-4595-ba3b-9c4c81c6fa10",
+      "interpolate_algorithm": "linear-1.1",
+      "interpolated": true,
+      "name": "test_keypoint_basic",
+      "properties": [],
+      "ranges": [
+        [
+          9,
+          10
+        ]
+      ],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "frames": {
+        "7": {
+          "ellipse": {
+            "angle": 0.4987,
+            "center": {
+              "x": 10.9804,
+              "y": 6.6912
+            },
+            "radius": {
+              "x": 3.1258,
+              "y": 3.1258
+            }
+          },
+          "keyframe": true
+        },
+        "8": {
+          "ellipse": {
+            "angle": 0.4987,
+            "center": {
+              "x": 10.9804,
+              "y": 6.6912
+            },
+            "radius": {
+              "x": 3.1258,
+              "y": 3.1258
+            }
+          },
+          "keyframe": false
+        },
+        "9": {
+          "ellipse": {
+            "angle": 0.4987,
+            "center": {
+              "x": 10.9804,
+              "y": 6.6912
+            },
+            "radius": {
+              "x": 3.1258,
+              "y": 3.1258
+            }
+          },
+          "keyframe": true
+        }
+      },
+      "global_sub_types": {},
+      "id": "d4c95883-3d62-484b-8396-ad515472a610",
+      "interpolate_algorithm": "linear-1.1",
+      "interpolated": true,
+      "name": "test_ellipse_basic",
+      "properties": [],
+      "ranges": [
+        [
+          7,
+          10
+        ]
+      ],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "frames": {
+        "7": {
+          "bounding_box": {
+            "h": 1.5196,
+            "w": 3.0882,
+            "x": 5.7353,
+            "y": 18.4314
+          },
+          "keyframe": true
+        },
+        "8": {
+          "bounding_box": {
+            "h": 1.5196,
+            "w": 3.0882,
+            "x": 5.7353,
+            "y": 18.4314
+          },
+          "keyframe": false
+        },
+        "9": {
+          "bounding_box": {
+            "h": 1.5196,
+            "w": 3.0882,
+            "x": 5.7353,
+            "y": 18.4314
+          },
+          "keyframe": true
+        }
+      },
+      "global_sub_types": {},
+      "id": "764aad3d-bfdf-434e-b39b-d1d89312d20f",
+      "interpolate_algorithm": "linear-1.1",
+      "interpolated": true,
+      "name": "test_bounding_box_basic",
+      "properties": [],
+      "ranges": [
+        [
+          7,
+          10
+        ]
+      ],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "frames": {
+        "3": {
+          "keyframe": true,
+          "mask": {}
+        },
+        "4": {
+          "keyframe": true,
+          "mask": {}
+        }
+      },
+      "id": "2b7d48b1-cfeb-4d86-a460-df1b488560e7",
+      "interpolate_algorithm": "linear-1.1",
+      "name": "test_mask_basic",
+      "only_keyframes": true,
+      "properties": [],
+      "ranges": [
+        [
+          3,
+          5
+        ]
+      ],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "frames": {
+        "5": {
+          "keyframe": true,
+          "tag": {}
+        },
+        "6": {
+          "keyframe": false,
+          "tag": {}
+        },
+        "7": {
+          "keyframe": true,
+          "tag": {}
+        }
+      },
+      "id": "38c36255-1807-4641-b83d-1b96a4839dba",
+      "name": "test_tag_basic",
+      "properties": [],
+      "ranges": [
+        [
+          5,
+          8
+        ]
+      ],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "frames": {
+        "3": {
+          "keyframe": true,
+          "raster_layer": {
+            "dense_rle": [
+              0,
+              26897,
+              1,
+              4,
+              0,
+              1914,
+              1,
+              8,
+              0,
+              1912,
+              1,
+              8,
+              0,
+              1911,
+              1,
+              10,
+              0,
+              1910,
+              1,
+              10,
+              0,
+              1910,
+              1,
+              10,
+              0,
+              1910,
+              1,
+              10,
+              0,
+              1911,
+              1,
+              8,
+              0,
+              1912,
+              1,
+              8,
+              0,
+              1914,
+              1,
+              4,
+              0,
+              2029419
+            ],
+            "mask_annotation_ids_mapping": {
+              "2b7d48b1-cfeb-4d86-a460-df1b488560e7": 1
+            },
+            "total_pixels": 2073600
+          }
+        },
+        "4": {
+          "keyframe": true,
+          "raster_layer": {
+            "dense_rle": [
+              0,
+              1937,
+              1,
+              4,
+              0,
+              1914,
+              1,
+              8,
+              0,
+              1912,
+              1,
+              8,
+              0,
+              1911,
+              1,
+              10,
+              0,
+              1910,
+              1,
+              10,
+              0,
+              1910,
+              1,
+              10,
+              0,
+              1910,
+              1,
+              10,
+              0,
+              1911,
+              1,
+              8,
+              0,
+              1912,
+              1,
+              8,
+              0,
+              1914,
+              1,
+              4,
+              0,
+              2054379
+            ],
+            "mask_annotation_ids_mapping": {
+              "2b7d48b1-cfeb-4d86-a460-df1b488560e7": 1
+            },
+            "total_pixels": 2073600
+          }
+        }
+      },
+      "id": "4d94efc6-dbea-4ccc-b49f-58510f7a7a71",
+      "name": "__raster_layer__",
+      "only_keyframes": true,
+      "properties": [],
+      "ranges": [
+        [
+          0,
+          10
+        ]
+      ],
+      "slot_names": [
+        "0"
+      ]
+    }
+  ],
+  "properties": []
+}

--- a/e2e_tests/objects.py
+++ b/e2e_tests/objects.py
@@ -145,6 +145,7 @@ def get_read_only_registration_payload(
     - `single_slotted`: A series of single-slotted items
     - `multi_slotted`: A single item with 3 image slots
     - `multi_channel`: A single item with 3 image channels
+    - `single_slotted_video`: A single single-slotted video
     """
     items = {
         "single_slotted": [
@@ -306,6 +307,87 @@ def get_read_only_registration_payload(
                 ],
                 "name": "multi_channel_item",
             },
+        ],
+        "single_slotted_video": [
+            {
+                "path": "/",
+                "type": "video",
+                "storage_key": "darwin-py/videos/mini_uct.mp4",
+                "storage_thumbnail_key": "darwin-py/videos/video_thumbnail.jpg",
+                "name": "mini_uct.mp4",
+                "sections": [
+                    {
+                        "section_index": 1,
+                        "height": 1080,
+                        "width": 1920,
+                        "storage_hq_key": "darwin-py/videos/hq_frames/image_1_hq.jpg",
+                        "storage_lq_key": "darwin-py/videos/hq_frames/image_1_lq.jpg",
+                    },
+                    {
+                        "section_index": 2,
+                        "height": 1080,
+                        "width": 1920,
+                        "storage_hq_key": "darwin-py/videos/hq_frames/image_2_hq.jpg",
+                        "storage_lq_key": "darwin-py/videos/hq_frames/image_2_lq.jpg",
+                    },
+                    {
+                        "section_index": 3,
+                        "height": 1080,
+                        "width": 1920,
+                        "storage_hq_key": "darwin-py/videos/hq_frames/image_3_hq.jpg",
+                        "storage_lq_key": "darwin-py/videos/hq_frames/image_3_lq.jpg",
+                    },
+                    {
+                        "section_index": 4,
+                        "height": 1080,
+                        "width": 1920,
+                        "storage_hq_key": "darwin-py/videos/hq_frames/image_4_hq.jpg",
+                        "storage_lq_key": "darwin-py/videos/hq_frames/image_4_lq.jpg",
+                    },
+                    {
+                        "section_index": 5,
+                        "height": 1080,
+                        "width": 1920,
+                        "storage_hq_key": "darwin-py/videos/hq_frames/image_5_hq.jpg",
+                        "storage_lq_key": "darwin-py/videos/hq_frames/image_5_lq.jpg",
+                    },
+                    {
+                        "section_index": 6,
+                        "height": 1080,
+                        "width": 1920,
+                        "storage_hq_key": "darwin-py/videos/hq_frames/image_6_hq.jpg",
+                        "storage_lq_key": "darwin-py/videos/hq_frames/image_6_lq.jpg",
+                    },
+                    {
+                        "section_index": 7,
+                        "height": 1080,
+                        "width": 1920,
+                        "storage_hq_key": "darwin-py/videos/hq_frames/image_7_hq.jpg",
+                        "storage_lq_key": "darwin-py/videos/hq_frames/image_7_lq.jpg",
+                    },
+                    {
+                        "section_index": 8,
+                        "height": 1080,
+                        "width": 1920,
+                        "storage_hq_key": "darwin-py/videos/hq_frames/image_8_hq.jpg",
+                        "storage_lq_key": "darwin-py/videos/hq_frames/image_8_lq.jpg",
+                    },
+                    {
+                        "section_index": 9,
+                        "height": 1080,
+                        "width": 1920,
+                        "storage_hq_key": "darwin-py/videos/hq_frames/image_9_hq.jpg",
+                        "storage_lq_key": "darwin-py/videos/hq_frames/image_9_lq.jpg",
+                    },
+                    {
+                        "section_index": 10,
+                        "height": 1080,
+                        "width": 1920,
+                        "storage_hq_key": "darwin-py/videos/hq_frames/image_10_hq.jpg",
+                        "storage_lq_key": "darwin-py/videos/hq_frames/image_10_lq.jpg",
+                    },
+                ],
+            }
         ],
     }
     return {


### PR DESCRIPTION
# Problem
When using `darwin dataset import`, if a user pushes an annotation with >1 value AND the `STATIC_INSTANCE_ID` FF is on, we throw a warning that only the first value is imported. We have no E2E test for this currently

# Solution
Add an E2E test for the above

# Changelog
Add test coverage for warning about importing multiple instance ID values
