### PR TITLE
[DAR-4878][External] Addition of the `handle_as_slices` argument for `push`

### DIFF
--- a/darwin/cli.py
+++ b/darwin/cli.py
@@ -124,6 +124,7 @@ def _run(args: Namespace, parser: ArgumentParser) -> None:
                 args.path,
                 args.frames,
                 args.extract_views,
+                args.handle_as_slices,
                 args.preserve_folders,
                 args.verbose,
                 args.item_merge_mode,

--- a/darwin/cli_functions.py
+++ b/darwin/cli_functions.py
@@ -655,6 +655,7 @@ def upload_data(
     path: Optional[str],
     frames: bool,
     extract_views: bool = False,
+    handle_as_slices: bool = False,
     preserve_folders: bool = False,
     verbose: bool = False,
     item_merge_mode: Optional[str] = None,
@@ -682,6 +683,8 @@ def upload_data(
         Specify whether the files will be uploaded as a list of frames or not.
     extract_views : bool
         If providing a volume, specify whether to extract the orthogonal views or not.
+    handle_as_slices : bool
+        Whether to upload DICOM files as slices
     preserve_folders : bool
         Specify whether or not to preserve folder paths when uploading.
     verbose : bool
@@ -779,6 +782,7 @@ def upload_data(
                 fps=fps,
                 as_frames=frames,
                 extract_views=extract_views,
+                handle_as_slices=handle_as_slices,
                 path=path,
                 preserve_folders=preserve_folders,
                 progress_callback=progress_callback,

--- a/darwin/dataset/remote_dataset_v2.py
+++ b/darwin/dataset/remote_dataset_v2.py
@@ -171,6 +171,7 @@ class RemoteDatasetV2(RemoteDataset):
         fps: int = 0,
         as_frames: bool = False,
         extract_views: bool = False,
+        handle_as_slices: Optional[bool] = False,
         files_to_exclude: Optional[List[PathLike]] = None,
         path: Optional[str] = None,
         preserve_folders: bool = False,
@@ -199,6 +200,8 @@ class RemoteDatasetV2(RemoteDataset):
             When the uploading file is a video, specify whether it's going to be uploaded as a list of frames.
         extract_views: bool, default: False
             When the uploading file is a volume, specify whether it's going to be split into orthogonal views.
+        handle_as_slices: Optioonal[bool], default: False
+            Whether to upload DICOM files as slices
         files_to_exclude : Optional[PathLike]], default: None
             Optional list of files to exclude from the file scan. These can be folders.
         path: Optional[str], default: None
@@ -267,7 +270,9 @@ class RemoteDatasetV2(RemoteDataset):
             local_files, multi_file_items = _find_files_to_upload_as_multi_file_items(
                 search_files, files_to_exclude, fps, item_merge_mode
             )
-            handler = UploadHandlerV2(self, local_files, multi_file_items)
+            handler = UploadHandlerV2(
+                self, local_files, multi_file_items, handle_as_slices=handle_as_slices
+            )
         else:
             local_files = _find_files_to_upload_as_single_file_items(
                 search_files,
@@ -279,7 +284,9 @@ class RemoteDatasetV2(RemoteDataset):
                 extract_views,
                 preserve_folders,
             )
-            handler = UploadHandlerV2(self, local_files)
+            handler = UploadHandlerV2(
+                self, local_files, handle_as_slices=handle_as_slices
+            )
         if blocking:
             handler.upload(
                 max_workers=max_workers,
@@ -883,10 +890,10 @@ def _find_files_to_upload_as_multi_file_items(
         List of directories to search for files.
     files_to_exclude : List[PathLike]
         List of files to exclude from the file scan.
-    item_merge_mode : str
-        Mode to merge the files in the folders. Valid options are: 'slots', 'series', 'channels'.
     fps : int
         When uploading video files, specify the framerate
+    item_merge_mode : str
+        Mode to merge the files in the folders. Valid options are: 'slots', 'series', 'channels'.
 
     Returns
     -------

--- a/darwin/options.py
+++ b/darwin/options.py
@@ -168,6 +168,11 @@ class Options:
             action="store_true",
             help="Upload a volume with all 3 orthogonal views.",
         )
+        parser_push.add_argument(
+            "--handle_as_slices",
+            action="store_true",
+            help="Upload DICOM files as slices",
+        )
 
         parser_push.add_argument(
             "--path", type=str, default=None, help="Folder to upload the files into."

--- a/tests/darwin/cli_functions_test.py
+++ b/tests/darwin/cli_functions_test.py
@@ -229,6 +229,7 @@ class TestUploadData:
                         None,
                         False,
                         False,
+                        False,
                         True,
                     )
                     get_remote_dataset_mock.assert_called_once()


### PR DESCRIPTION
# Problem
Our upload APIs expose a `handle_as_slices` option, which forces each input DICOM file to be treated as a single slice rather than a volume

darwin-py does not currently expose this, but it should

# Solution
Add `handle_as_slices` as a CLI & SDK `push` option

# Changelog
Allow users to force DICOM files to be uploaded as slices when uploading via darwin-py