### PR TITLE
Fix incompatibility between semantic mask export and single-slot DICOM/video annotation

### DIFF
--- a/darwin/utils/utils.py
+++ b/darwin/utils/utils.py
@@ -1040,8 +1040,18 @@ def _parse_darwin_video_annotation(annotation: dict) -> Optional[dt.VideoAnnotat
             if annotation_type:
                 break
     for f, frame in frames.items():
+        parent_data = {
+            "name": name,
+            "id": annotation.get("id", None),
+        }
+        if not parse_slot_names(frame) and len(parse_slot_names(annotation)) == 1:
+            parent_data["slot_names"] = parse_slot_names(annotation)
+
         frame_annotations[int(f)] = _parse_darwin_annotation(
-            {**frame, **{"name": name, "id": annotation.get("id", None)}},
+            {
+                **frame,
+                **parent_data,
+            },
             only_keyframes,
             annotation_type,
             annotation_data,


### PR DESCRIPTION
# Problem
When converting a Darwin JSON export with mask annotations for a single-slot DICOM/video into semantic mask format, `ValueError("RasterLayer must be associated with at least one slot")` is raised. This is due to the lack of `"slot_names"` in each frame of the annotations in the export.

# Solution
For a single-slot DICOM/video, each frame annotation should share the same slot names as the main annotation, so we pass the `slot_names` of main annotation along with the name and id when parsing the frame annotations.

# Changelog
Fix incompatibility between semantic mask export and single-slot DICOM/video annotation
