### PR TITLE
[DAR-4813][External] Allow upload of volumetric DICOM series from folders of DICOM slices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,4 @@ scripts/
 *test_results.xml
 version.txt
 !e2e_tests/data
+.cursorrules

--- a/tests/darwin/dataset/remote_dataset_test.py
+++ b/tests/darwin/dataset/remote_dataset_test.py
@@ -985,15 +985,13 @@ class TestPushDICOMSeries:
             [directory], [], 0, item_merge_mode="series"
         )
         assert len(multi_file_items) == 1
-        assert len(local_files) == 5
+        assert len(local_files) == 1
         assert multi_file_items[0].merge_mode == ItemMergeMode.SERIES
         assert multi_file_items[0].files == local_files
         assert multi_file_items[0].directory == directory
         assert multi_file_items[0].name == directory.name
-        assert multi_file_items[0].layout == {
-            "version": 3,
-            "slots_grid": [[["dicoms"]]],
-        }
+        assert multi_file_items[0].slot_names == ["0"]
+        assert multi_file_items[0].layout is None
 
     def test_dicoms_and_other_files(self, setup_zip):
         directory = (
@@ -1003,15 +1001,13 @@ class TestPushDICOMSeries:
             [directory], [], 0, item_merge_mode="series"
         )
         assert len(multi_file_items) == 1
-        assert len(local_files) == 5
+        assert len(local_files) == 1
         assert multi_file_items[0].merge_mode == ItemMergeMode.SERIES
         assert multi_file_items[0].files == local_files
         assert multi_file_items[0].directory == directory
         assert multi_file_items[0].name == directory.name
-        assert multi_file_items[0].layout == {
-            "version": 3,
-            "slots_grid": [[["dicoms_and_other_files"]]],
-        }
+        assert multi_file_items[0].layout is None
+        assert multi_file_items[0].slot_names == ["0"]
 
     def test_multiple_file_types(self, setup_zip):
         directory = setup_zip / "push_test_dir" / "multiple_file_types"
@@ -1019,15 +1015,13 @@ class TestPushDICOMSeries:
             [directory], [], 0, item_merge_mode="series"
         )
         assert len(multi_file_items) == 1
-        assert len(local_files) == 3
+        assert len(local_files) == 1
         assert multi_file_items[0].merge_mode == ItemMergeMode.SERIES
         assert multi_file_items[0].files == local_files
         assert multi_file_items[0].directory == directory
         assert multi_file_items[0].name == directory.name
-        assert multi_file_items[0].layout == {
-            "version": 3,
-            "slots_grid": [[["multiple_file_types"]]],
-        }
+        assert multi_file_items[0].layout is None
+        assert multi_file_items[0].slot_names == ["0"]
 
 
 @pytest.mark.usefixtures("setup_zip")


### PR DESCRIPTION
# Problem
We discovered that some DICOM slices uploaded as series via darwin-py would result in items that could not be viewed in MPR, and some would outright fail to process - This is despite the same files being uploadable via the UI as ZIP archives with the `.dcm` extension

This comes down to a difference in the way that darwin-py was uploading data vs. what happens happens when you upload a `.dcm` ZIP archive through the UI. Currently, darwin-py sends a registration payload to `/register_upload` containing as many objects are there are slices to be uploaded. This causes backend to assume the item is a multi-slotted item, in which case we cannot display volumes. Therefore backend sets `is_volume=False`, which disables MPR

The reason backend makes this assumption is that it currently doesn't have a way to know for certain if every item in the payload is part of the same slot

# Solution
This PR changes the way darwin-py uploads DICOM series. Specifically:
- Every slice bound for a specific item is placed in a ZIP archive, then the archive is renamed to `.dcm`
- We remove the `ignore_dicom_layout` flag when uploading DICOM series to more closely mirror the UI-upload experience
- We always use slot name `"0"` as this is required for MPR to work
- We set `layout` to None as layout is not required for a single-slotted item

# Changelog
Allowed upload of volumetric DICOM series from folders of slices via darwin-py