### PR TITLE
Revert "DAR-6458 [external]: upgraded argcomplete to 3.6.2"

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -63,14 +63,15 @@ files = [
 
 [[package]]
 name = "argcomplete"
-version = "3.6.2"
+version = "2.1.2"
 description = "Bash tab completion for argparse"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.6"
 groups = ["main"]
+markers = "platform_system == \"Linux\" and platform_machine == \"aarch64\""
 files = [
-    {file = "argcomplete-3.6.2-py3-none-any.whl", hash = "sha256:65b3133a29ad53fb42c48cf5114752c7ab66c1c38544fdf6460f450c09b42591"},
-    {file = "argcomplete-3.6.2.tar.gz", hash = "sha256:d0519b1bc867f5f4f4713c41ad0aba73a4a5f007449716b16f385f2166dc6adf"},
+    {file = "argcomplete-2.1.2-py3-none-any.whl", hash = "sha256:4ba9cdaa28c361d251edce884cd50b4b1215d65cdc881bd204426cdde9f52731"},
+    {file = "argcomplete-2.1.2.tar.gz", hash = "sha256:fc82ef070c607b1559b5c720529d63b54d9dcf2dcfc2632b10e6372314a34457"},
 ]
 
 [package.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ max-line-length = 88
 line-length = 88
 
 [tool.poetry.dependencies]
-argcomplete = "^3.5.0"
+argcomplete = "^2.0.0"
 deprecation = "^2.1.0"
 humanize = "^4.4.0"
 json-stream = "^2.3.2"


### PR DESCRIPTION
Reverts v7labs/darwin-py#1046 because it breaks the master build