### PR TITLE
[DAR-4308][External] Allow `fetch_remote_files` to return files that have not yet finished processing

### DIFF
--- a/darwin/item.py
+++ b/darwin/item.py
@@ -98,7 +98,7 @@ class DatasetItem(BaseModel):
                 "current_workflow_id": raw.get("workflow_data", {}).get("workflow_id"),
                 "current_workflow": raw.get("workflow_data"),
                 "slots": raw["slots"],
-                "layout": raw["layout"],
+                "layout": raw.get("layout"),
             }
         else:
             data = {


### PR DESCRIPTION
# Problem
In DAR-2981, we allowed `fetch_remote_files` to return the layout of a remote file

However, this change assumed there would always be a layout, and for non-processed files, the layout is not yet populated, leading to a syntax error

# Solution
Allow `fetch_remote_files` to return non-processed files

# Changelog
Allow `fetch_remote_files` to return non-processed files
