### PR TITLE
[internal] Shift left testing

### DIFF
--- a/.github/workflows/EVENT_merge_to_master.yml
+++ b/.github/workflows/EVENT_merge_to_master.yml
@@ -11,10 +11,6 @@ permissions:
   contents: read
   id-token: write # Necessary for the generate documentation job
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   run_tests:
     name: Run tests

--- a/.github/workflows/EVENT_merge_to_master.yml
+++ b/.github/workflows/EVENT_merge_to_master.yml
@@ -9,17 +9,21 @@ on:
 
 permissions:
   contents: read
-  id-token: write # Necessary for the generate documentation job 
+  id-token: write # Necessary for the generate documentation job
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-
   run_tests:
     name: Run tests
     uses: ./.github/workflows/JOB_tests.yml
+
+  e2e_tests:
+    name: E2E Tests
+    uses: ./.github/workflows/JOB_e2e.yml
+    secrets: inherit
 
   documentation:
     name: Documentation
@@ -30,18 +34,18 @@ jobs:
       contents: read
 
   warn_on_fail:
-    needs: [run_tests, documentation]
+    needs: [run_tests, e2e_tests, documentation]
     if: ${{ failure() }}
     name: Slack message us on fail
     uses: ./.github/workflows/JOB_slack_message.yml
     secrets: inherit
     with:
       at_team: true
-      icon: ':warning:'
-      message: 'Master is failing after a push event, please review at ${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}'
+      icon: ":warning:"
+      message: "Master is failing after a push event, please review at ${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}"
 
   success:
-    needs: [run_tests, documentation]
+    needs: [run_tests, e2e_tests, documentation]
     if: ${{ success() }}
     name: Success
     runs-on: ubuntu-latest

--- a/.github/workflows/JOB_tests.yml
+++ b/.github/workflows/JOB_tests.yml
@@ -4,6 +4,8 @@ run-name: Tests
 
 on:
   workflow_call:
+  pull_request:
+    branches: [main, master]
 
 permissions:
   contents: read
@@ -48,7 +50,7 @@ jobs:
                      pip install wheel && \
                      pip install --upgrade setuptools && \
                      pip install --editable '.[test,ml,medical,dev, ocv]'"
-                     
+
       - name: Install ffmpeg (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         shell: bash


### PR DESCRIPTION
# Problem
1. We must avoid being notified of a failure late after the code is merged.
2. We must avoid being notified about an e2e failure only after the nightly run
3. If multiple PRs are merged to master only the last one runs the full GHA 

# Solution
1. Run unit tests for each PR (Ideally we'd run e2e but curretly it takes 45min so not worth it)
2. Run e2e for each merge to master
3. Remove concurrency so that each commit to master gets its own full run. This is important cause in case of multiple PRs we can quickly identify which commit is responsible of a failure (otherwise we wouldn't know what introduced a failure and we'd need to revert them all)
