### PR TITLE
[DAR-5340][External] Update `github-script` syntax

### DIFF
--- a/.github/workflows/EVENT_merge_to_master.yml
+++ b/.github/workflows/EVENT_merge_to_master.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            github.repos.createCommitStatus({
+            await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
               sha: context.sha,


### PR DESCRIPTION
# Problem
We recently updated `github-script` from version 3.2.0 to 7.0.1. This update uses slightly different syntax

# Solution
Update syntax of `createCommitStatus` used in the merge to master event

# Changelog
Maintenance of CI pipeline