### PR TITLE
[DAR-4932][Internal] correct pixdim application in mask to polygon

### DIFF
--- a/darwin/importer/formats/nifti.py
+++ b/darwin/importer/formats/nifti.py
@@ -376,7 +376,7 @@ def mask_to_polygon(
             else:
                 return {"x": y, "y": x}
         else:
-            return {"x": y * pixdims[1], "y": x * pixdims[0]}
+            return {"x": y * pixdims[0], "y": x * pixdims[1]}
 
     _labels, external_paths, _internal_paths = find_contours(mask)
     if len(external_paths) > 1:


### PR DESCRIPTION
# Problem
When pixdims[0] ≠ pixdims[1], 3D mask annotations are incorrectly scaled when imported as polygons from a NifTI file.

# Solution
The key thing to note is in numpy 
- rows are indexed top to bottom
- columns are indexed left to right
But in visualisation space, the numpy columns represent the x axis and the numpy rows represent the y axis. Since pixdims[i] represents axis i in visualisation space, we need to switch the application of the pixdims.

# Changelog
(Will appear in release docs)
