### PR TITLE
Fix increase version for --minor and --major flags 

### DIFF
--- a/deploy/increase_version.py
+++ b/deploy/increase_version.py
@@ -82,10 +82,13 @@ class Version:
 
     def increment_major(self) -> None:
         self.major += 1
+        self.minor = 0
+        self.patch = 0
         self._changed = True
 
     def increment_minor(self) -> None:
         self.minor += 1
+        self.patch = 0
         self._changed = True
 
     def increment_patch(self) -> None:


### PR DESCRIPTION
# Problem
`--minor` flag didn't reset `patch` version. `--major` flag didn't reset `minor` and `patch`

# Solution
`--minor` flag resets `patch` to zero
`--major` flag resets `minor` and `patch` to zero

# Changelog
Fix increase version for --minor and --major flags by properly resetting lower version numbers to zero
