### PR TITLE
Fix version_bump workflow: update Python 3.9 → 3.10

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5.5.0
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Install dependencies with retry
         uses: nick-invision/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08


### PR DESCRIPTION
## Summary

- Updates `version_bump.yml` to use Python 3.10 instead of 3.9
- PR #1134 bumped the minimum Python version to `>=3.10` but missed this workflow, causing the version bump CI to fail with `ERROR: Package 'darwin-py' requires a different Python: 3.9.25 not in '<3.13,>=3.10'`

## Context

This is blocking the v3.4.5 release. Once merged, we can re-run the "Version Bump and Release" workflow to publish the Pillow CVE fix.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the GitHub Actions runtime Python version for the release/version-bump workflow, with no production code changes.
> 
> **Overview**
> Updates the `Version Bump and Release` GitHub Actions workflow to use **Python 3.10** instead of 3.9, aligning CI with the project’s minimum supported Python version and preventing dependency resolution failures during version bump/release runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d30ee0ca729744b0b7afc15eb33e454732801e7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->