### PR TITLE
[DAR-6861] Update E2E workflow schedule

### DIFF
--- a/.github/workflows/JOB_e2e.yml
+++ b/.github/workflows/JOB_e2e.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   schedule:
-    - cron: "0 8 * * mon-fri"
+    - cron: "0 3 * * mon-fri"
   workflow_dispatch:
   pull_request:
     paths:
@@ -18,6 +18,11 @@ on:
         required: true
       E2E_TEAM:
         required: true
+
+concurrency:
+  group: e2e-tests-${{ github.event_name == 'repository_dispatch' && 'backend-triggered' || github.ref }}
+  cancel-in-progress: false  # Don't cancel running E2E tests, just queue them
+
 jobs:
   e2e:
     name: End to End Testing

--- a/.github/workflows/JOB_e2e.yml
+++ b/.github/workflows/JOB_e2e.yml
@@ -6,6 +6,8 @@ permissions:
 on:
   schedule:
     - cron: "0 3 * * mon-fri"
+  repository_dispatch:
+    types: [backend-master-merge]
   workflow_dispatch:
   pull_request:
     paths:

--- a/.github/workflows/JOB_e2e.yml
+++ b/.github/workflows/JOB_e2e.yml
@@ -20,7 +20,7 @@ on:
         required: true
 
 concurrency:
-  group: e2e-tests-${{ github.event_name == 'repository_dispatch' && 'backend-triggered' || github.ref }}
+  group: e2e-tests-${{ (github.event_name == 'repository_dispatch' && 'backend-triggered') || github.ref }}
   cancel-in-progress: false  # Don't cancel running E2E tests, just queue them
 
 jobs:


### PR DESCRIPTION
- Run at 3am so that results are ready before releases
- Given we've added trigger runs from backend staging releases https://github.com/v7labs/darwin-backend/pull/5778 I've also added concurrency checks to avoid overlapping runs