### PR TITLE
keep frame id for annotation parsing

### DIFF
--- a/darwin/utils/utils.py
+++ b/darwin/utils/utils.py
@@ -1028,7 +1028,7 @@ def _parse_darwin_video_annotation(annotation: dict) -> Optional[dt.VideoAnnotat
                 break
     for f, frame in frames.items():
         frame_annotations[int(f)] = _parse_darwin_annotation(
-            {**frame, **{"name": name, "id": annotation.get("id", None)}},
+            {**frame, **{"name": name, "id": frame.get("id", None)}},
             only_keyframes,
             annotation_type,
             annotation_data,


### PR DESCRIPTION
# Problem
When parsing video annotation files, the annotations have an `id` at the frame level but not at the annotation level in the JSON file. Previously, this caused the id to be set to None even though it existed in the frame data.

# Solution
Update the parsing logic to check for the id at the frame level (when available) instead of the annotation level.

# Changelog
Fixed bug where annotation id is lost if defined at the frame level.
