### PR TITLE
[DAR-4923][External] Grant more memory to Ubuntu GH runners that need it

### DIFF
--- a/.github/workflows/EVENT_release.yml
+++ b/.github/workflows/EVENT_release.yml
@@ -77,6 +77,12 @@ jobs:
       id-token: write
       contents: write
     steps:
+      - name: Free Disk space
+        shell: bash
+        run: |
+          sudo rm -rf /usr/local/lib/android  # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: ${{ github.ref }}
@@ -106,6 +112,12 @@ jobs:
       id-token: write
       contents: write
     steps:
+      - name: Free Disk space
+        shell: bash
+        run: |
+          sudo rm -rf /usr/local/lib/android  # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+          
       - name: Harden Runner
         uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
         with:

--- a/.github/workflows/JOB_generate_documentation.yml
+++ b/.github/workflows/JOB_generate_documentation.yml
@@ -22,6 +22,12 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
+      - name: Free Disk space
+        shell: bash
+        run: |
+          sudo rm -rf /usr/local/lib/android  # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+
       - name: Harden Runner
         uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
         with:


### PR DESCRIPTION
# Problem
Since including support for Python 3.12 in master, Ubuntu GH runners that need to install all darwin-py dependencies have started OOMing

# Solution
Remove unnecessary files from Ubuntu GH runners that require the space

# Changelog
Fixed an out-of-memory issue in darwin-py's GitHub CI
