### PR TITLE
[DAR-2973][External] Creation and import of text item-level properties

### DIFF
--- a/darwin/future/data_objects/properties.py
+++ b/darwin/future/data_objects/properties.py
@@ -93,10 +93,11 @@ class FullProperty(DefaultDarwin):
             "name": True,
             "type": True,
             "required": True,
-            "property_values": {"__all__": {"value", "color", "type"}},
             "description": True,
             "granularity": True,
         }
+        if self.type != "text":
+            include_fields["property_values"] = {"__all__": {"value", "color", "type"}}
         if self.granularity != PropertyGranularity.item:
             if self.annotation_class_id is None:
                 raise ValueError("annotation_class_id must be set")

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -948,7 +948,6 @@ def _normalize_item_properties(
     if isinstance(item_properties, dict):
         return item_properties
 
-    # How does this work for item-level properties created from annotations? We need to block text properties from annotations
     normalized_properties = defaultdict(lambda: {"property_values": []})
     if item_properties:
         for item_prop in item_properties:

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -385,14 +385,21 @@ def _serialize_item_level_properties(
     for item_property_value in item_property_values:
         item_property = team_item_properties_lookup[item_property_value["name"]]
         item_property_id = item_property.id
-        item_property_value_id = next(
-            (
-                pv.id
-                for pv in item_property.property_values or []
-                if pv.value == item_property_value["value"]
-            ),
-            None,
-        )
+        if (
+            item_property.type == "single_select"
+            or item_property.type == "multi_select"
+        ):
+            item_property_value_id = next(
+                (
+                    pv.id
+                    for pv in item_property.property_values or []
+                    if pv.value == item_property_value["value"]
+                ),
+                None,
+            )
+            value = {"id": item_property_value_id}
+        elif item_property.type == "text":
+            value = {"text": item_property_value["value"]}
         actors: List[dt.DictFreeForm] = []
         actors.extend(
             _handle_annotators(
@@ -406,7 +413,7 @@ def _serialize_item_level_properties(
             {
                 "actors": actors,
                 "property_id": item_property_id,
-                "value": {"id": item_property_value_id},
+                "value": value,
             }
         )
 
@@ -798,39 +805,19 @@ def _import_properties(
         _get_team_properties_annotation_lookup(client, dataset.team)
     )
 
-    # Create or update item-level properties from annotations
-    item_property_creations_from_metadata, item_property_updates_from_metadata = (
-        _create_update_item_properties(
-            _normalize_item_properties(item_properties),
-            team_item_properties_lookup,
-            client,
-        )
+    # Update item-level properties from annotations
+    _, item_properties_to_update_from_annotations = _create_update_item_properties(
+        _normalize_item_properties(item_properties),
+        team_item_properties_lookup,
+        client,
     )
 
-    properties_to_create = item_property_creations_from_metadata
-    properties_to_update = item_property_updates_from_metadata
-
-    if properties_to_create:
-        console.print(f"Creating {len(properties_to_create)} properties:", style="info")
-        for full_property in properties_to_create:
-            if full_property.granularity.value == "item":
-                console.print(
-                    f"- Creating item-level property '{full_property.name}' of type: {full_property.type}"
-                )
-            console.print(
-                f"- Creating property '{full_property.name}' of type {full_property.type}",
-            )
-            prop = client.create_property(
-                team_slug=full_property.slug, params=full_property
-            )
-            created_properties.append(prop)
-
-    if item_property_updates_from_metadata:
+    if item_properties_to_update_from_annotations:
         console.print(
-            f"Performing {len(item_property_updates_from_metadata)} property update(s):",
+            f"Performing {len(item_properties_to_update_from_annotations)} property update(s):",
             style="info",
         )
-        for full_property in item_property_updates_from_metadata:
+        for full_property in item_properties_to_update_from_annotations:
             if full_property.granularity.value == "item":
                 console.print(
                     f"- Updating item-level property '{full_property.name}' with new value: {full_property.property_values[0].value}"
@@ -961,12 +948,14 @@ def _normalize_item_properties(
     if isinstance(item_properties, dict):
         return item_properties
 
+    # How does this work for item-level properties created from annotations? We need to block text properties from annotations
     normalized_properties = defaultdict(lambda: {"property_values": []})
     if item_properties:
         for item_prop in item_properties:
             name = item_prop["name"]
             value = item_prop["value"]
-            normalized_properties[name]["property_values"].append({"value": value})
+            if value:
+                normalized_properties[name]["property_values"].append({"value": value})
 
     return normalized_properties
 
@@ -996,7 +985,11 @@ def _create_update_item_properties(
 
         # If the property exists in the team, check that all values are present
         if item_prop_name in team_item_properties_lookup:
+
             t_prop = team_item_properties_lookup[item_prop_name]
+            # If the property is a text property it won't have predefined values, so continue
+            if t_prop.type == "text":
+                continue
             t_prop_values = [
                 prop_val.value for prop_val in t_prop.property_values or []
             ]

--- a/darwin/path_utils.py
+++ b/darwin/path_utils.py
@@ -122,7 +122,10 @@ def is_properties_enabled(
         if _cls.get("properties"):
             return metadata_path
     for _item_level_property in metadata_item_level_properties:
-        if _item_level_property.get("property_values"):
+        if (
+            _item_level_property.get("property_values")
+            or _item_level_property["type"] == "text"
+        ):
             return metadata_path
 
     return False

--- a/e2e_tests/data/import/image_annotations_with_item_level_properties/image_1.json
+++ b/e2e_tests/data/import/image_annotations_with_item_level_properties/image_1.json
@@ -590,6 +590,10 @@
     {
       "name": "test_item_level_property_single_select",
       "value": "1"
+    },
+    {
+      "name": "test_item_level_property_text",
+      "value": "sample text"
     }
   ]
 }

--- a/e2e_tests/data/import/image_annotations_with_item_level_properties/image_2.json
+++ b/e2e_tests/data/import/image_annotations_with_item_level_properties/image_2.json
@@ -482,6 +482,10 @@
     {
       "name": "test_item_level_property_single_select",
       "value": "1"
+    },
+    {
+      "name": "test_item_level_property_text",
+      "value": "sample text"
     }
   ]
 }

--- a/e2e_tests/data/import/image_annotations_with_item_level_properties/image_3.json
+++ b/e2e_tests/data/import/image_annotations_with_item_level_properties/image_3.json
@@ -526,6 +526,10 @@
     {
       "name": "test_item_level_property_single_select",
       "value": "1"
+    },
+    {
+      "name": "test_item_level_property_text",
+      "value": "sample text"
     }
   ]
 }

--- a/e2e_tests/data/import/image_annotations_with_item_level_properties/image_4.json
+++ b/e2e_tests/data/import/image_annotations_with_item_level_properties/image_4.json
@@ -578,6 +578,10 @@
     {
       "name": "test_item_level_property_single_select",
       "value": "1"
+    },
+    {
+      "name": "test_item_level_property_text",
+      "value": "sample text"
     }
   ]
 }

--- a/e2e_tests/data/import/image_annotations_with_item_level_properties/image_5.json
+++ b/e2e_tests/data/import/image_annotations_with_item_level_properties/image_5.json
@@ -450,6 +450,10 @@
     {
       "name": "test_item_level_property_single_select",
       "value": "1"
+    },
+    {
+      "name": "test_item_level_property_text",
+      "value": "sample text"
     }
   ]
 }

--- a/e2e_tests/data/import/image_annotations_with_item_level_properties/image_6.json
+++ b/e2e_tests/data/import/image_annotations_with_item_level_properties/image_6.json
@@ -462,6 +462,10 @@
     {
       "name": "test_item_level_property_single_select",
       "value": "1"
+    },
+    {
+      "name": "test_item_level_property_text",
+      "value": "sample text"
     }
   ]
 }

--- a/e2e_tests/data/import/image_annotations_with_item_level_properties/image_7.json
+++ b/e2e_tests/data/import/image_annotations_with_item_level_properties/image_7.json
@@ -502,6 +502,10 @@
     {
       "name": "test_item_level_property_single_select",
       "value": "1"
+    },
+    {
+      "name": "test_item_level_property_text",
+      "value": "sample text"
     }
   ]
 }

--- a/e2e_tests/data/import/image_annotations_with_item_level_properties/image_8.json
+++ b/e2e_tests/data/import/image_annotations_with_item_level_properties/image_8.json
@@ -478,6 +478,10 @@
     {
       "name": "test_item_level_property_single_select",
       "value": "1"
+    },
+    {
+      "name": "test_item_level_property_text",
+      "value": "sample text"
     }
   ]
 }

--- a/e2e_tests/data/import/image_new_annotations_with_item_level_properties/.v7/metadata.json
+++ b/e2e_tests/data/import/image_new_annotations_with_item_level_properties/.v7/metadata.json
@@ -89,6 +89,14 @@
         }
       ],
       "granularity": "item"
+    },
+    {
+      "name": "new_item_level_property_text",
+      "type": "text",
+      "description": "",
+      "required": false,
+      "property_values": [],
+      "granularity": "item"
     }
   ]
 }

--- a/e2e_tests/data/import/image_new_annotations_with_item_level_properties/image_1.json
+++ b/e2e_tests/data/import/image_new_annotations_with_item_level_properties/image_1.json
@@ -590,6 +590,10 @@
     {
       "name": "new_item_level_property_single_select",
       "value": "1"
+    },
+    {
+      "name": "new_item_level_property_text",
+      "value": "sample text"
     }
   ]
 }

--- a/e2e_tests/data/import/image_new_annotations_with_item_level_properties/image_2.json
+++ b/e2e_tests/data/import/image_new_annotations_with_item_level_properties/image_2.json
@@ -482,6 +482,10 @@
     {
       "name": "new_item_level_property_single_select",
       "value": "1"
+    },
+    {
+      "name": "new_item_level_property_text",
+      "value": "sample text"
     }
   ]
 }

--- a/e2e_tests/data/import/image_new_annotations_with_item_level_properties/image_3.json
+++ b/e2e_tests/data/import/image_new_annotations_with_item_level_properties/image_3.json
@@ -526,6 +526,10 @@
     {
       "name": "new_item_level_property_single_select",
       "value": "1"
+    },
+    {
+      "name": "new_item_level_property_text",
+      "value": "sample text"
     }
   ]
 }

--- a/e2e_tests/data/import/image_new_annotations_with_item_level_properties/image_4.json
+++ b/e2e_tests/data/import/image_new_annotations_with_item_level_properties/image_4.json
@@ -578,6 +578,10 @@
     {
       "name": "new_item_level_property_single_select",
       "value": "1"
+    },
+    {
+      "name": "new_item_level_property_text",
+      "value": "sample text"
     }
   ]
 }

--- a/e2e_tests/data/import/image_new_annotations_with_item_level_properties/image_5.json
+++ b/e2e_tests/data/import/image_new_annotations_with_item_level_properties/image_5.json
@@ -450,6 +450,10 @@
     {
       "name": "test_item_level_property_single_select",
       "value": "1"
+    },
+    {
+      "name": "new_item_level_property_text",
+      "value": "sample text"
     }
   ]
 }

--- a/e2e_tests/data/import/image_new_annotations_with_item_level_properties/image_6.json
+++ b/e2e_tests/data/import/image_new_annotations_with_item_level_properties/image_6.json
@@ -462,6 +462,10 @@
     {
       "name": "new_item_level_property_single_select",
       "value": "1"
+    },
+    {
+      "name": "new_item_level_property_text",
+      "value": "sample text"
     }
   ]
 }

--- a/e2e_tests/data/import/image_new_annotations_with_item_level_properties/image_7.json
+++ b/e2e_tests/data/import/image_new_annotations_with_item_level_properties/image_7.json
@@ -502,6 +502,10 @@
     {
       "name": "new_item_level_property_single_select",
       "value": "1"
+    },
+    {
+      "name": "new_item_level_property_text",
+      "value": "sample text"
     }
   ]
 }

--- a/e2e_tests/data/import/image_new_annotations_with_item_level_properties/image_8.json
+++ b/e2e_tests/data/import/image_new_annotations_with_item_level_properties/image_8.json
@@ -478,6 +478,10 @@
     {
       "name": "new_item_level_property_single_select",
       "value": "1"
+    },
+    {
+      "name": "new_item_level_property_text",
+      "value": "sample text"
     }
   ]
 }

--- a/e2e_tests/setup_tests.py
+++ b/e2e_tests/setup_tests.py
@@ -284,11 +284,12 @@ def create_item_level_property(
         "name": name,
         "type": item_level_property_type,
         "granularity": "item",
-        "property_values": [
+    }
+    if item_level_property_type in ["single_select", "multi_select"]:
+        payload["property_values"] = [
             {"color": "rgba(255,92,0,1.0)", "value": "1"},
             {"color": "rgba(255,92,0,1.0)", "value": "2"},
-        ],
-    }
+        ]
     response = requests.post(url, json=payload, headers=headers)
     parsed_response = response.json()
     return E2EItemLevelProperty(
@@ -593,7 +594,7 @@ def setup_item_level_properties(config: ConfigValues) -> List[E2EItemLevelProper
     item_level_properties: List[E2EItemLevelProperty] = []
 
     print("Setting up item-level properties")
-    item_level_property_types = ["single_select", "multi_select"]
+    item_level_property_types = ["single_select", "multi_select", "text"]
     try:
         for item_level_property_type in item_level_property_types:
             try:


### PR DESCRIPTION
# Problem
darwin-py does not have the ability to:
- Create missing text-item level properties from the properties manifest file
- Import text item-property values

# Solution
- Add the above capabilities
- We also remove the ability to create any property (`item`, `annotation`, or `section`) from annotations alone. Properties may only be created from the manifest file, since otherwise we'd need to make an assumption about what type of property we are creating

# Changelog
Import of text item-level properties
