### PR TITLE
[DAR-5614][External] Make the `NifTI` importer re-orient files to orientation of target file instead of `LPI`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 Darwin-py can both be used from the [command line](#usage-as-a-command-line-interface-cli) and as a [python library](#usage-as-a-python-library).
 
+📚 Check out the complete [SDK Reference Documentation](https://darwin-py-sdk.v7labs.com/) for detailed API information.
+
 <hr/>
 
 Main functions are (but not limited to):

--- a/darwin/dataset/download_manager.py
+++ b/darwin/dataset/download_manager.py
@@ -756,7 +756,7 @@ def _remove_empty_directories(images_path: Path) -> bool:
 
 
 def _check_for_duplicate_local_filepaths(
-    download_functions: List[Callable[[], None]]
+    download_functions: List[Callable[[], None]],
 ) -> None:
     """
     If pulling a release without folders, check for duplicate filepaths in the download functions.

--- a/darwin/dataset/remote_dataset_v2.py
+++ b/darwin/dataset/remote_dataset_v2.py
@@ -908,10 +908,12 @@ class RemoteDatasetV2(RemoteDataset):
             ):
                 slot_affine_map = {}
                 for slot in remote_file.slots:
-                    slot_affine_map[slot["slot_name"]] = np.array(
-                        slot["metadata"]["medical"]["affine"],
-                        dtype=np.float64,
-                    )
+                    affine = slot["metadata"]["medical"]["affine"]
+                    if affine:
+                        slot_affine_map[slot["slot_name"]] = np.array(
+                            affine,
+                            dtype=np.float64,
+                        )
                 remote_files_that_require_legacy_scaling[
                     Path(remote_file.full_path)
                 ] = slot_affine_map

--- a/darwin/future/core/items/uploads.py
+++ b/darwin/future/core/items/uploads.py
@@ -84,7 +84,7 @@ async def _build_layout(item: UploadItem) -> Dict:
 
 
 async def _build_payload_items(
-    items_and_paths: List[Tuple[UploadItem, Path]]
+    items_and_paths: List[Tuple[UploadItem, Path]],
 ) -> List[Dict]:
     """
     Builds the payload for the items to be registered for upload

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -81,7 +81,7 @@ instead of calling this low-level function directly.
 
 
 def _build_main_annotations_lookup_table(
-    annotation_classes: List[Dict[str, Unknown]]
+    annotation_classes: List[Dict[str, Unknown]],
 ) -> Dict[str, Unknown]:
     MAIN_ANNOTATION_TYPES = [
         "bounding_box",
@@ -487,7 +487,7 @@ def _serialize_item_level_properties(
 
 
 def _parse_metadata_file(
-    metadata_path: Union[Path, bool]
+    metadata_path: Union[Path, bool],
 ) -> Tuple[List[PropertyClass], List[Dict[str, str]]]:
     if isinstance(metadata_path, Path):
         metadata = parse_metadata(metadata_path)
@@ -1004,7 +1004,7 @@ def _import_properties(
 
 
 def _normalize_item_properties(
-    item_properties: Union[Dict[str, Dict[str, Any]], List[Dict[str, str]]]
+    item_properties: Union[Dict[str, Dict[str, Any]], List[Dict[str, str]]],
 ) -> Dict[str, Dict[str, Any]]:
     """
     Normalizes item properties to a common dictionary format.
@@ -2051,7 +2051,7 @@ def _overwrite_warning(
 
 
 def _get_annotation_format(
-    importer: Callable[[Path], Union[List[dt.AnnotationFile], dt.AnnotationFile, None]]
+    importer: Callable[[Path], Union[List[dt.AnnotationFile], dt.AnnotationFile, None]],
 ) -> str:
     """
     Returns the annotation format of the importer used to parse local annotation files

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -118,6 +118,7 @@ def _find_and_parse(  # noqa: C901
     use_multi_cpu: bool = True,
     cpu_limit: int = 1,
     remote_files_that_require_legacy_scaling: Optional[List[Path]] = None,
+    remote_file_orientations: Optional[Dict[str, Dict[str, Any]]] = None,
 ) -> Optional[Iterable[dt.AnnotationFile]]:
     is_console = console is not None
 
@@ -152,6 +153,7 @@ def _find_and_parse(  # noqa: C901
                         lambda file: importer(
                             file,
                             remote_files_that_require_legacy_scaling=remote_files_that_require_legacy_scaling,  # type: ignore
+                            remote_file_orientations=remote_file_orientations,  # type: ignore
                         ),
                         tqdm(files),
                     )
@@ -173,6 +175,7 @@ def _find_and_parse(  # noqa: C901
                 importer(
                     file,
                     remote_files_that_require_legacy_scaling=remote_files_that_require_legacy_scaling,  # type: ignore
+                    remote_file_orientations=remote_file_orientations,  # type: ignore
                 )
                 for file in tqdm(files)
             ]
@@ -1253,9 +1256,10 @@ def import_annotations(  # noqa: C901
     local_files = []
     local_files_missing_remotely = []
     if importer.__module__ == "darwin.importer.formats.nifti":
-        remote_files_that_require_legacy_scaling = (
-            dataset._get_remote_files_that_require_legacy_scaling()
-        )
+        (
+            remote_files_that_require_legacy_scaling,
+            remote_file_orientations,
+        ) = dataset._get_remote_files_that_require_legacy_scaling()
         maybe_parsed_files: Optional[Iterable[dt.AnnotationFile]] = _find_and_parse(
             importer,
             file_paths,
@@ -1263,6 +1267,7 @@ def import_annotations(  # noqa: C901
             use_multi_cpu,
             cpu_limit,
             remote_files_that_require_legacy_scaling,
+            remote_file_orientations,
         )
     else:
         maybe_parsed_files: Optional[Iterable[dt.AnnotationFile]] = _find_and_parse(

--- a/darwin/utils/utils.py
+++ b/darwin/utils/utils.py
@@ -1220,7 +1220,7 @@ def _parse_annotators(annotators: List[Dict[str, Any]]) -> List[dt.AnnotationAut
 
 
 def _parse_properties(
-    properties: List[Dict[str, Any]]
+    properties: List[Dict[str, Any]],
 ) -> Optional[List[SelectedProperty]]:
     selected_properties = []
     for property in properties:
@@ -1512,7 +1512,7 @@ def _parse_version(data: dict) -> dt.AnnotationFileVersion:
 
 
 def _data_to_annotations(
-    data: Dict[str, Any]
+    data: Dict[str, Any],
 ) -> List[Union[dt.Annotation, dt.VideoAnnotation]]:
     raw_image_annotations = filter(
         lambda annotation: (

--- a/e2e_tests/helpers.py
+++ b/e2e_tests/helpers.py
@@ -263,7 +263,7 @@ def export_release(
 
 
 def delete_annotation_uuids(
-    annotations: Sequence[Union[dt.Annotation, dt.VideoAnnotation]]
+    annotations: Sequence[Union[dt.Annotation, dt.VideoAnnotation]],
 ):
     """
     Removes all UUIDs present in instances of `dt.Annotation` and `dt.VideoAnnotation` objects.


### PR DESCRIPTION
# Problem
Since we released the `DISABLE_REORIENTATION_ON_UPLOAD` feature flag, not every post-`MED_2D_VIEWER` file will be in the `LPI` orientation, but the current `NifTI` importer assumes they are

This ticket is to introduce logic into the `NifTI` importer similar to the export logic so that we re-orient inbound annotations to the target file instead of statically to `LPI`

# Solution
Re-orient inbound `NifTI` annotations to the orientation of the remote file it's targeting

# Changelog
Support for importing `NifTI` annotations to non-`LPI` oriented dataset files