### PR TITLE
[DAR-6195][external] Support Reports v3 in Darwin Py

### DIFF
--- a/darwin/cli.py
+++ b/darwin/cli.py
@@ -6,6 +6,7 @@ from argparse import ArgumentParser, Namespace
 from pathlib import Path
 
 import requests.exceptions
+from darwin.datatypes import AnnotatorReportGrouping
 from rich.console import Console
 
 import darwin.cli_functions as f
@@ -219,6 +220,19 @@ def _run(args: Namespace, parser: ArgumentParser) -> None:
             silent=args.silent,
             output=args.output,
         )
+
+    # Report generation commands
+    elif args.command == "report":
+        if args.action == "annotators":
+            f.report_annotators(
+                args.datasets,
+                args.start,
+                args.stop,
+                [AnnotatorReportGrouping(value) for value in args.group_by],
+                args.pretty,
+            )
+        elif args.action == "help" or args.action is None:
+            f.help(parser, "report")
 
 
 if __name__ == "__main__":

--- a/darwin/cli_functions.py
+++ b/darwin/cli_functions.py
@@ -1391,18 +1391,16 @@ def report_annotators(
         group_by,
     ).text
 
+    # the API does not return CSV headers if the report is empty
+    if not report:
+        report = "timestamp,dataset_id,dataset_name,dataset_slug,workflow_id,workflow_name,current_stage_id,current_stage_name,actor_id,actor_type,actor_email,actor_full_name,active_time,total_annotations,review_pass_rate,total_items_annotated,time_per_annotation,time_per_item\n"
+
     if not pretty:
-        # if no one worked in the report, we print nothing
         print(report)
         return
 
     lines: List[str] = report.split("\n")
     lines.pop(0)  # remove csv headers
-
-    if not lines:
-        console.print("No one has worked on this dataset yet!\n", style="success")
-        return
-
     lines.pop()  # remove last line, which is empty
 
     table: Table = Table(show_header=True, header_style="bold cyan")

--- a/darwin/cli_functions.py
+++ b/darwin/cli_functions.py
@@ -1372,7 +1372,7 @@ def report_annotators(
     pretty : bool
         If ``True``, it will print the output in a Rich formatted table.
     """
-    client: Client = _load_client(offline=True)
+    client: Client = _load_client()
     console = Console(theme=_console_theme())
 
     dataset_ids = []
@@ -1406,24 +1406,28 @@ def report_annotators(
     lines.pop()  # remove last line, which is empty
 
     table: Table = Table(show_header=True, header_style="bold cyan")
+
     table.add_column("Date")
-    table.add_column("Dataset Id", justify="right")
-    table.add_column("Dataset Name", justify="right")
-    table.add_column("Dataset Slug", justify="right")
-    table.add_column("Workflow Id", justify="right")
-    table.add_column("Workflow Name", justify="right")
-    table.add_column("Current Stage Id", justify="right")
-    table.add_column("Current Stage Name", justify="right")
-    table.add_column("User Id", justify="right")
-    table.add_column("User Type", justify="right")
-    table.add_column("Email", justify="right")
-    table.add_column("Full Name", justify="right")
-    table.add_column("Active Time", justify="right")
-    table.add_column("Total Annotations", justify="right")
-    table.add_column("Review Pass Rate", justify="right")
-    table.add_column("Total Items Annotated", justify="right")
-    table.add_column("Time Per Annotation", justify="right")
-    table.add_column("Time Per Item", justify="right")
+    for header in [
+        "Dataset Id",
+        "Dataset Name",
+        "Dataset Slug",
+        "Workflow Id",
+        "Workflow Name",
+        "Current Stage Id",
+        "Current Stage Name",
+        "User Id",
+        "User Type",
+        "Email",
+        "Full Name",
+        "Active Time",
+        "Total Annotations",
+        "Review Pass Rate",
+        "Total Items Annotated",
+        "Time Per Annotation",
+        "Time Per Item",
+    ]:
+        table.add_column(header, justify="right")
 
     for row in lines:
         table.add_row(*row.split(","))

--- a/darwin/datatypes.py
+++ b/darwin/datatypes.py
@@ -1567,3 +1567,17 @@ class StorageKeyDictModel(BaseModel):
 
 class StorageKeyListModel(BaseModel):
     storage_keys: List[str]
+
+
+class ReportJob(BaseModel):
+    id: str
+    status: str
+    format: str
+    url: str | None
+    team_id: int
+
+
+class AnnotatorReportGrouping(str, Enum):
+    ANNOTATORS = "annotators"
+    DATASETS = "datasets"
+    STAGES = "stages"

--- a/darwin/options.py
+++ b/darwin/options.py
@@ -1,8 +1,10 @@
 import sys
 from argparse import ArgumentParser, Namespace
+from datetime import datetime
 from typing import Any, Optional, Tuple
 
 import argcomplete
+from darwin.datatypes import AnnotatorReportGrouping
 
 
 class Options:
@@ -542,6 +544,49 @@ class Options:
 
         # Help
         dataset_action.add_parser("help", help="Show this help message and exit.")
+
+        # REPORT
+        report = subparsers.add_parser(
+            "report",
+            help="Report related functions.",
+            description="Arguments to interact with reports",
+        )
+        report_action = report.add_subparsers(dest="action")
+
+        # Annotators
+        parser_annotators = report_action.add_parser(
+            "annotators", help="Report about the annotators."
+        )
+        parser_annotators.add_argument(
+            "--datasets",
+            default=[],
+            type=lambda csv: [value.strip() for value in csv.split(",")],
+            help="List of comma-separated dataset slugs to include in the report.",
+        )
+        parser_annotators.add_argument(
+            "--start",
+            required=True,
+            type=lambda dt: datetime.strptime(dt, "%Y-%m-%dT%H:%M:%S%z"),
+            help="Report start DateTime in RFC3339 format (e.g. 2020-01-20T14:00:00Z).",
+        )
+        parser_annotators.add_argument(
+            "--stop",
+            required=True,
+            type=lambda dt: datetime.strptime(dt, "%Y-%m-%dT%H:%M:%S%z"),
+            help="Report end DateTime in RFC3339 format (e.g. 2020-01-20T15:00:00Z).",
+        )
+        parser_annotators.add_argument(
+            "--group-by",
+            type=lambda csv: [value.strip() for value in csv.split(",")],
+            help=f"Non-empty list of comma-separated grouping options for the report, any of: f{[name.value for name in AnnotatorReportGrouping]}.",
+        )
+        parser_annotators.add_argument(
+            "-r",
+            "--pretty",
+            action="store_true",
+            default=False,
+            help="Prints the results formatted in a rich table.",
+        )
 
         # VERSION
         subparsers.add_parser(

--- a/darwin/options.py
+++ b/darwin/options.py
@@ -577,6 +577,7 @@ class Options:
         )
         parser_annotators.add_argument(
             "--group-by",
+            required=True,
             type=lambda csv: [value.strip() for value in csv.split(",")],
             help=f"Non-empty list of comma-separated grouping options for the report, any of: f{[name.value for name in AnnotatorReportGrouping]}.",
         )

--- a/tests/darwin/cli_functions_test.py
+++ b/tests/darwin/cli_functions_test.py
@@ -1,11 +1,14 @@
 import builtins
 import sys
+from datetime import datetime, timedelta, timezone
 from unittest.mock import call, patch
 
+from darwin.datatypes import AnnotatorReportGrouping
 import pytest
 import responses
 from rich.console import Console
 
+from darwin import cli
 from darwin.cli_functions import (
     delete_files,
     extract_video_artifacts,
@@ -16,6 +19,7 @@ from darwin.client import Client
 from darwin.config import Config
 from darwin.dataset import RemoteDataset
 from darwin.dataset.remote_dataset_v2 import RemoteDatasetV2
+from darwin.options import Options
 from darwin.utils import BLOCKED_UPLOAD_ERROR_ALREADY_EXISTS
 from tests.fixtures import *
 
@@ -447,4 +451,78 @@ class TestExtractVideo:
                 segment_length=2,
                 repair=False,
                 storage_key_prefix="test/prefix",
+            )
+
+
+class TestReportAnnotators:
+    def test_parses_datetimes_and_comma_separated_lists(
+        self, remote_dataset: RemoteDataset
+    ):
+        start_date = datetime(2024, 11, 4, tzinfo=timezone.utc)
+        stop_date = datetime(2025, 5, 1, tzinfo=timezone(timedelta(hours=2)))
+        group_by = [
+            AnnotatorReportGrouping.STAGES,
+            AnnotatorReportGrouping.ANNOTATORS,
+            AnnotatorReportGrouping.DATASETS,
+        ]
+        dataset_id = remote_dataset.dataset_id
+        test_args = [
+            "darwin",
+            "report",
+            "annotators",
+            "--start",
+            "2024-11-04T00:00:00Z",
+            "--stop",
+            "2025-05-01T00:00:00+02:00",
+            "--group-by",
+            "  stages, annotators,datasets",
+            "--datasets",
+            remote_dataset.slug,
+        ]
+
+        with (
+            patch.object(sys, "argv", test_args),
+            patch.object(Client, "list_remote_datasets", return_value=[remote_dataset]),
+            patch.object(Client, "get_annotators_report") as get_report_mock,
+        ):
+            args, parser = Options().parse_args()
+            cli._run(args, parser)
+
+            get_report_mock.assert_called_once_with(
+                [dataset_id],
+                start_date,
+                stop_date,
+                group_by,
+            )
+
+    def test_exits_with_error_if_dataset_not_found(
+        self, remote_dataset: RemoteDataset, capsys
+    ):
+        test_args = [
+            "darwin",
+            "report",
+            "annotators",
+            "--start",
+            "2024-11-04T00:00:00Z",
+            "--stop",
+            "2025-05-01T00:00:00+02:00",
+            "--group-by",
+            "stages,annotators,datasets",
+            "--datasets",
+            f"{remote_dataset.slug},non-existent-dataset",
+        ]
+
+        with (
+            patch.object(sys, "argv", test_args),
+            patch.object(Client, "list_remote_datasets", return_value=[remote_dataset]),
+        ):
+            args, parser = Options().parse_args()
+
+            with pytest.raises(SystemExit):
+                cli._run(args, parser)
+
+            captured = capsys.readouterr()
+            assert (
+                "Error: Datasets '['non-existent-dataset']' do not exist."
+                in captured.out
             )

--- a/tests/darwin/cli_functions_test.py
+++ b/tests/darwin/cli_functions_test.py
@@ -548,5 +548,8 @@ class TestReportAnnotators:
         ):
             args, parser = Options().parse_args()
 
-            with pytest.raises(ValueError, match="'bad-grouping-option' is not a valid AnnotatorReportGrouping"):
+            with pytest.raises(
+                ValueError,
+                match="'bad-grouping-option' is not a valid AnnotatorReportGrouping",
+            ):
                 cli._run(args, parser)

--- a/tests/darwin/cli_functions_test.py
+++ b/tests/darwin/cli_functions_test.py
@@ -526,3 +526,27 @@ class TestReportAnnotators:
                 "Error: Datasets '['non-existent-dataset']' do not exist."
                 in captured.out
             )
+
+    def test_raises_if_invalid_grouping_option_supplied(
+        self, remote_dataset: RemoteDataset, capsys
+    ):
+        test_args = [
+            "darwin",
+            "report",
+            "annotators",
+            "--start",
+            "2024-11-04T00:00:00Z",
+            "--stop",
+            "2025-05-01T00:00:00+02:00",
+            "--group-by",
+            "annotators,bad-grouping-option",
+        ]
+
+        with (
+            patch.object(sys, "argv", test_args),
+            patch.object(Client, "list_remote_datasets", return_value=[remote_dataset]),
+        ):
+            args, parser = Options().parse_args()
+
+            with pytest.raises(ValueError, match="'bad-grouping-option' is not a valid AnnotatorReportGrouping"):
+                cli._run(args, parser)


### PR DESCRIPTION
# Problem
It is impossible to query V3 annotator reports using the SDK. Reports V1 can be queried, but are not created since 11/05/2024.

# Solution
Add a new top-level command and an action for V3 annotator reports: `darwin report annotators`.

Instead of requesting an annotator report synchronously, start a report job, and poll for results with exponential backoff. For now, log the id of the created job and raise an error if the happy path fails.

# Changelog
Added top-level `report` command, added `report annotators` command to query V3 annotator reports
