### PR TITLE
Fix docs generation workflow: drop Python 3.9 from matrix

### DIFF
--- a/.github/workflows/JOB_generate_documentation.yml
+++ b/.github/workflows/JOB_generate_documentation.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - name: Free Disk space
         shell: bash


### PR DESCRIPTION
## Summary

- Drops Python 3.9 from the `JOB_generate_documentation.yml` matrix, aligning it with the `JOB_tests.yml` change from PR #1134
- This fixes the [`generate-documentation (3.9)` failure](https://github.com/v7labs/darwin-py/actions/runs/24350561393/job/71103453238) on merge to master, where `pip install` fails with `Package 'darwin-py' requires a different Python: 3.9.x not in '<3.13,>=3.10'`

## Context

PR #1134 bumped the minimum Python to `>=3.10` and updated `JOB_tests.yml` and `EVENT_release.yml`, but missed `JOB_generate_documentation.yml`. PR #1138 already fixed `version_bump.yml` for the same reason.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that simply stops running the docs generation job on an unsupported Python version.
> 
> **Overview**
> Stops running the `generate-documentation` workflow on Python `3.9` by removing it from the matrix, aligning docs generation with the project’s supported Python versions and avoiding `pip install` failures on merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba7e34930561a5d87e79486fc81c36c15712ff34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->