### PR TITLE
Fix E2E test: compare PNG images by pixel data, not raw bytes

### DIFF
--- a/e2e_tests/helpers.py
+++ b/e2e_tests/helpers.py
@@ -304,19 +304,24 @@ def exclude_annotations_of_type(
     ]
 
 
-def _compare_images_by_pixels(file_a: Path, file_b: Path) -> bool:
+def _compare_images_by_pixels(file_a: Path, file_b: Path) -> None:
     """Compare two image files by their decoded pixel data, ignoring
     compression differences (e.g. zlib vs zlib-ng in different Pillow versions).
-    """
-    try:
-        import numpy as np
-        from PIL import Image
 
-        arr_a = np.array(Image.open(file_a))
-        arr_b = np.array(Image.open(file_b))
-        return np.array_equal(arr_a, arr_b)
-    except Exception:
-        return False
+    Raises AssertionError with a descriptive message on mismatch or if files
+    cannot be opened.
+    """
+    import numpy as np
+    from PIL import Image
+
+    img_a = Image.open(file_a)
+    img_b = Image.open(file_b)
+    arr_a = np.array(img_a)
+    arr_b = np.array(img_b)
+    assert np.array_equal(arr_a, arr_b), (
+        f"Image pixel data mismatch:\n  {file_a}\n  {file_b}\n"
+        f"  shapes: {arr_a.shape} vs {arr_b.shape}"
+    )
 
 
 _IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".bmp", ".tiff", ".tif", ".webp"}
@@ -342,9 +347,7 @@ def compare_directories(path: Path, expected_path: Path) -> None:
 
             # For images, compare decoded pixel data to tolerate compression differences
             if file.suffix.lower() in _IMAGE_EXTENSIONS:
-                assert _compare_images_by_pixels(
-                    file, expected_file
-                ), f"Image pixel data mismatch: {file} vs {expected_file}"
+                _compare_images_by_pixels(file, expected_file)
                 continue
 
             # Compare non-image files by raw bytes

--- a/e2e_tests/helpers.py
+++ b/e2e_tests/helpers.py
@@ -304,6 +304,24 @@ def exclude_annotations_of_type(
     ]
 
 
+def _compare_images_by_pixels(file_a: Path, file_b: Path) -> bool:
+    """Compare two image files by their decoded pixel data, ignoring
+    compression differences (e.g. zlib vs zlib-ng in different Pillow versions).
+    """
+    try:
+        import numpy as np
+        from PIL import Image
+
+        arr_a = np.array(Image.open(file_a))
+        arr_b = np.array(Image.open(file_b))
+        return np.array_equal(arr_a, arr_b)
+    except Exception:
+        return False
+
+
+_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".bmp", ".tiff", ".tif", ".webp"}
+
+
 def compare_directories(path: Path, expected_path: Path) -> None:
     """
     Compare two directories recursively
@@ -320,15 +338,24 @@ def compare_directories(path: Path, expected_path: Path) -> None:
                 # Ignore hidden files
                 continue
 
-            # Compare files
+            expected_file = expected_path / file.name
+
+            # For images, compare decoded pixel data to tolerate compression differences
+            if file.suffix.lower() in _IMAGE_EXTENSIONS:
+                assert _compare_images_by_pixels(
+                    file, expected_file
+                ), f"Image pixel data mismatch: {file} vs {expected_file}"
+                continue
+
+            # Compare non-image files by raw bytes
             with file.open("rb") as f:
                 content = f.read()
 
-            with Path(expected_path / file.name).open("rb") as f:
+            with expected_file.open("rb") as f:
                 expected_content = f.read()
 
             if content != expected_content:
-                print(f"Expected file: {expected_path / file.name}")
+                print(f"Expected file: {expected_file}")
                 print(f"Expected Content: \n{expected_content}")
                 print("---------------------")
                 print(f"Actual file: {file}")


### PR DESCRIPTION
## [DAR-7761](https://linear.app/v7labs/issue/DAR-7761/fix-e2e-test-compare-png-images-by-pixel-data-not-raw-bytes)

## Summary

- Fixes the consistent `test_darwin_convert[instance_mask]` E2E failure on Windows introduced by PR #1134
- Changes `compare_directories` in `e2e_tests/helpers.py` to compare image files (PNG, JPEG, etc.) by decoded pixel data instead of raw bytes

## Root cause

The Pillow upgrade from 10.4.0 → 12.2.0 changed the PNG encoder from `zlib` to `zlib-ng`. This produces different compressed bytes for identical pixel data ([python-pillow/Pillow#8796](https://github.com/python-pillow/Pillow/issues/8796)). The `instance_mask` convert test compared generated PNGs byte-for-byte against committed reference fixtures, causing a deterministic failure.

## Fix

For image file extensions (`.png`, `.jpg`, etc.), the comparison now decodes both files via `PIL.Image.open` and compares the resulting numpy arrays. This is resilient to encoder/compression changes while still catching actual pixel-level differences. Non-image files continue to use exact byte comparison.

## Test plan

- [x] Windows E2E `test_darwin_convert[instance_mask]` passes
- [x] Ubuntu E2E passes
- [x] All unit tests pass (all platforms, 3.10-3.12)