### PR TITLE
[DAR-5014][External] Better error messaging when importing to items not ready to receive annotations

### DIFF
--- a/darwin/dataset/remote_dataset_v2.py
+++ b/darwin/dataset/remote_dataset_v2.py
@@ -889,7 +889,9 @@ class RemoteDatasetV2(RemoteDataset):
             A list of full remote paths of dataset items that require NifTI annotations to be scaled
         """
         remote_files_that_require_legacy_scaling = []
-        remote_files = self.fetch_remote_files()
+        remote_files = self.fetch_remote_files(
+            filters={"statuses": ["new", "annotate", "review", "complete", "archived"]}
+        )
         for remote_file in remote_files:
             if not (
                 remote_file.slots[0]


### PR DESCRIPTION
# Problem
This ticket tackles 2 problems:
- 1: When importing annotations to items not ready to receive them, imports would fail without any error handling. These are items in the `uploading`, `processing`, `error`, and `archived` statuses
- 2: When importing `NifTI` annotations, if any item in the dataset was not in a state to receive annotations (even an item not targeted by the import), the import would fail without any error handling. This is happening due to the `fetch_remote_files()` call in `_get_remote_files_that_require_legacy_scaling()` not filtering for item status, then trying to retrieve slot information

# Solution
- 1: If an import job is trying to import annotations to item(s) not ready to receive them, we raise an error and display which items are affected and what statuses they are in
- 2: When importing `NifTI` annotations, we only retrieve items in valid import statuses in the `_get_remote_files_that_require_legacy_scaling()` function. If there are items not ready to receive annotations, they will be found later in the import flow by `_get_remote_files_ready_for_import()`

# Changelog
Better error handling and messaging when importing annotations to items not ready to receive them