### PR TITLE
[DAR-6557][Internal] Use np.uint8 as datatype for output nifti volumes to reduce allocations

### DIFF
--- a/darwin/exporter/formats/nifti.py
+++ b/darwin/exporter/formats/nifti.py
@@ -212,7 +212,7 @@ def build_output_volumes(
 
         output_volumes[series_instance_uid] = {
             class_name: Volume(
-                pixel_array=np.zeros(volume_dims),
+                pixel_array=np.zeros(volume_dims, dtype=np.uint8),
                 affine=affine,
                 original_affine=original_affine,
                 dims=volume_dims,
@@ -460,7 +460,7 @@ def populate_output_volumes_from_raster_layer(
                 next_global_id += 1
 
     # Initialize multilabel volume
-    multilabel_volume = np.zeros(slot.metadata["shape"][1:])
+    multilabel_volume = np.zeros(slot.metadata["shape"][1:], dtype=np.uint8)
 
     # Second pass: populate the multilabel volume using the global mapping
     for frame_idx in sorted(frames.keys()):
@@ -470,7 +470,7 @@ def populate_output_volumes_from_raster_layer(
         mask_2d = decode_rle(dense_rle, slot.width, slot.height)
 
         # Convert the mask_2d using the global mapping
-        converted_mask_2d = np.zeros_like(mask_2d)
+        converted_mask_2d = np.zeros_like(mask_2d, dtype=np.uint8)
         local_mapping = frame_data.data["mask_annotation_ids_mapping"]
 
         for mask_id, local_id in local_mapping.items():


### PR DESCRIPTION
# Problem
Export to nifti volumes has a large memory footprint. We encountered out of memory errors during export.

# Solution
Each exported nifti volume is casted to int16 to be written to disk, moreover, each volume we export has just one mask. Thus we can use `np.uint8` datatype for volumes during export processing to save space.

# Changelog
Use np.uint8 as datatype for output nifti volumes to reduce allocations
