### PR TITLE
[DAR-6756][Internal] Add e2e tests for mask instances on single and multi slot items

### DIFF
--- a/e2e_tests/conftest.py
+++ b/e2e_tests/conftest.py
@@ -11,7 +11,7 @@ import tempfile
 from darwin.future.data_objects.typing import UnknownType
 from e2e_tests.exceptions import E2EEnvironmentVariableNotSet
 from e2e_tests.objects import ConfigValues, E2EDataset
-from e2e_tests.helpers import new_dataset  # noqa: F401
+from e2e_tests.helpers import SERVER_WAIT_TIME, new_dataset  # noqa: F401
 from e2e_tests.setup_tests import (
     setup_annotation_classes,
     setup_datasets,
@@ -72,7 +72,7 @@ def pytest_sessionstart(session: pytest.Session) -> None:
     environ["DARWIN_API_KEY"] = api_key
 
     print("Sleeping for 10 seconds to allow the server to catch up")
-    sleep(10)
+    sleep(SERVER_WAIT_TIME)
 
 
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:

--- a/e2e_tests/data/import/image_annotations_without_subtypes/.v7/metadata.json
+++ b/e2e_tests/data/import/image_annotations_without_subtypes/.v7/metadata.json
@@ -1,0 +1,162 @@
+{
+  "version": "1.0",
+  "schema_ref": "https://darwin-public.s3.eu-west-1.amazonaws.com/darwin_json/metadata/1.0/schema.json",
+  "classes": [
+    {
+      "name": "__raster_layer__",
+      "type": "raster_layer",
+      "description": "System class for all team's annotations with raster_layer type",
+      "color": "rgba(0,0,0,1.0)",
+      "sub_types": [],
+      "properties": [],
+      "sub_types_settings": {}
+    },
+    {
+      "name": "test_bounding_box_basic",
+      "type": "bounding_box",
+      "description": null,
+      "color": "rgba(255,85,0,1.0)",
+      "sub_types": [
+        "inference"
+      ],
+      "properties": [],
+      "sub_types_settings": {
+        "inference": {}
+      }
+    },
+    {
+      "name": "test_polygon_basic",
+      "type": "polygon",
+      "description": null,
+      "color": "rgba(85,255,0,1.0)",
+      "sub_types": [
+        "inference"
+      ],
+      "properties": [],
+      "sub_types_settings": {
+        "inference": {}
+      }
+    },
+    {
+      "name": "test_ellipse_basic",
+      "type": "ellipse",
+      "description": null,
+      "color": "rgba(255,0,255,1.0)",
+      "sub_types": [
+        "inference"
+      ],
+      "properties": [],
+      "sub_types_settings": {
+        "inference": {}
+      }
+    },
+    {
+      "name": "test_keypoint_basic",
+      "type": "keypoint",
+      "description": null,
+      "color": "rgba(0,0,255,1.0)",
+      "sub_types": [
+        "inference"
+      ],
+      "properties": [],
+      "sub_types_settings": {
+        "inference": {}
+      }
+    },
+    {
+      "name": "test_line_basic",
+      "type": "line",
+      "description": null,
+      "color": "rgba(0,255,255,1.0)",
+      "sub_types": [
+        "inference"
+      ],
+      "properties": [],
+      "sub_types_settings": {
+        "inference": {}
+      }
+    },
+    {
+      "name": "test_mask_basic",
+      "type": "mask",
+      "description": null,
+      "color": "rgba(255,0,85,1.0)",
+      "sub_types": [],
+      "properties": [],
+      "sub_types_settings": {}
+    },
+    {
+      "name": "test_skeleton_basic",
+      "type": "skeleton",
+      "description": null,
+      "color": "rgba(255,0,0,1.0)",
+      "sub_types": [
+        "inference"
+      ],
+      "properties": [],
+      "sub_types_settings": {
+        "inference": {}
+      }
+    },
+    {
+      "name": "test_tag_basic",
+      "type": "tag",
+      "description": null,
+      "color": "rgba(255,255,0,1.0)",
+      "sub_types": [
+        "inference"
+      ],
+      "properties": [],
+      "sub_types_settings": {
+        "inference": {}
+      }
+    }
+  ],
+  "properties": [
+    {
+      "name": "test_item_level_property_text",
+      "type": "text",
+      "description": "",
+      "required": false,
+      "granularity": "item",
+      "property_values": []
+    },
+    {
+      "name": "test_item_level_property_single_select",
+      "type": "single_select",
+      "description": "",
+      "required": false,
+      "granularity": "item",
+      "property_values": [
+        {
+          "value": "2",
+          "color": "rgba(255,92,0,1.0)"
+        },
+        {
+          "value": "1",
+          "color": "rgba(255,92,0,1.0)"
+        }
+      ]
+    },
+    {
+      "name": "test_item_level_property_multi_select",
+      "type": "multi_select",
+      "description": "",
+      "required": false,
+      "granularity": "item",
+      "property_values": [
+        {
+          "value": "2",
+          "color": "rgba(255,92,0,1.0)"
+        },
+        {
+          "value": "1",
+          "color": "rgba(255,92,0,1.0)"
+        }
+      ]
+    }
+  ],
+  "mask_classes_labels": {
+    "test_mask_basic": 56
+  }
+}

--- a/e2e_tests/data/import/image_annotations_without_subtypes/image_1.json
+++ b/e2e_tests/data/import/image_annotations_without_subtypes/image_1.json
@@ -36,46 +36,49 @@
   },
   "annotations": [
     {
-      "bounding_box": {
-        "h": 38.138,
-        "w": 67.608,
-        "x": 36.019,
-        "y": 50.273
+      "id": "c47e5305-a9c4-4f1d-8d0b-57c42362aa70",
+      "line": {
+        "path": [
+          {
+            "x": 136.565,
+            "y": 353.6437
+          },
+          {
+            "x": 107.0947,
+            "y": 402.183
+          },
+          {
+            "x": 169.5024,
+            "y": 407.3836
+          }
+        ]
       },
-      "id": "5f545fca-1fe9-408b-a715-9ef0e56cfeba",
-      "name": "test_bounding_box_basic",
+      "name": "test_line_basic",
       "properties": [],
       "slot_names": [
         "0"
       ]
     },
     {
-      "ellipse": {
-        "angle": 0.2004,
-        "center": {
-          "x": 214.5746,
-          "y": 259.1653
-        },
-        "radius": {
-          "x": 169.8191,
-          "y": 169.8191
-        }
-      },
-      "id": "d260483b-3bf6-4e43-85b5-2b38ca4ebd84",
-      "name": "test_ellipse_basic",
+      "id": "262c92b5-5ab9-457a-881d-77eb1b907f14",
+      "name": "test_skeleton_basic",
       "properties": [],
-      "slot_names": [
-        "0"
-      ]
-    },
-    {
-      "id": "4e5e1fc4-ee95-4da5-bb69-d10f1a743f6e",
-      "keypoint": {
-        "x": 483.2745,
-        "y": 199.3579
+      "skeleton": {
+        "nodes": [
+          {
+            "name": "node",
+            "occluded": false,
+            "x": 55.0883,
+            "y": 303.3708
+          },
+          {
+            "name": "2",
+            "occluded": false,
+            "x": 70.3435,
+            "y": 275.634
+          }
+        ]
       },
-      "name": "test_keypoint_basic",
-      "properties": [],
       "slot_names": [
         "0"
       ]
@@ -87,7 +90,7 @@
         "x": 18.6838,
         "y": 135.2167
       },
-      "id": "9cc99669-f6e5-4d6e-88cd-f87e85060321",
+      "id": "6eb4eefb-8808-40c2-bb67-4b50bbe9e814",
       "name": "test_polygon_basic",
       "polygon": {
         "paths": [
@@ -117,55 +120,52 @@
       ]
     },
     {
-      "id": "6597df19-d711-4f89-b031-f167af3fdb5e",
-      "name": "test_skeleton_basic",
-      "properties": [],
-      "skeleton": {
-        "nodes": [
-          {
-            "name": "node",
-            "occluded": false,
-            "x": 55.0883,
-            "y": 303.3708
-          },
-          {
-            "name": "2",
-            "occluded": false,
-            "x": 70.3435,
-            "y": 275.634
-          }
-        ]
+      "id": "d0549243-5923-4c62-b845-82bff4d6e9e3",
+      "keypoint": {
+        "x": 483.2745,
+        "y": 199.3579
       },
-      "slot_names": [
-        "0"
-      ]
-    },
-    {
-      "id": "e716185a-bb70-4118-bf70-0be7d41551fa",
-      "line": {
-        "path": [
-          {
-            "x": 136.565,
-            "y": 353.6437
-          },
-          {
-            "x": 107.0947,
-            "y": 402.183
-          },
-          {
-            "x": 169.5024,
-            "y": 407.3836
-          }
-        ]
-      },
-      "name": "test_line_basic",
+      "name": "test_keypoint_basic",
       "properties": [],
       "slot_names": [
         "0"
       ]
     },
     {
-      "id": "97fce761-d432-4968-88b4-70a25a50796c",
+      "ellipse": {
+        "angle": 0.2004,
+        "center": {
+          "x": 214.5746,
+          "y": 259.1653
+        },
+        "radius": {
+          "x": 169.8191,
+          "y": 169.8191
+        }
+      },
+      "id": "14d347f2-879d-4ea3-804f-9d83b184e71c",
+      "name": "test_ellipse_basic",
+      "properties": [],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "bounding_box": {
+        "h": 38.138,
+        "w": 67.608,
+        "x": 36.019,
+        "y": 50.273
+      },
+      "id": "d78df3fa-f9e2-4596-8a05-59e342c88f88",
+      "name": "test_bounding_box_basic",
+      "properties": [],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "id": "80444495-1342-4829-b032-4c643fb381df",
       "name": "test_tag_basic",
       "properties": [],
       "slot_names": [
@@ -174,7 +174,7 @@
       "tag": {}
     },
     {
-      "id": "c5dd19cf-3473-4a9b-ae56-eff81130504a",
+      "id": "5ee21711-af0c-4e29-a367-bd52a6a803fa",
       "mask": {},
       "name": "test_mask_basic",
       "properties": [],
@@ -183,7 +183,16 @@
       ]
     },
     {
-      "id": "e0c12ded-5d4f-45e7-8e00-52358e264d4b",
+      "id": "686d39ce-679a-4a43-862f-5fbfd7aa2551",
+      "mask": {},
+      "name": "test_mask_basic",
+      "properties": [],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "id": "a0c91703-d5c2-473a-b1e4-ab0e520ea2df",
       "name": "__raster_layer__",
       "properties": [],
       "raster_layer": {
@@ -301,10 +310,15 @@
           1,
           4,
           0,
-          1737320
+          28828,
+          2,
+          1,
+          0,
+          1708491
         ],
         "mask_annotation_ids_mapping": {
-          "c5dd19cf-3473-4a9b-ae56-eff81130504a": 1
+          "5ee21711-af0c-4e29-a367-bd52a6a803fa": 1,
+          "686d39ce-679a-4a43-862f-5fbfd7aa2551": 2
         },
         "total_pixels": 2073600
       },

--- a/e2e_tests/data/import/image_annotations_without_subtypes/image_2.json
+++ b/e2e_tests/data/import/image_annotations_without_subtypes/image_2.json
@@ -36,46 +36,49 @@
   },
   "annotations": [
     {
-      "bounding_box": {
-        "h": 38.138,
-        "w": 67.608,
-        "x": 36.019,
-        "y": 50.273
+      "id": "085f3540-a56d-4cae-8564-aa2a316a3d4c",
+      "line": {
+        "path": [
+          {
+            "x": 136.565,
+            "y": 353.6437
+          },
+          {
+            "x": 107.0947,
+            "y": 402.183
+          },
+          {
+            "x": 169.5024,
+            "y": 407.3836
+          }
+        ]
       },
-      "id": "4cfcfbf6-f4d8-488a-971e-c580b52c4977",
-      "name": "test_bounding_box_basic",
+      "name": "test_line_basic",
       "properties": [],
       "slot_names": [
         "0"
       ]
     },
     {
-      "ellipse": {
-        "angle": 0.2004,
-        "center": {
-          "x": 214.5746,
-          "y": 259.1653
-        },
-        "radius": {
-          "x": 169.8191,
-          "y": 169.8191
-        }
-      },
-      "id": "5b3ce3f4-e482-4fee-8df6-78fa28e4ecf5",
-      "name": "test_ellipse_basic",
+      "id": "274608f5-971a-42ef-95e5-0794d308c201",
+      "name": "test_skeleton_basic",
       "properties": [],
-      "slot_names": [
-        "0"
-      ]
-    },
-    {
-      "id": "74be1e13-89c8-4884-981f-a42ead674d2d",
-      "keypoint": {
-        "x": 483.2745,
-        "y": 199.3579
+      "skeleton": {
+        "nodes": [
+          {
+            "name": "node",
+            "occluded": false,
+            "x": 55.0883,
+            "y": 303.3708
+          },
+          {
+            "name": "2",
+            "occluded": false,
+            "x": 70.3435,
+            "y": 275.634
+          }
+        ]
       },
-      "name": "test_keypoint_basic",
-      "properties": [],
       "slot_names": [
         "0"
       ]
@@ -87,7 +90,7 @@
         "x": 18.6838,
         "y": 135.2167
       },
-      "id": "4db09862-3f41-45ca-a3c9-a6bc6a09c6b4",
+      "id": "d373092f-71d7-4f46-96fe-09cb27136d51",
       "name": "test_polygon_basic",
       "polygon": {
         "paths": [
@@ -117,55 +120,52 @@
       ]
     },
     {
-      "id": "bcd34162-c3ee-4914-9e6d-5744190d68b3",
-      "name": "test_skeleton_basic",
-      "properties": [],
-      "skeleton": {
-        "nodes": [
-          {
-            "name": "node",
-            "occluded": false,
-            "x": 55.0883,
-            "y": 303.3708
-          },
-          {
-            "name": "2",
-            "occluded": false,
-            "x": 70.3435,
-            "y": 275.634
-          }
-        ]
+      "id": "825b32b3-5e49-44d0-a807-8848328b2b3a",
+      "keypoint": {
+        "x": 483.2745,
+        "y": 199.3579
       },
-      "slot_names": [
-        "0"
-      ]
-    },
-    {
-      "id": "8c1c7d28-529b-4862-9330-15dab4bd1f1a",
-      "line": {
-        "path": [
-          {
-            "x": 136.565,
-            "y": 353.6437
-          },
-          {
-            "x": 107.0947,
-            "y": 402.183
-          },
-          {
-            "x": 169.5024,
-            "y": 407.3836
-          }
-        ]
-      },
-      "name": "test_line_basic",
+      "name": "test_keypoint_basic",
       "properties": [],
       "slot_names": [
         "0"
       ]
     },
     {
-      "id": "56a4ac8d-ed1a-4e8f-90a9-0f6b77de9a83",
+      "ellipse": {
+        "angle": 0.2004,
+        "center": {
+          "x": 214.5746,
+          "y": 259.1653
+        },
+        "radius": {
+          "x": 169.8191,
+          "y": 169.8191
+        }
+      },
+      "id": "e9a2b123-4cac-464f-a55d-685d8a38c639",
+      "name": "test_ellipse_basic",
+      "properties": [],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "bounding_box": {
+        "h": 38.138,
+        "w": 67.608,
+        "x": 36.019,
+        "y": 50.273
+      },
+      "id": "8af82d7a-8d3a-422e-90c2-c147bbcf8771",
+      "name": "test_bounding_box_basic",
+      "properties": [],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "id": "d9474687-e64a-4de9-81c0-38fbae4073b9",
       "name": "test_tag_basic",
       "properties": [],
       "slot_names": [
@@ -174,7 +174,7 @@
       "tag": {}
     },
     {
-      "id": "c7fb2f73-5524-4c46-b7e3-80dac048df13",
+      "id": "112be000-bd9b-4870-b5c0-487a3815c0ca",
       "mask": {},
       "name": "test_mask_basic",
       "properties": [],
@@ -183,7 +183,16 @@
       ]
     },
     {
-      "id": "dcfe76bc-2518-418d-9a75-5b38baa02db7",
+      "id": "f2764537-21e8-4035-a7ee-5aa98313ee94",
+      "mask": {},
+      "name": "test_mask_basic",
+      "properties": [],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "id": "555a4d3d-e173-4a58-8d2f-b2537e218a40",
       "name": "__raster_layer__",
       "properties": [],
       "raster_layer": {
@@ -281,10 +290,15 @@
           1,
           4,
           0,
-          1752619
+          53766,
+          2,
+          1,
+          0,
+          1698852
         ],
         "mask_annotation_ids_mapping": {
-          "c7fb2f73-5524-4c46-b7e3-80dac048df13": 1
+          "112be000-bd9b-4870-b5c0-487a3815c0ca": 1,
+          "f2764537-21e8-4035-a7ee-5aa98313ee94": 2
         },
         "total_pixels": 2073600
       },

--- a/e2e_tests/data/import/image_annotations_without_subtypes/image_3.json
+++ b/e2e_tests/data/import/image_annotations_without_subtypes/image_3.json
@@ -36,46 +36,49 @@
   },
   "annotations": [
     {
-      "bounding_box": {
-        "h": 38.138,
-        "w": 67.608,
-        "x": 36.019,
-        "y": 50.273
+      "id": "9fd73963-09a7-4c9e-88bc-d2d19872e401",
+      "line": {
+        "path": [
+          {
+            "x": 136.565,
+            "y": 353.6437
+          },
+          {
+            "x": 107.0947,
+            "y": 402.183
+          },
+          {
+            "x": 169.5024,
+            "y": 407.3836
+          }
+        ]
       },
-      "id": "adce54ea-6abe-426d-93d0-f03902845831",
-      "name": "test_bounding_box_basic",
+      "name": "test_line_basic",
       "properties": [],
       "slot_names": [
         "0"
       ]
     },
     {
-      "ellipse": {
-        "angle": 0.2004,
-        "center": {
-          "x": 214.5746,
-          "y": 259.1653
-        },
-        "radius": {
-          "x": 169.8191,
-          "y": 169.8191
-        }
-      },
-      "id": "6e77f7f1-9980-4b06-95e4-5972df202a09",
-      "name": "test_ellipse_basic",
+      "id": "3375659b-82fd-4ce2-b941-646e1547bac2",
+      "name": "test_skeleton_basic",
       "properties": [],
-      "slot_names": [
-        "0"
-      ]
-    },
-    {
-      "id": "4fd45ba5-e8e0-4a37-ad0b-32391b06e52b",
-      "keypoint": {
-        "x": 483.2745,
-        "y": 199.3579
+      "skeleton": {
+        "nodes": [
+          {
+            "name": "node",
+            "occluded": false,
+            "x": 55.0883,
+            "y": 303.3708
+          },
+          {
+            "name": "2",
+            "occluded": false,
+            "x": 70.3435,
+            "y": 275.634
+          }
+        ]
       },
-      "name": "test_keypoint_basic",
-      "properties": [],
       "slot_names": [
         "0"
       ]
@@ -87,7 +90,7 @@
         "x": 18.6838,
         "y": 135.2167
       },
-      "id": "8de8e41b-0e83-47c9-b6b8-aaf41a62ce60",
+      "id": "999744da-8d4e-4f13-9e69-2f6ec9a90943",
       "name": "test_polygon_basic",
       "polygon": {
         "paths": [
@@ -117,55 +120,52 @@
       ]
     },
     {
-      "id": "ac1eb7de-7003-44b1-88f4-108f0166e2a9",
-      "name": "test_skeleton_basic",
-      "properties": [],
-      "skeleton": {
-        "nodes": [
-          {
-            "name": "node",
-            "occluded": false,
-            "x": 55.0883,
-            "y": 303.3708
-          },
-          {
-            "name": "2",
-            "occluded": false,
-            "x": 70.3435,
-            "y": 275.634
-          }
-        ]
+      "id": "2e646e92-4e09-45d4-8ea1-4980e6da18ba",
+      "keypoint": {
+        "x": 483.2745,
+        "y": 199.3579
       },
-      "slot_names": [
-        "0"
-      ]
-    },
-    {
-      "id": "24a15a17-964b-49b9-930f-c58d0f54ebfc",
-      "line": {
-        "path": [
-          {
-            "x": 136.565,
-            "y": 353.6437
-          },
-          {
-            "x": 107.0947,
-            "y": 402.183
-          },
-          {
-            "x": 169.5024,
-            "y": 407.3836
-          }
-        ]
-      },
-      "name": "test_line_basic",
+      "name": "test_keypoint_basic",
       "properties": [],
       "slot_names": [
         "0"
       ]
     },
     {
-      "id": "2353d32b-ba84-4ff9-8a03-60acc036152f",
+      "ellipse": {
+        "angle": 0.2004,
+        "center": {
+          "x": 214.5746,
+          "y": 259.1653
+        },
+        "radius": {
+          "x": 169.8191,
+          "y": 169.8191
+        }
+      },
+      "id": "4b1b5d33-4545-4931-aff5-634825dc06b3",
+      "name": "test_ellipse_basic",
+      "properties": [],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "bounding_box": {
+        "h": 38.138,
+        "w": 67.608,
+        "x": 36.019,
+        "y": 50.273
+      },
+      "id": "06b39f0e-be7b-4669-b5cd-f87c1e481322",
+      "name": "test_bounding_box_basic",
+      "properties": [],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "id": "ed1ce69a-d0a3-4bbb-9240-cb02690abc64",
       "name": "test_tag_basic",
       "properties": [],
       "slot_names": [
@@ -174,7 +174,7 @@
       "tag": {}
     },
     {
-      "id": "3fc409df-3c62-4c3a-b942-a5a2b5c675c1",
+      "id": "a7289a0e-9967-44f8-845e-650160b5f54d",
       "mask": {},
       "name": "test_mask_basic",
       "properties": [],
@@ -183,7 +183,16 @@
       ]
     },
     {
-      "id": "6952da44-cea8-4441-b133-fff9584497a1",
+      "id": "d0d1856e-a633-4991-b92f-646dda3b4c38",
+      "mask": {},
+      "name": "test_mask_basic",
+      "properties": [],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "id": "ec3d221b-6751-432b-9e74-e2c641e0e580",
       "name": "__raster_layer__",
       "properties": [],
       "raster_layer": {
@@ -393,10 +402,15 @@
           1,
           10,
           0,
-          1683471
+          26879,
+          2,
+          1,
+          0,
+          1656591
         ],
         "mask_annotation_ids_mapping": {
-          "3fc409df-3c62-4c3a-b942-a5a2b5c675c1": 1
+          "a7289a0e-9967-44f8-845e-650160b5f54d": 1,
+          "d0d1856e-a633-4991-b92f-646dda3b4c38": 2
         },
         "total_pixels": 2073600
       },

--- a/e2e_tests/data/import/image_annotations_without_subtypes/image_4.json
+++ b/e2e_tests/data/import/image_annotations_without_subtypes/image_4.json
@@ -36,46 +36,49 @@
   },
   "annotations": [
     {
-      "bounding_box": {
-        "h": 38.138,
-        "w": 67.608,
-        "x": 36.019,
-        "y": 50.273
+      "id": "07939040-c9d5-4f53-a7d9-bfdf05322425",
+      "line": {
+        "path": [
+          {
+            "x": 136.565,
+            "y": 353.6437
+          },
+          {
+            "x": 107.0947,
+            "y": 402.183
+          },
+          {
+            "x": 169.5024,
+            "y": 407.3836
+          }
+        ]
       },
-      "id": "c6b1f752-5a30-408f-8f2d-32823bcfed96",
-      "name": "test_bounding_box_basic",
+      "name": "test_line_basic",
       "properties": [],
       "slot_names": [
         "0"
       ]
     },
     {
-      "ellipse": {
-        "angle": 0.2004,
-        "center": {
-          "x": 214.5746,
-          "y": 259.1653
-        },
-        "radius": {
-          "x": 169.8191,
-          "y": 169.8191
-        }
-      },
-      "id": "c2bf9ab2-4861-417c-95fc-34d851980484",
-      "name": "test_ellipse_basic",
+      "id": "debe77ba-a76b-4814-b7f5-54096527a2ec",
+      "name": "test_skeleton_basic",
       "properties": [],
-      "slot_names": [
-        "0"
-      ]
-    },
-    {
-      "id": "71ab4ef4-e014-46d6-8e56-971f69a021bc",
-      "keypoint": {
-        "x": 483.2745,
-        "y": 199.3579
+      "skeleton": {
+        "nodes": [
+          {
+            "name": "node",
+            "occluded": false,
+            "x": 55.0883,
+            "y": 303.3708
+          },
+          {
+            "name": "2",
+            "occluded": false,
+            "x": 70.3435,
+            "y": 275.634
+          }
+        ]
       },
-      "name": "test_keypoint_basic",
-      "properties": [],
       "slot_names": [
         "0"
       ]
@@ -87,7 +90,7 @@
         "x": 18.6838,
         "y": 135.2167
       },
-      "id": "4bc01445-fc05-4eae-b3e6-1d89a82fc941",
+      "id": "27cf7065-bd5c-4837-a520-ebc707406f96",
       "name": "test_polygon_basic",
       "polygon": {
         "paths": [
@@ -117,55 +120,52 @@
       ]
     },
     {
-      "id": "61cb6aaa-11ce-4004-ab3a-5ca89d59180a",
-      "name": "test_skeleton_basic",
-      "properties": [],
-      "skeleton": {
-        "nodes": [
-          {
-            "name": "node",
-            "occluded": false,
-            "x": 55.0883,
-            "y": 303.3708
-          },
-          {
-            "name": "2",
-            "occluded": false,
-            "x": 70.3435,
-            "y": 275.634
-          }
-        ]
+      "id": "da9f1706-44b7-43e2-a6e1-df1549357eca",
+      "keypoint": {
+        "x": 483.2745,
+        "y": 199.3579
       },
-      "slot_names": [
-        "0"
-      ]
-    },
-    {
-      "id": "0ca8ddda-b52e-4d67-b80b-a04f98ca5595",
-      "line": {
-        "path": [
-          {
-            "x": 136.565,
-            "y": 353.6437
-          },
-          {
-            "x": 107.0947,
-            "y": 402.183
-          },
-          {
-            "x": 169.5024,
-            "y": 407.3836
-          }
-        ]
-      },
-      "name": "test_line_basic",
+      "name": "test_keypoint_basic",
       "properties": [],
       "slot_names": [
         "0"
       ]
     },
     {
-      "id": "abd4cd0f-a64e-4e88-8dd3-60b22cf3083c",
+      "ellipse": {
+        "angle": 0.2004,
+        "center": {
+          "x": 214.5746,
+          "y": 259.1653
+        },
+        "radius": {
+          "x": 169.8191,
+          "y": 169.8191
+        }
+      },
+      "id": "ab8974c5-c415-4bf5-aed3-d7a0dca4e6cb",
+      "name": "test_ellipse_basic",
+      "properties": [],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "bounding_box": {
+        "h": 38.138,
+        "w": 67.608,
+        "x": 36.019,
+        "y": 50.273
+      },
+      "id": "c7df8a8d-566a-49ff-9ec2-faf157e45503",
+      "name": "test_bounding_box_basic",
+      "properties": [],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "id": "d99aa806-643a-4e46-a805-fd5905690213",
       "name": "test_tag_basic",
       "properties": [],
       "slot_names": [
@@ -174,7 +174,7 @@
       "tag": {}
     },
     {
-      "id": "d2ff122c-2c4f-4158-8ab3-5a660e4137f7",
+      "id": "5aeaf1a9-2f0b-4ddd-ae85-1c8cdf411936",
       "mask": {},
       "name": "test_mask_basic",
       "properties": [],
@@ -183,7 +183,16 @@
       ]
     },
     {
-      "id": "c35b932c-a593-4063-a083-5b3e985635fa",
+      "id": "d48acb16-8e8a-465f-830d-6417ce6c03d1",
+      "mask": {},
+      "name": "test_mask_basic",
+      "properties": [],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "id": "23f7292f-ad7c-4d21-8c7a-b21f2be692d2",
       "name": "__raster_layer__",
       "properties": [],
       "raster_layer": {
@@ -309,10 +318,15 @@
           1,
           4,
           0,
-          1673922
+          36475,
+          2,
+          1,
+          0,
+          1637446
         ],
         "mask_annotation_ids_mapping": {
-          "d2ff122c-2c4f-4158-8ab3-5a660e4137f7": 1
+          "5aeaf1a9-2f0b-4ddd-ae85-1c8cdf411936": 1,
+          "d48acb16-8e8a-465f-830d-6417ce6c03d1": 2
         },
         "total_pixels": 2073600
       },

--- a/e2e_tests/data/import/image_annotations_without_subtypes/image_5.json
+++ b/e2e_tests/data/import/image_annotations_without_subtypes/image_5.json
@@ -36,46 +36,49 @@
   },
   "annotations": [
     {
-      "bounding_box": {
-        "h": 38.138,
-        "w": 67.608,
-        "x": 36.019,
-        "y": 50.273
+      "id": "2b136d83-363e-440f-94e3-c70851517e52",
+      "line": {
+        "path": [
+          {
+            "x": 136.565,
+            "y": 353.6437
+          },
+          {
+            "x": 107.0947,
+            "y": 402.183
+          },
+          {
+            "x": 169.5024,
+            "y": 407.3836
+          }
+        ]
       },
-      "id": "047ed9e8-27cd-4809-9ad9-3fc566fab086",
-      "name": "test_bounding_box_basic",
+      "name": "test_line_basic",
       "properties": [],
       "slot_names": [
         "0"
       ]
     },
     {
-      "ellipse": {
-        "angle": 0.2004,
-        "center": {
-          "x": 214.5746,
-          "y": 259.1653
-        },
-        "radius": {
-          "x": 169.8191,
-          "y": 169.8191
-        }
-      },
-      "id": "41c2402e-c4a0-49cb-a2ba-03d551df8cd0",
-      "name": "test_ellipse_basic",
+      "id": "13498f4b-6621-495b-b036-9bf267cec8f5",
+      "name": "test_skeleton_basic",
       "properties": [],
-      "slot_names": [
-        "0"
-      ]
-    },
-    {
-      "id": "a70842c8-eca4-4091-aced-802793a65038",
-      "keypoint": {
-        "x": 483.2745,
-        "y": 199.3579
+      "skeleton": {
+        "nodes": [
+          {
+            "name": "node",
+            "occluded": false,
+            "x": 55.0883,
+            "y": 303.3708
+          },
+          {
+            "name": "2",
+            "occluded": false,
+            "x": 70.3435,
+            "y": 275.634
+          }
+        ]
       },
-      "name": "test_keypoint_basic",
-      "properties": [],
       "slot_names": [
         "0"
       ]
@@ -87,7 +90,7 @@
         "x": 18.6838,
         "y": 135.2167
       },
-      "id": "b42f2409-feed-47fc-935c-ce10db9eab54",
+      "id": "29ef1ee8-7376-485a-bdf9-1d5652fc001c",
       "name": "test_polygon_basic",
       "polygon": {
         "paths": [
@@ -117,55 +120,52 @@
       ]
     },
     {
-      "id": "1575cf2d-4c80-4f73-ab30-bed32764f784",
-      "name": "test_skeleton_basic",
-      "properties": [],
-      "skeleton": {
-        "nodes": [
-          {
-            "name": "node",
-            "occluded": false,
-            "x": 55.0883,
-            "y": 303.3708
-          },
-          {
-            "name": "2",
-            "occluded": false,
-            "x": 70.3435,
-            "y": 275.634
-          }
-        ]
+      "id": "20b99874-0982-4754-bc68-8db993a3b08b",
+      "keypoint": {
+        "x": 483.2745,
+        "y": 199.3579
       },
-      "slot_names": [
-        "0"
-      ]
-    },
-    {
-      "id": "0c4fb76b-402b-424e-9406-91139ce842eb",
-      "line": {
-        "path": [
-          {
-            "x": 136.565,
-            "y": 353.6437
-          },
-          {
-            "x": 107.0947,
-            "y": 402.183
-          },
-          {
-            "x": 169.5024,
-            "y": 407.3836
-          }
-        ]
-      },
-      "name": "test_line_basic",
+      "name": "test_keypoint_basic",
       "properties": [],
       "slot_names": [
         "0"
       ]
     },
     {
-      "id": "4b56c891-95c3-438e-8e80-7f29bb6f8593",
+      "ellipse": {
+        "angle": 0.2004,
+        "center": {
+          "x": 214.5746,
+          "y": 259.1653
+        },
+        "radius": {
+          "x": 169.8191,
+          "y": 169.8191
+        }
+      },
+      "id": "dfdc5ac9-bac9-4486-add6-53f7b2b30336",
+      "name": "test_ellipse_basic",
+      "properties": [],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "bounding_box": {
+        "h": 38.138,
+        "w": 67.608,
+        "x": 36.019,
+        "y": 50.273
+      },
+      "id": "3339c5b7-0830-4efe-b788-df15732d8a47",
+      "name": "test_bounding_box_basic",
+      "properties": [],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "id": "e12a715b-ff8b-417f-98b5-8752d080d02b",
       "name": "test_tag_basic",
       "properties": [],
       "slot_names": [
@@ -174,7 +174,7 @@
       "tag": {}
     },
     {
-      "id": "499731b1-5885-460e-bf4c-1a5f81634545",
+      "id": "43ff8902-2990-46a3-a8b1-d4a511e5cc76",
       "mask": {},
       "name": "test_mask_basic",
       "properties": [],
@@ -183,7 +183,16 @@
       ]
     },
     {
-      "id": "bd963672-e400-4c8f-8504-49096325d9a6",
+      "id": "60231167-2b1f-4681-a8df-62ef9389ff11",
+      "mask": {},
+      "name": "test_mask_basic",
+      "properties": [],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "id": "8f4eb256-a98d-4481-8ed9-d00e8398551e",
       "name": "__raster_layer__",
       "properties": [],
       "raster_layer": {
@@ -353,10 +362,15 @@
           1,
           8,
           0,
-          1673906
+          28804,
+          2,
+          1,
+          0,
+          1645101
         ],
         "mask_annotation_ids_mapping": {
-          "499731b1-5885-460e-bf4c-1a5f81634545": 1
+          "43ff8902-2990-46a3-a8b1-d4a511e5cc76": 1,
+          "60231167-2b1f-4681-a8df-62ef9389ff11": 2
         },
         "total_pixels": 2073600
       },

--- a/e2e_tests/data/import/image_annotations_without_subtypes/image_6.json
+++ b/e2e_tests/data/import/image_annotations_without_subtypes/image_6.json
@@ -36,46 +36,49 @@
   },
   "annotations": [
     {
-      "bounding_box": {
-        "h": 38.138,
-        "w": 67.608,
-        "x": 36.019,
-        "y": 50.273
+      "id": "7f09ffba-81db-40e9-8079-b2002260f4c3",
+      "line": {
+        "path": [
+          {
+            "x": 136.565,
+            "y": 353.6437
+          },
+          {
+            "x": 107.0947,
+            "y": 402.183
+          },
+          {
+            "x": 169.5024,
+            "y": 407.3836
+          }
+        ]
       },
-      "id": "1da823b4-eddb-49b3-aa01-90ff84ebfa46",
-      "name": "test_bounding_box_basic",
+      "name": "test_line_basic",
       "properties": [],
       "slot_names": [
         "0"
       ]
     },
     {
-      "ellipse": {
-        "angle": 0.2004,
-        "center": {
-          "x": 214.5746,
-          "y": 259.1653
-        },
-        "radius": {
-          "x": 169.8191,
-          "y": 169.8191
-        }
-      },
-      "id": "08e44f5b-61d8-4023-816a-42d246749907",
-      "name": "test_ellipse_basic",
+      "id": "feb4c545-715b-4534-a1f5-487fea8015e8",
+      "name": "test_skeleton_basic",
       "properties": [],
-      "slot_names": [
-        "0"
-      ]
-    },
-    {
-      "id": "9ae92e99-fa0b-4d24-9bda-38a485d538f5",
-      "keypoint": {
-        "x": 483.2745,
-        "y": 199.3579
+      "skeleton": {
+        "nodes": [
+          {
+            "name": "node",
+            "occluded": false,
+            "x": 55.0883,
+            "y": 303.3708
+          },
+          {
+            "name": "2",
+            "occluded": false,
+            "x": 70.3435,
+            "y": 275.634
+          }
+        ]
       },
-      "name": "test_keypoint_basic",
-      "properties": [],
       "slot_names": [
         "0"
       ]
@@ -87,7 +90,7 @@
         "x": 18.6838,
         "y": 135.2167
       },
-      "id": "7d3d984c-099e-4b59-a53d-c3e0467e3fc9",
+      "id": "045ddef6-d4b4-4924-bf29-c6435ac37996",
       "name": "test_polygon_basic",
       "polygon": {
         "paths": [
@@ -117,55 +120,52 @@
       ]
     },
     {
-      "id": "a6d75c80-e1ad-4721-b702-ba14757834e9",
-      "name": "test_skeleton_basic",
-      "properties": [],
-      "skeleton": {
-        "nodes": [
-          {
-            "name": "node",
-            "occluded": false,
-            "x": 55.0883,
-            "y": 303.3708
-          },
-          {
-            "name": "2",
-            "occluded": false,
-            "x": 70.3435,
-            "y": 275.634
-          }
-        ]
+      "id": "e9f1b9b2-6afd-4c89-b9df-18e418f3d920",
+      "keypoint": {
+        "x": 483.2745,
+        "y": 199.3579
       },
-      "slot_names": [
-        "0"
-      ]
-    },
-    {
-      "id": "883f884f-f617-4a96-8874-54a2eba0a464",
-      "line": {
-        "path": [
-          {
-            "x": 136.565,
-            "y": 353.6437
-          },
-          {
-            "x": 107.0947,
-            "y": 402.183
-          },
-          {
-            "x": 169.5024,
-            "y": 407.3836
-          }
-        ]
-      },
-      "name": "test_line_basic",
+      "name": "test_keypoint_basic",
       "properties": [],
       "slot_names": [
         "0"
       ]
     },
     {
-      "id": "446c259e-78f3-4f5e-a9f2-ad441a91e5eb",
+      "ellipse": {
+        "angle": 0.2004,
+        "center": {
+          "x": 214.5746,
+          "y": 259.1653
+        },
+        "radius": {
+          "x": 169.8191,
+          "y": 169.8191
+        }
+      },
+      "id": "6a0ce006-6549-48ae-86b7-c02db513aeed",
+      "name": "test_ellipse_basic",
+      "properties": [],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "bounding_box": {
+        "h": 38.138,
+        "w": 67.608,
+        "x": 36.019,
+        "y": 50.273
+      },
+      "id": "719e192d-1a9e-486d-ae88-46cf53d9ff6d",
+      "name": "test_bounding_box_basic",
+      "properties": [],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "id": "c95fb63f-fcca-4932-870e-06d54cf87d01",
       "name": "test_tag_basic",
       "properties": [],
       "slot_names": [
@@ -174,7 +174,7 @@
       "tag": {}
     },
     {
-      "id": "82f068db-0781-44cf-8207-3a119f2e8fc2",
+      "id": "dceb432a-3719-4705-9caa-5bc41d4ebed9",
       "mask": {},
       "name": "test_mask_basic",
       "properties": [],
@@ -183,7 +183,16 @@
       ]
     },
     {
-      "id": "182ce0cd-375e-42ed-96b8-93dc9a326411",
+      "id": "3f7d2b30-a6d7-49fa-a8d7-f229eaf2cbcc",
+      "mask": {},
+      "name": "test_mask_basic",
+      "properties": [],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "id": "0f3a6d6d-82c1-44b4-9f05-d88c49601ecb",
       "name": "__raster_layer__",
       "properties": [],
       "raster_layer": {
@@ -345,10 +354,15 @@
           1,
           4,
           0,
-          1710390
+          38396,
+          2,
+          1,
+          0,
+          1671993
         ],
         "mask_annotation_ids_mapping": {
-          "82f068db-0781-44cf-8207-3a119f2e8fc2": 1
+          "3f7d2b30-a6d7-49fa-a8d7-f229eaf2cbcc": 2,
+          "dceb432a-3719-4705-9caa-5bc41d4ebed9": 1
         },
         "total_pixels": 2073600
       },

--- a/e2e_tests/data/import/image_annotations_without_subtypes/image_7.json
+++ b/e2e_tests/data/import/image_annotations_without_subtypes/image_7.json
@@ -36,46 +36,49 @@
   },
   "annotations": [
     {
-      "bounding_box": {
-        "h": 38.138,
-        "w": 67.608,
-        "x": 36.019,
-        "y": 50.273
+      "id": "7aed5e8f-f144-4a69-9767-ce4d14972f23",
+      "line": {
+        "path": [
+          {
+            "x": 136.565,
+            "y": 353.6437
+          },
+          {
+            "x": 107.0947,
+            "y": 402.183
+          },
+          {
+            "x": 169.5024,
+            "y": 407.3836
+          }
+        ]
       },
-      "id": "d874ccb2-d2c4-4847-af78-f6d3dd2e5300",
-      "name": "test_bounding_box_basic",
+      "name": "test_line_basic",
       "properties": [],
       "slot_names": [
         "0"
       ]
     },
     {
-      "ellipse": {
-        "angle": 0.2004,
-        "center": {
-          "x": 214.5746,
-          "y": 259.1653
-        },
-        "radius": {
-          "x": 169.8191,
-          "y": 169.8191
-        }
-      },
-      "id": "a3ccd0cc-3b2b-48d7-8ee9-139b953bb2dd",
-      "name": "test_ellipse_basic",
+      "id": "e7d95a9c-0400-4975-aa84-f9f5171bd5b6",
+      "name": "test_skeleton_basic",
       "properties": [],
-      "slot_names": [
-        "0"
-      ]
-    },
-    {
-      "id": "ac69bc21-d802-43c9-9b90-5f7caac5d98a",
-      "keypoint": {
-        "x": 483.2745,
-        "y": 199.3579
+      "skeleton": {
+        "nodes": [
+          {
+            "name": "node",
+            "occluded": false,
+            "x": 55.0883,
+            "y": 303.3708
+          },
+          {
+            "name": "2",
+            "occluded": false,
+            "x": 70.3435,
+            "y": 275.634
+          }
+        ]
       },
-      "name": "test_keypoint_basic",
-      "properties": [],
       "slot_names": [
         "0"
       ]
@@ -87,7 +90,7 @@
         "x": 18.6838,
         "y": 135.2167
       },
-      "id": "eb86579d-ca6f-4c74-9a1d-fdf12f5e19ca",
+      "id": "a912677a-6ca4-41d7-8836-9c82850ea777",
       "name": "test_polygon_basic",
       "polygon": {
         "paths": [
@@ -117,55 +120,52 @@
       ]
     },
     {
-      "id": "d47006b1-5b12-4398-b1a7-57f43e7e4f9a",
-      "name": "test_skeleton_basic",
-      "properties": [],
-      "skeleton": {
-        "nodes": [
-          {
-            "name": "node",
-            "occluded": false,
-            "x": 55.0883,
-            "y": 303.3708
-          },
-          {
-            "name": "2",
-            "occluded": false,
-            "x": 70.3435,
-            "y": 275.634
-          }
-        ]
+      "id": "7d0fcea1-9fa6-479a-968c-1d19f8133050",
+      "keypoint": {
+        "x": 483.2745,
+        "y": 199.3579
       },
-      "slot_names": [
-        "0"
-      ]
-    },
-    {
-      "id": "b274a449-098a-49e3-8091-846720b5c880",
-      "line": {
-        "path": [
-          {
-            "x": 136.565,
-            "y": 353.6437
-          },
-          {
-            "x": 107.0947,
-            "y": 402.183
-          },
-          {
-            "x": 169.5024,
-            "y": 407.3836
-          }
-        ]
-      },
-      "name": "test_line_basic",
+      "name": "test_keypoint_basic",
       "properties": [],
       "slot_names": [
         "0"
       ]
     },
     {
-      "id": "5fe86f0c-f337-4d0e-b146-c30a533cf354",
+      "ellipse": {
+        "angle": 0.2004,
+        "center": {
+          "x": 214.5746,
+          "y": 259.1653
+        },
+        "radius": {
+          "x": 169.8191,
+          "y": 169.8191
+        }
+      },
+      "id": "ddeb5295-42b2-4d69-8266-0449c414106d",
+      "name": "test_ellipse_basic",
+      "properties": [],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "bounding_box": {
+        "h": 38.138,
+        "w": 67.608,
+        "x": 36.019,
+        "y": 50.273
+      },
+      "id": "3dbe025f-545f-4497-9f6f-d749aef7136e",
+      "name": "test_bounding_box_basic",
+      "properties": [],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "id": "19640e45-db00-4926-a8a3-52abfe64fb23",
       "name": "test_tag_basic",
       "properties": [],
       "slot_names": [
@@ -174,7 +174,7 @@
       "tag": {}
     },
     {
-      "id": "29b23515-6a9f-4886-9117-a15b07e0ea05",
+      "id": "6a65c9ff-555e-49ff-8062-5f3a2346794b",
       "mask": {},
       "name": "test_mask_basic",
       "properties": [],
@@ -183,7 +183,16 @@
       ]
     },
     {
-      "id": "6f0e0d25-4e49-4989-8444-8ee19459369c",
+      "id": "add94bb5-6a52-4b65-be1d-8ee416150ec4",
+      "mask": {},
+      "name": "test_mask_basic",
+      "properties": [],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "id": "4bfe75f6-7d8a-4158-897f-487c8a64019e",
       "name": "__raster_layer__",
       "properties": [],
       "raster_layer": {
@@ -229,10 +238,15 @@
           1,
           5,
           0,
-          1802664
+          59605,
+          2,
+          1,
+          0,
+          1743058
         ],
         "mask_annotation_ids_mapping": {
-          "29b23515-6a9f-4886-9117-a15b07e0ea05": 1
+          "6a65c9ff-555e-49ff-8062-5f3a2346794b": 1,
+          "add94bb5-6a52-4b65-be1d-8ee416150ec4": 2
         },
         "total_pixels": 2073600
       },

--- a/e2e_tests/data/import/image_annotations_without_subtypes/image_8.json
+++ b/e2e_tests/data/import/image_annotations_without_subtypes/image_8.json
@@ -36,46 +36,49 @@
   },
   "annotations": [
     {
-      "bounding_box": {
-        "h": 38.138,
-        "w": 67.608,
-        "x": 36.019,
-        "y": 50.273
+      "id": "04ac0c7d-8d7e-409b-a063-ad203b68c579",
+      "line": {
+        "path": [
+          {
+            "x": 136.565,
+            "y": 353.6437
+          },
+          {
+            "x": 107.0947,
+            "y": 402.183
+          },
+          {
+            "x": 169.5024,
+            "y": 407.3836
+          }
+        ]
       },
-      "id": "1c22588e-f006-4bff-9842-d6690cd743db",
-      "name": "test_bounding_box_basic",
+      "name": "test_line_basic",
       "properties": [],
       "slot_names": [
         "0"
       ]
     },
     {
-      "ellipse": {
-        "angle": 0.2004,
-        "center": {
-          "x": 214.5746,
-          "y": 259.1653
-        },
-        "radius": {
-          "x": 169.8191,
-          "y": 169.8191
-        }
-      },
-      "id": "bd7896fb-3635-4c3e-a417-7a005b29bb78",
-      "name": "test_ellipse_basic",
+      "id": "c098c71d-1e1b-45cf-963e-ad6884c77415",
+      "name": "test_skeleton_basic",
       "properties": [],
-      "slot_names": [
-        "0"
-      ]
-    },
-    {
-      "id": "6fd4261b-0aca-4d31-9f02-fa0461e4c6d6",
-      "keypoint": {
-        "x": 483.2745,
-        "y": 199.3579
+      "skeleton": {
+        "nodes": [
+          {
+            "name": "node",
+            "occluded": false,
+            "x": 55.0883,
+            "y": 303.3708
+          },
+          {
+            "name": "2",
+            "occluded": false,
+            "x": 70.3435,
+            "y": 275.634
+          }
+        ]
       },
-      "name": "test_keypoint_basic",
-      "properties": [],
       "slot_names": [
         "0"
       ]
@@ -87,7 +90,7 @@
         "x": 18.6838,
         "y": 135.2167
       },
-      "id": "8c91c90f-3744-4b72-85aa-938c862189ae",
+      "id": "32243dde-2aab-4a8d-926e-75e5060b2ab1",
       "name": "test_polygon_basic",
       "polygon": {
         "paths": [
@@ -117,55 +120,52 @@
       ]
     },
     {
-      "id": "c37bc7ac-0d5c-45c7-8e9c-bcff3df871be",
-      "name": "test_skeleton_basic",
-      "properties": [],
-      "skeleton": {
-        "nodes": [
-          {
-            "name": "node",
-            "occluded": false,
-            "x": 55.0883,
-            "y": 303.3708
-          },
-          {
-            "name": "2",
-            "occluded": false,
-            "x": 70.3435,
-            "y": 275.634
-          }
-        ]
+      "id": "616ff7f6-f3c7-4fca-b321-313492572328",
+      "keypoint": {
+        "x": 483.2745,
+        "y": 199.3579
       },
-      "slot_names": [
-        "0"
-      ]
-    },
-    {
-      "id": "53d52c56-ca8d-4869-b72e-8c02c8018f17",
-      "line": {
-        "path": [
-          {
-            "x": 136.565,
-            "y": 353.6437
-          },
-          {
-            "x": 107.0947,
-            "y": 402.183
-          },
-          {
-            "x": 169.5024,
-            "y": 407.3836
-          }
-        ]
-      },
-      "name": "test_line_basic",
+      "name": "test_keypoint_basic",
       "properties": [],
       "slot_names": [
         "0"
       ]
     },
     {
-      "id": "2d5279e7-eb36-4a61-a33b-4d1e57ffc8de",
+      "ellipse": {
+        "angle": 0.2004,
+        "center": {
+          "x": 214.5746,
+          "y": 259.1653
+        },
+        "radius": {
+          "x": 169.8191,
+          "y": 169.8191
+        }
+      },
+      "id": "78e5f112-4708-44ec-986b-04508be7f1e8",
+      "name": "test_ellipse_basic",
+      "properties": [],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "bounding_box": {
+        "h": 38.138,
+        "w": 67.608,
+        "x": 36.019,
+        "y": 50.273
+      },
+      "id": "188c11d4-8821-423c-af37-3ab4d4bf4cb2",
+      "name": "test_bounding_box_basic",
+      "properties": [],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "id": "146e3dfd-141f-40d3-a26e-9fad3e50c6e1",
       "name": "test_tag_basic",
       "properties": [],
       "slot_names": [
@@ -174,7 +174,7 @@
       "tag": {}
     },
     {
-      "id": "c9a8e156-b9aa-4a99-9219-e9046b28ecd4",
+      "id": "3c7de2c9-e894-4ca0-9265-69e5f12f5c5b",
       "mask": {},
       "name": "test_mask_basic",
       "properties": [],
@@ -183,13 +183,26 @@
       ]
     },
     {
-      "id": "2810456f-eda2-4fd2-b1a3-130983972290",
+      "id": "af48569a-9327-4802-8eba-e174a7be376e",
+      "mask": {},
+      "name": "test_mask_basic",
+      "properties": [],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "id": "bf7a597c-8f92-42f1-987f-6cd962bccee4",
       "name": "__raster_layer__",
       "properties": [],
       "raster_layer": {
         "dense_rle": [
           0,
-          345921,
+          295981,
+          2,
+          1,
+          0,
+          49939,
           1,
           4,
           0,
@@ -372,7 +385,8 @@
           1643193
         ],
         "mask_annotation_ids_mapping": {
-          "c9a8e156-b9aa-4a99-9219-e9046b28ecd4": 1
+          "3c7de2c9-e894-4ca0-9265-69e5f12f5c5b": 1,
+          "af48569a-9327-4802-8eba-e174a7be376e": 2
         },
         "total_pixels": 2073600
       },

--- a/e2e_tests/data/import/multi_slotted_annotations_with_slots_defined/.v7/metadata.json
+++ b/e2e_tests/data/import/multi_slotted_annotations_with_slots_defined/.v7/metadata.json
@@ -1,0 +1,84 @@
+{
+  "version": "1.0",
+  "schema_ref": "https://darwin-public.s3.eu-west-1.amazonaws.com/darwin_json/metadata/1.0/schema.json",
+  "classes": [
+    {
+      "name": "__raster_layer__",
+      "type": "raster_layer",
+      "description": "System class for all team's annotations with raster_layer type",
+      "color": "rgba(0,0,0,1.0)",
+      "sub_types": [],
+      "properties": [],
+      "sub_types_settings": {}
+    },
+    {
+      "name": "test_bounding_box_basic",
+      "type": "bounding_box",
+      "description": null,
+      "color": "rgba(0,255,255,1.0)",
+      "sub_types": [
+        "inference"
+      ],
+      "properties": [],
+      "sub_types_settings": {
+        "inference": {}
+      }
+    },
+    {
+      "name": "test_mask_basic",
+      "type": "mask",
+      "description": null,
+      "color": "rgba(255,0,85,1.0)",
+      "sub_types": [],
+      "properties": [],
+      "sub_types_settings": {}
+    }
+  ],
+  "properties": [
+    {
+      "name": "test_item_level_property_single_select",
+      "type": "single_select",
+      "description": "",
+      "required": false,
+      "granularity": "item",
+      "property_values": [
+        {
+          "value": "2",
+          "color": "rgba(255,92,0,1.0)"
+        },
+        {
+          "value": "1",
+          "color": "rgba(255,92,0,1.0)"
+        }
+      ]
+    },
+    {
+      "name": "test_item_level_property_multi_select",
+      "type": "multi_select",
+      "description": "",
+      "required": false,
+      "granularity": "item",
+      "property_values": [
+        {
+          "value": "2",
+          "color": "rgba(255,92,0,1.0)"
+        },
+        {
+          "value": "1",
+          "color": "rgba(255,92,0,1.0)"
+        }
+      ]
+    },
+    {
+      "name": "test_item_level_property_text",
+      "type": "text",
+      "description": "",
+      "required": false,
+      "granularity": "item",
+      "property_values": []
+    }
+  ],
+  "mask_classes_labels": {
+    "test_mask_basic": 52
+  }
+}

--- a/e2e_tests/data/import/multi_slotted_annotations_with_slots_defined/multi_slotted_item.json
+++ b/e2e_tests/data/import/multi_slotted_annotations_with_slots_defined/multi_slotted_item.json
@@ -106,6 +106,51 @@
       ]
     },
     {
+      "id": "657ab125-1a8f-4e21-bf94-27956b44c6b0",
+      "mask": {},
+      "name": "test_mask_basic",
+      "properties": [],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "id": "b2f0b41a-bb00-4d4c-b946-5c35218aeec0",
+      "mask": {},
+      "name": "test_mask_basic",
+      "properties": [],
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
+      "id": "87d6540f-2667-4c64-9fba-5c35a140d30b",
+      "name": "__raster_layer__",
+      "properties": [],
+      "raster_layer": {
+        "dense_rle": [
+          0,
+          843137,
+          1,
+          1,
+          0,
+          201629,
+          2,
+          1,
+          0,
+          1028832
+        ],
+        "mask_annotation_ids_mapping": {
+          "657ab125-1a8f-4e21-bf94-27956b44c6b0": 1,
+          "b2f0b41a-bb00-4d4c-b946-5c35218aeec0": 2
+        },
+        "total_pixels": 2073600
+      },
+      "slot_names": [
+        "0"
+      ]
+    },
+    {
       "bounding_box": {
         "h": 7.9365,
         "w": 11.7725,
@@ -115,6 +160,59 @@
       "id": "2a4fc53e-52e2-4c29-a558-90307f7beb7a",
       "name": "test_bounding_box_basic",
       "properties": [],
+      "slot_names": [
+        "1"
+      ]
+    },
+    {
+      "id": "d58dfad5-7b9f-42da-93a7-c955fa79abad",
+      "mask": {},
+      "name": "test_mask_basic",
+      "properties": [],
+      "slot_names": [
+        "1"
+      ]
+    },
+    {
+      "id": "08d3c9c3-2b38-472f-ab4d-169e183e7cac",
+      "mask": {},
+      "name": "test_mask_basic",
+      "properties": [],
+      "slot_names": [
+        "1"
+      ]
+    },
+    {
+      "id": "787221f4-5f37-45a5-92db-86cf0e2c1d23",
+      "name": "__raster_layer__",
+      "properties": [],
+      "raster_layer": {
+        "dense_rle": [
+          0,
+          806744,
+          1,
+          2,
+          0,
+          1918,
+          1,
+          1,
+          0,
+          1920,
+          1,
+          1,
+          0,
+          163216,
+          2,
+          1,
+          0,
+          1099797
+        ],
+        "mask_annotation_ids_mapping": {
+          "08d3c9c3-2b38-472f-ab4d-169e183e7cac": 2,
+          "d58dfad5-7b9f-42da-93a7-c955fa79abad": 1
+        },
+        "total_pixels": 2073600
+      },
       "slot_names": [
         "1"
       ]
@@ -157,6 +255,51 @@
       "id": "3a2b9b85-c423-4509-a7fe-b7a8e5761817",
       "name": "test_bounding_box_basic",
       "properties": [],
+      "slot_names": [
+        "2"
+      ]
+    },
+    {
+      "id": "567da26d-6c7b-4ac3-a3fe-8552f163a91f",
+      "mask": {},
+      "name": "test_mask_basic",
+      "properties": [],
+      "slot_names": [
+        "2"
+      ]
+    },
+    {
+      "id": "a1e5e24c-647e-4bc4-b1d4-c6f6aaf64520",
+      "mask": {},
+      "name": "test_mask_basic",
+      "properties": [],
+      "slot_names": [
+        "2"
+      ]
+    },
+    {
+      "id": "fd1ab6df-a866-463c-ac7f-36a654258e16",
+      "name": "__raster_layer__",
+      "properties": [],
+      "raster_layer": {
+        "dense_rle": [
+          0,
+          814476,
+          1,
+          1,
+          0,
+          151683,
+          2,
+          1,
+          0,
+          1107439
+        ],
+        "mask_annotation_ids_mapping": {
+          "567da26d-6c7b-4ac3-a3fe-8552f163a91f": 1,
+          "a1e5e24c-647e-4bc4-b1d4-c6f6aaf64520": 2
+        },
+        "total_pixels": 2073600
+      },
       "slot_names": [
         "2"
       ]


### PR DESCRIPTION
# Problem
We want to validate that import and export of mask instances works as expected in darwin-py.

# Solution
Add mask instances to single and multi-slot test items in e2e import tests. If these tests pass, we validate that: mask instances were preserved after being imported to, and exported from the platform.

**Note:** for now the modified tests will fail, as they require a fix to be applied on BE side to allow import of mask instances: https://github.com/v7labs/darwin-backend/pull/5784. However, I ran the e2e tests locally against a modified version of the BE, and they passed.

# Changelog
Add e2e tests for mask instances on single and multi slot items
