### PR TITLE
[DAR-4137][External] Do not push files in root of pushed directories to a `.` directory when `preserve_folders=True`

### DIFF
--- a/darwin/dataset/remote_dataset_v2.py
+++ b/darwin/dataset/remote_dataset_v2.py
@@ -986,6 +986,8 @@ def _find_files_to_upload_as_single_file_items(
                 local_path = str(
                     found_file.relative_to(source_files[0]).parent.as_posix()
                 )
+                if local_path == ".":
+                    local_path = "/"
         uploading_files.append(
             LocalFile(
                 found_file,

--- a/tests/darwin/dataset/remote_dataset_test.py
+++ b/tests/darwin/dataset/remote_dataset_test.py
@@ -22,6 +22,7 @@ from darwin.dataset.download_manager import (
 from darwin.dataset.release import Release, ReleaseStatus
 from darwin.dataset.remote_dataset_v2 import (
     RemoteDatasetV2,
+    _find_files_to_upload_as_single_file_items,
     _find_files_to_upload_as_multi_file_items,
 )
 from darwin.dataset.upload_manager import (
@@ -845,6 +846,24 @@ class TestPush:
                     item_merge_mode="slots",
                     **args,  # type: ignore
                 )
+
+    @pytest.mark.usefixtures("setup_zip")
+    def test_files_in_root_push_directoies_are_given_correct_remote_path(
+        self, setup_zip
+    ):
+        directory = setup_zip / "push_test_dir" / "topdir" / "subdir_1"
+        local_files = _find_files_to_upload_as_single_file_items(
+            [directory],
+            [],
+            [],
+            path="",
+            fps=1,
+            as_frames=False,
+            extract_views=False,
+            preserve_folders=True,
+        )
+        assert local_files[0].data["path"] == "/"
+        assert local_files[1].data["path"] == "/"
 
 
 @pytest.mark.usefixtures("setup_zip")


### PR DESCRIPTION
# Problem
Items in the root of a folder being pushed are currently uploaded to a `.` folder, instead of the actual dataset root itself

# Solution
When uploading files while preserving the local directory structure, place items in the root of target directories into the dataset root instead of a `.` directory

# Changelog
Fixed minor bug when uploading files to the root of a dataset folder when preserving the local directory structure
