### PR TITLE
[DAR-6533][External] Do not store duplicate attributes in keyframes

### DIFF
--- a/darwin/datatypes.py
+++ b/darwin/datatypes.py
@@ -348,8 +348,8 @@ class VideoAnnotation:
 
         # Only put attributes in the payload if the attributes have changed this frame
         last_attributes = None
-        for idx, frame in output["frames"].items():
-            attributes = frame.get("attributes")
+        for idx in sorted(output["frames"]):
+            attributes = output["frames"][idx].get("attributes")
             if attributes is not None and attributes == last_attributes:
                 output["frames"][idx].pop("attributes")
             last_attributes = attributes

--- a/darwin/datatypes.py
+++ b/darwin/datatypes.py
@@ -25,9 +25,9 @@ except ImportError:
     NDArray = Any  # type:ignore
 
 from darwin.future.data_objects.properties import (
+    PropertyGranularity,
     PropertyType,
     SelectedProperty,
-    PropertyGranularity,
 )
 from darwin.path_utils import construct_full_path, is_properties_enabled, parse_metadata
 
@@ -124,7 +124,6 @@ class SubAnnotationType(str, Enum):
     INFERENCE = "inference"
     DIRECTIONAL_VECTOR = "directional_vector"
     MEASURES = "measures"
-    AUTO_ANNOTATE = "auto_annotate"
 
 
 @dataclass
@@ -1410,7 +1409,7 @@ def make_opaque_sub(type: str, data: UnknownType) -> SubAnnotation:
     SubAnnotation
         A text ``SubAnnotation``.
     """
-    return SubAnnotation(type, data)
+    return SubAnnotation(SubAnnotationType(type), data)
 
 
 KeyFrame = Dict[str, Union[int, Annotation]]

--- a/darwin/datatypes.py
+++ b/darwin/datatypes.py
@@ -346,6 +346,14 @@ class VideoAnnotation:
             "hidden_areas": self.hidden_areas,
         }
 
+        # Only put attributes in the payload if the attributes have changed this frame
+        last_attributes = None
+        for idx, frame in output["frames"].items():
+            attributes = frame.get("attributes")
+            if attributes is not None and attributes == last_attributes:
+                output["frames"][idx].pop("attributes")
+            last_attributes = attributes
+
         return output
 
 

--- a/darwin/utils/utils.py
+++ b/darwin/utils/utils.py
@@ -889,10 +889,6 @@ def _parse_darwin_annotation(
         main_annotation.subs.append(
             dt.make_opaque_sub("measures", annotation["measures"])
         )
-    if "auto_annotate" in annotation:
-        main_annotation.subs.append(
-            dt.make_opaque_sub("auto_annotate", annotation["auto_annotate"])
-        )
 
     if annotation.get("annotators") is not None:
         main_annotation.annotators = _parse_annotators(annotation["annotators"])

--- a/tests/darwin/importer/importer_test.py
+++ b/tests/darwin/importer/importer_test.py
@@ -785,7 +785,7 @@ def test__get_annotation_data_video_annotation_only_stores_updates_to_sub_annota
     attributes = {"video_class_id": {"attribute_1": "id_1", "attribute_2": "id_2"}}
     result = _get_annotation_data(video_annotation, "video_class_id", attributes)
     assert result["frames"][1]["attributes"] == {"attributes": ["id_1", "id_2"]}
-    assert result["frames"].get(2) == None
+    assert 2 not in result["frames"]
     assert result["frames"][3].get("attributes") == None
 
 

--- a/tests/darwin/importer/importer_test.py
+++ b/tests/darwin/importer/importer_test.py
@@ -739,7 +739,7 @@ def test__get_annotation_data_video_annotation_with_attributes_that_become_empty
     assert result["frames"][4]["attributes"] == {"attributes": []}
 
 
-def test__get_annotation_data_video_annotation_does_not_wipe_sub_annotations_when_keyframe_is_true() -> (
+def test__get_annotation_data_video_annotation_only_stores_updates_to_sub_annotations_when_keyframe_is_true() -> (
     None
 ):
     from darwin.importer.importer import _get_annotation_data
@@ -785,7 +785,8 @@ def test__get_annotation_data_video_annotation_does_not_wipe_sub_annotations_whe
     attributes = {"video_class_id": {"attribute_1": "id_1", "attribute_2": "id_2"}}
     result = _get_annotation_data(video_annotation, "video_class_id", attributes)
     assert result["frames"][1]["attributes"] == {"attributes": ["id_1", "id_2"]}
-    assert result["frames"][3]["attributes"] == {"attributes": ["id_1", "id_2"]}
+    assert result["frames"].get(2) == None
+    assert result["frames"][3].get("attributes") == None
 
 
 def __expectation_factory(i: int, slot_names: List[str]) -> dt.Annotation:

--- a/tests/darwin/importer/importer_test.py
+++ b/tests/darwin/importer/importer_test.py
@@ -786,7 +786,7 @@ def test__get_annotation_data_video_annotation_only_stores_updates_to_sub_annota
     result = _get_annotation_data(video_annotation, "video_class_id", attributes)
     assert result["frames"][1]["attributes"] == {"attributes": ["id_1", "id_2"]}
     assert 2 not in result["frames"]
-    assert result["frames"][3].get("attributes") == None
+    assert result["frames"][3].get("attributes") is None
 
 
 def __expectation_factory(i: int, slot_names: List[str]) -> dt.Annotation:


### PR DESCRIPTION
# Problem
In [DAR-5605](https://github.com/v7labs/darwin-py/pull/993) we started properly handling the case when attributes are unset during import, by passing an empty list of attributes in the payload for the unset frame.

In [DAR-5903](https://github.com/v7labs/darwin-py/pull/1005/files) we made sure unsetting attributes by passing an empty list happened only to keyframes, not to all frames.

The remaining problem is:
- we have keyframes 1 and 3, 4 where the annotation changes.
- we have key subframes 2 and 3, where the attributes change.
- during export we don't differentiate between frames and subframes, and end up getting key frames 1, 2, 3, 4.
- on re-import we create *both* keyframes and key subframes 1, 2, 3, 4.
```
--- Original item
    key frames: 1 _ 3 4
key sub-frames: _ 2 3 _

--- Exported item
    key frames: 1 2 3 4
key sub-frames: 1 2 3 4

--- Imported item (actual)
    key frames: 1 2 3 4
key sub-frames: 1 2 3 4

--- Imported item (expected)
    key frames: 1 2 3 4
key sub-frames: _ 2 3 _
```

Changes in attributes between subframes are presented correctly, however the user ends up with more key subframes than in the original item: 2, 3 vs 1, 2, 3, 4.

Notice that keyframes are created even for key subframes in the original item: if we change an attribute, and the annotation itself doesn't change, it creates a key subframe, but after export-import we get both a key frame and a key subframe (see 2 in the example).

# Solution
When importing annotations we avoid storing attributes in a keyframe (creating a key subframe) if the attributes have not changed since last keyframe.

All attributes in the frame are treated as a set. If the set changes, the whole set is included in the payload for the keyframe, if the set remains the same nothing is included for the keyframe. This way we avoid creating extra key subframes where not neccessary.

# Changelog
Fix annotation attributes not populating correctly upon re-import, create key subframes only if the attributes change.