### PR TITLE
[DAR-4931][External] Fixed regression affecting converting complex polygons to coco

### DIFF
--- a/e2e_tests/data/convert/coco/from/base_annotation.json
+++ b/e2e_tests/data/convert/coco/from/base_annotation.json
@@ -3,7 +3,15 @@
   "schema_ref": "https://darwin-public.s3.eu-west-1.amazonaws.com/darwin_json/2.0/schema.json",
   "item": {
     "name": "",
-    "path": "/"
+    "path": "/",
+    "slots": [
+      {
+        "type": "image",
+        "slot_name": "0",
+        "width": 1080,
+        "height": 1920
+      }
+    ]
   },
   "annotations": [
     {
@@ -58,6 +66,24 @@
             {
               "x": 0.0,
               "y": 1.0
+            }
+          ],
+          [
+            {
+              "x": 1.0,
+              "y": 0.0
+            },
+            {
+              "x": 1.0,
+              "y": 1.0
+            },
+            {
+              "x": 0.0,
+              "y": 1.0
+            },
+            {
+              "x": 0.0,
+              "y": 0.0
             }
           ]
         ]

--- a/e2e_tests/data/convert/coco/to/output.json
+++ b/e2e_tests/data/convert/coco/to/output.json
@@ -19,8 +19,8 @@
       "license": 0,
       "file_name": "",
       "coco_url": "n/a",
-      "height": null,
-      "width": null,
+      "height": 1920,
+      "width": 1080,
       "date_captured": "",
       "flickr_url": "n/a",
       "darwin_url": null,
@@ -60,26 +60,27 @@
       "id": 3,
       "image_id": 2043925204,
       "category_id": 3961009249,
-      "segmentation": [
-        [
-          0.0,
-          0.0,
-          1.0,
-          0.0,
-          1.0,
-          1.0,
-          0.0,
-          1.0
+      "segmentation": {
+        "counts": [
+          0,
+          2,
+          1918,
+          2,
+          2071678
+        ],
+        "size": [
+          1920,
+          1080
         ]
-      ],
-      "area": 1.0,
+      },
+      "area": 0,
       "bbox": [
-        0.0,
-        0.0,
-        1.0,
-        1.0
+        0,
+        0,
+        2,
+        2
       ],
-      "iscrowd": 0,
+      "iscrowd": 1,
       "extra": {}
     }
   ],

--- a/tests/darwin/exporter/formats/export_coco_test.py
+++ b/tests/darwin/exporter/formats/export_coco_test.py
@@ -14,12 +14,14 @@ class TestBuildAnnotations:
             filename="test.json",
             annotation_classes=set(),
             annotations=[],
+            image_height=1920,
+            image_width=1080,
         )
 
     def test_polygon_include_extras(self, annotation_file: dt.AnnotationFile):
         polygon = dt.Annotation(
             dt.AnnotationClass("polygon_class", "polygon"),
-            {"paths": [{"x": 1, "y": 1}, {"x": 2, "y": 2}, {"x": 1, "y": 2}]},
+            {"paths": [[{"x": 1, "y": 1}, {"x": 2, "y": 2}, {"x": 1, "y": 2}]]},
             [dt.make_instance_id(1)],
         )
 
@@ -28,6 +30,34 @@ class TestBuildAnnotations:
         assert coco._build_annotation(annotation_file, "test-id", polygon, categories)[
             "extra"
         ] == {"instance_id": 1}
+
+    def test_complex_polygon(self, annotation_file: dt.AnnotationFile):
+        polygon = dt.Annotation(
+            dt.AnnotationClass("polygon_class", "polygon"),
+            {
+                "paths": [
+                    [{"x": 1, "y": 1}, {"x": 2, "y": 2}, {"x": 1, "y": 2}],
+                    [{"x": 3, "y": 3}, {"x": 4, "y": 4}, {"x": 3, "y": 4}],
+                ]
+            },
+            [],
+        )
+
+        categories = {"polygon_class": 1}
+
+        annotations = coco._build_annotation(annotation_file, 1, polygon, categories)
+        assert annotations["segmentation"]["counts"] == [
+            1921,
+            2,
+            1919,
+            1,
+            1920,
+            2,
+            1919,
+            1,
+            2065915,
+        ]
+        assert annotations["segmentation"]["size"] == [1920, 1080]
 
     def test_bounding_boxes_include_extras(self, annotation_file: dt.AnnotationFile):
         bbox = dt.Annotation(


### PR DESCRIPTION
# Problem
In [this section](https://github.com/v7labs/darwin-py/commit/973d9cc7b87b1b001c42c5a0726c19000d03f8bb#diff-1ce0353c6b56373ab8cacc1aede1e66dbe5470136d11e76597b7e93f36895fd2L525-L552) of PLA-585, we removed the coco exporter's ability to export complex polygons. This was done by mistake as part of removing V1 code

# Solution
Re-add the logic for converting complex polygons. In the [COCO format](https://cocodataset.org/#format-data):
- Simple polygons (`iscrowd=0`) are represented as series of `(x, y)` points
- Complex polygons (`iscrowd=1`) are represented with RLE

Also updated existing unit & E2E tests for converting to COCO to include complex polygons

# Changelog
Fixed regression affecting conversion of complex polygons to the COCO format
