### PR TITLE
fix: use fresh action SHAs and update allowlist

### DIFF
--- a/.github/workflows/EVENT_merge_to_master.yml
+++ b/.github/workflows/EVENT_merge_to_master.yml
@@ -50,7 +50,7 @@ jobs:
       statuses: write
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.18.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/EVENT_release.yml
+++ b/.github/workflows/EVENT_release.yml
@@ -38,12 +38,12 @@ jobs:
       contents: read
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.18.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
 
       - name: Harden Runner
-        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.18.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
 
@@ -125,7 +125,7 @@ jobs:
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
 
       - name: Harden Runner
-        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.18.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/EVENT_update-linear-labels.yml
+++ b/.github/workflows/EVENT_update-linear-labels.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.18.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/JOB_e2e.yml
+++ b/.github/workflows/JOB_e2e.yml
@@ -53,7 +53,7 @@ jobs:
           sudo rm -rf /usr/local/lib/android  # will release about 10 GB if you don't need Android
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
       - name: Harden Runner
-        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.18.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/JOB_format.yml
+++ b/.github/workflows/JOB_format.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Harden Runner
-      uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.18.0
+      uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
       with:
         egress-policy: audit
 

--- a/.github/workflows/JOB_generate_documentation.yml
+++ b/.github/workflows/JOB_generate_documentation.yml
@@ -29,7 +29,7 @@ jobs:
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
 
       - name: Harden Runner
-        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.18.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/JOB_get_changed_files.yml
+++ b/.github/workflows/JOB_get_changed_files.yml
@@ -34,7 +34,7 @@ jobs:
       json_changed_files: ${{ steps.changed_json_files.outputs.json_changed_files }}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.18.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/JOB_lint.yml
+++ b/.github/workflows/JOB_lint.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read
     steps:
     - name: Harden Runner
-      uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.18.0
+      uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
       with:
         egress-policy: audit
 

--- a/.github/workflows/JOB_slack_message.yml
+++ b/.github/workflows/JOB_slack_message.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.18.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/JOB_tests.yml
+++ b/.github/workflows/JOB_tests.yml
@@ -26,7 +26,7 @@ jobs:
           sudo rm -rf /usr/local/lib/android  # will release about 10 GB if you don't need Android
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
       - name: Harden Runner
-        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.18.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
 
@@ -39,7 +39,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies with retry
-        uses: nick-invision/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08
+        uses: nick-invision/retry@ad984534de44a9489a53aefd81eb77f87c70dc60
         with:
           timeout_minutes: 10
           max_attempts: 3

--- a/.github/workflows/JOB_typecheck.yml
+++ b/.github/workflows/JOB_typecheck.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Harden Runner
-      uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.18.0
+      uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
       with:
         egress-policy: audit
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.18.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.18.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.18.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df
         with:
           egress-policy: audit
 
@@ -46,7 +46,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install dependencies with retry
-        uses: nick-invision/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08
+        uses: nick-invision/retry@ad984534de44a9489a53aefd81eb77f87c70dc60
         with:
           timeout_minutes: 10
           max_attempts: 3


### PR DESCRIPTION
## Summary
- Reverts #1148 which downgraded `step-security/harden-runner` and `nick-invision/retry` to old SHA pins
- Instead, the repository's actions allowlist has been updated to include all the new SHAs from the dependabot PR #1144

## Context
PR #1148 was the wrong fix -- it reverted action SHAs to old versions to match the allowlist. The correct approach is to update the allowlist to accept the fresh versions that dependabot provided. The allowlist has now been updated via the API to include:
- `step-security/harden-runner@6c3c2f2c...` (new)
- `nick-invision/retry@ad984534...` (new)
- `aws-actions/configure-aws-credentials@ec61189d...` (new)
- `ossf/scorecard-action@4eaacf0c...` (new)
- `pypa/gh-action-pypi-publish@cef22109...` (new)

This also fixes the `startup_failure` on `merge_to_master` and `scorecards` workflows.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates pinned third-party GitHub Action SHAs in workflow YAMLs; main risk is unexpected CI behavior changes from the upstream action revisions.
> 
> **Overview**
> Refreshes GitHub Actions pins across CI/release workflows by updating `step-security/harden-runner` to a newer commit SHA everywhere it’s used.
> 
> Also updates `nick-invision/retry` to a newer pinned SHA in the test and version bump workflows, keeping workflow behavior the same while aligning with the repository’s allowlisted action revisions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24ce8972cfbc6af4300b5571d159557b23f80d9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->