### PR TITLE
Fix type annotation

### DIFF
--- a/darwin/datatypes.py
+++ b/darwin/datatypes.py
@@ -1573,7 +1573,7 @@ class ReportJob(BaseModel):
     id: str
     status: str
     format: str
-    url: str | None
+    url: Optional[str]
     team_id: int
 
 


### PR DESCRIPTION
# Problem
Type annotaitons like `str | None` are not supported for python 3.9. Darwin v1.3.0 can't be used

# Solution
Change annotation to `Optional[str]`

# Changelog
Fix type annotaiton, use `Optional`