### PR TITLE
[DAR-4305][External] Cancel `push` operations if there are no valid files to upload, and correctly remove invalid files

### DIFF
--- a/darwin/dataset/upload_manager.py
+++ b/darwin/dataset/upload_manager.py
@@ -452,18 +452,20 @@ class UploadHandler(ABC):
                     local_files_to_remove.extend(multi_file_item.files)
                     multi_file_items_to_remove.append(multi_file_item)
                     console.print(
-                        f"The remote filepath {multi_file_item.full_path} is already occupied by a dataset item in the {self.dataset.slug} dataset. Skipping upload of item.",
+                        f"The remote filepath {multi_file_item.full_path} is already occupied by a dataset item in the `{self.dataset.slug}` dataset. Skipping upload of item.",
                         style="warning",
                     )
         if self.local_files:
             for local_file in self.local_files:
-                if Path(local_file.full_path) in full_remote_filepaths:
+                if (
+                    Path(local_file.full_path) in full_remote_filepaths
+                    and local_file not in local_files_to_remove
+                ):
                     local_files_to_remove.append(local_file)
                     console.print(
-                        f"The remote filepath {local_file.full_path} already exists in the {self.dataset.slug} dataset. Skipping upload of item.",
+                        f"The remote filepath {local_file.full_path} already exists in the `{self.dataset.slug}` dataset. Skipping upload of item.",
                         style="warning",
                     )
-
         self.local_files = [
             local_file
             for local_file in self.local_files
@@ -475,6 +477,11 @@ class UploadHandler(ABC):
                 for multi_file_item in self.multi_file_items
                 if multi_file_item not in multi_file_items_to_remove
             ]
+
+        if not self.local_files and not self.multi_file_items:
+            raise ValueError(
+                "All items to be uploaded have paths that already exist in the remote dataset. No items to upload."
+            )
 
     def prepare_upload(
         self,


### PR DESCRIPTION
# Problem
There are 2 minor issues that were released with multi-file `push` in 1.0.10:

- When [pruning files to upload](https://github.com/v7labs/darwin-py/blob/14790692fda69d9bca403ca8c8c33207cab42ec4/darwin/dataset/upload_manager.py#L435) based on the full filepaths currently in the dataset - If we remove any multi-file items, we don't correctly remove the corresponding `LocalFile` objects. This leads to duplicate warnings
- If after [pruning files to upload](https://github.com/v7labs/darwin-py/blob/14790692fda69d9bca403ca8c8c33207cab42ec4/darwin/dataset/upload_manager.py#L435), there are no files left - The importer should stop and display this to the user. Currently it continues then displays:

```
All 0 files have been successfully uploaded.
```

# Solution
When removing local_

# Changelog
Improved error messaging when attempting to upload duplicate files