### PR TITLE
[DAR-5342][External] Allow import of complex polygons in `COCO`

### DIFF
--- a/darwin/importer/formats/coco.py
+++ b/darwin/importer/formats/coco.py
@@ -170,7 +170,7 @@ def parse_annotation(
         return [dt.make_polygon(category["name"], paths)]
     elif isinstance(segmentation, list):
         paths = segmentation if isinstance(segmentation[0], list) else [segmentation]
-        polygons = []
+        point_paths = []
         for path in paths:
             point_path = []
             points = iter(path)
@@ -180,8 +180,8 @@ def parse_annotation(
                     point_path.append({"x": x, "y": y})
                 except StopIteration:
                     break
-            polygons.append(dt.make_polygon(category["name"], point_path))
-        return polygons
+            point_paths.append(point_path)
+        return [dt.make_polygon(category["name"], point_paths)]
     else:
         return []
 

--- a/tests/darwin/importer/formats/import_coco_test.py
+++ b/tests/darwin/importer/formats/import_coco_test.py
@@ -1,0 +1,92 @@
+from typing import Dict, Any
+
+import darwin.datatypes as dt
+from darwin.importer.formats.coco import parse_annotation
+
+
+def test_parse_annotation_single_polygon():
+    """Test parsing a single polygon segmentation"""
+    annotation = {
+        "segmentation": [[10, 10, 20, 10, 20, 20, 10, 20]],
+        "category_id": "1",
+        "bbox": [10, 10, 10, 10],
+        "iscrowd": 0,
+    }
+    category_lookup: Dict[str, Any] = {"1": {"name": "test_class"}}
+
+    result = parse_annotation(annotation, category_lookup)
+
+    assert len(result) == 1
+    assert isinstance(result[0], dt.Annotation)
+    assert result[0].annotation_class.name == "test_class"
+    assert len(result[0].data["paths"]) == 1
+    path = result[0].data["paths"][0]
+    assert len(path) == 4
+    assert path[0] == {"x": 10, "y": 10}
+    assert path[2] == {"x": 20, "y": 20}
+
+
+def test_parse_annotation_multiple_polygons():
+    """Test parsing segmentation with multiple polygons"""
+    annotation = {
+        "segmentation": [
+            [10, 10, 20, 10, 20, 20, 10, 20],
+            [30, 30, 40, 30, 40, 40, 30, 40],
+        ],
+        "category_id": "1",
+        "bbox": [10, 10, 30, 30],
+        "iscrowd": 0,
+    }
+    category_lookup: Dict[str, Any] = {"1": {"name": "test_class"}}
+
+    result = parse_annotation(annotation, category_lookup)
+
+    assert len(result) == 2
+    assert all(isinstance(r, dt.Annotation) for r in result)
+    assert all(r.annotation_class.name == "test_class" for r in result)
+
+    path1 = result[0].data["paths"][0]
+    assert len(path1) == 4
+    assert path1[0] == {"x": 10, "y": 10}
+    assert path1[2] == {"x": 20, "y": 20}
+
+    path2 = result[1].data["paths"][0]
+    assert len(path2) == 4
+    assert path2[0] == {"x": 30, "y": 30}
+    assert path2[2] == {"x": 40, "y": 40}
+
+
+def test_parse_annotation_bounding_box():
+    """Test parsing a bounding box annotation"""
+    annotation = {
+        "segmentation": [],
+        "category_id": "1",
+        "bbox": [10, 20, 30, 40],
+        "iscrowd": 0,
+    }
+    category_lookup: Dict[str, Any] = {"1": {"name": "test_class"}}
+
+    result = parse_annotation(annotation, category_lookup)
+
+    assert len(result) == 1
+    assert isinstance(result[0], dt.Annotation)
+    assert result[0].annotation_class.name == "test_class"
+    assert result[0].data["x"] == 10
+    assert result[0].data["y"] == 20
+    assert result[0].data["w"] == 30
+    assert result[0].data["h"] == 40
+
+
+def test_parse_annotation_crowd():
+    """Test that crowd annotations are skipped"""
+    annotation = {
+        "segmentation": [[10, 10, 20, 10, 20, 20, 10, 20]],
+        "category_id": "1",
+        "bbox": [10, 10, 10, 10],
+        "iscrowd": 1,
+    }
+    category_lookup: Dict[str, Any] = {"1": {"name": "test_class"}}
+
+    result = parse_annotation(annotation, category_lookup)
+
+    assert len(result) == 0

--- a/tests/darwin/importer/formats/import_coco_test.py
+++ b/tests/darwin/importer/formats/import_coco_test.py
@@ -26,8 +26,8 @@ def test_parse_annotation_single_polygon():
     assert path[2] == {"x": 20, "y": 20}
 
 
-def test_parse_annotation_multiple_polygons():
-    """Test parsing segmentation with multiple polygons"""
+def test_parse_annotation_multiple_paths():
+    """Test parsing segmentation with multiple paths in a single polygon"""
     annotation = {
         "segmentation": [
             [10, 10, 20, 10, 20, 20, 10, 20],
@@ -41,16 +41,17 @@ def test_parse_annotation_multiple_polygons():
 
     result = parse_annotation(annotation, category_lookup)
 
-    assert len(result) == 2
-    assert all(isinstance(r, dt.Annotation) for r in result)
-    assert all(r.annotation_class.name == "test_class" for r in result)
+    assert len(result) == 1
+    assert isinstance(result[0], dt.Annotation)
+    assert result[0].annotation_class.name == "test_class"
+    assert len(result[0].data["paths"]) == 2
 
     path1 = result[0].data["paths"][0]
     assert len(path1) == 4
     assert path1[0] == {"x": 10, "y": 10}
     assert path1[2] == {"x": 20, "y": 20}
 
-    path2 = result[1].data["paths"][0]
+    path2 = result[0].data["paths"][1]
     assert len(path2) == 4
     assert path2[0] == {"x": 30, "y": 30}
     assert path2[2] == {"x": 40, "y": 40}


### PR DESCRIPTION
# Problem
COCO segmentations can have >1 polygon (an array of arrays containing `x, y`). Currently we only select the first element

# Solution
Allow import of multiple segmentation array elements as a single polygon. This effectively adds support for importing complex polygons

# Changelog
Allowed import of multi-array COCO segmentations
