### PR TITLE
chore: clean up dependabot config and increase PR limits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,7 @@ updates:
       github-actions:
         patterns:
           - '*'
-    reviewers:
-      - "saurbhc"
-      - "umbertoDifa"
-      - "aleksandar-ivic"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 5
     labels:
       - "github-actions-updates"
 
@@ -21,7 +17,6 @@ updates:
     schedule:
       interval: "monthly"
     ignore:
-      # For all packages, ignore all major updates
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
@@ -29,11 +24,7 @@ updates:
       python-requirements:
         patterns:
           - '*'
-    reviewers:
-      - "saurbhc"
-      - "umbertoDifa"
-      - "aleksandar-ivic"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 5
     labels:
       - "dependencies"
 


### PR DESCRIPTION
## Summary
- Remove deprecated `reviewers` field from dependabot config (GitHub deprecated this in favor of CODEOWNERS)
- Increase `open-pull-requests-limit` from 1 to 5 for pip and github-actions ecosystems so dependabot can create all needed PRs at once
- This change will also re-trigger dependabot to create fresh PRs after closing all stale ones

## Context
Closed 8 stale dependabot PRs that had merge conflicts or were outdated. This config change triggers dependabot to re-run and create fresh PRs against current master (v3.5.0).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to Dependabot behavior; no runtime code paths or security-sensitive logic affected.
> 
> **Overview**
> Cleans up Dependabot configuration by removing the deprecated `reviewers` entries for the `github-actions` and `pip` update jobs.
> 
> Increases `open-pull-requests-limit` from `1` to `5` for those ecosystems so Dependabot can open more update PRs concurrently (docker settings unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 963b90121db37392bbcd73f7ff1497957a7e3fe9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->