### PR TITLE
fix(client): stop debug logs from draining streamed response bodies

### DIFF
--- a/darwin/client.py
+++ b/darwin/client.py
@@ -1155,7 +1155,7 @@ class Client:
         try:
 
             def parse_version(version: str) -> DarwinVersionNumber:
-                (major, minor, patch) = version.split(".")
+                major, minor, patch = version.split(".")
                 return (int(major), int(minor), int(patch))
 
             from darwin.version import __version__

--- a/darwin/client.py
+++ b/darwin/client.py
@@ -57,7 +57,7 @@ from darwin.future.core.properties import update_property as update_property_fut
 from darwin.future.core.types.common import JSONDict
 from darwin.future.data_objects.properties import FullProperty
 from darwin.utils import (
-    get_response_content,
+    describe_response_for_log,
     has_json_content_type,
     is_project_dir,
     urljoin,
@@ -915,12 +915,15 @@ class Client:
             stream=stream,
         )
 
-        self.log.debug(
-            f"Client GET request response ({get_response_content(response)}) with status "
-            f"({response.status_code}). "
-            f"Client: ({self})"
-            f"Request: (url={url})"
-        )
+        if self.log.isEnabledFor(logging.DEBUG):
+            self.log.debug(
+                "Client GET request response (%s) with status (%s). "
+                "Client: (%s) Request: (url=%s)",
+                describe_response_for_log(response),
+                response.status_code,
+                self,
+                url,
+            )
 
         self._raise_if_known_error(response, url)
         response.raise_for_status()
@@ -960,12 +963,16 @@ class Client:
             headers=self._get_headers(team_slug),
         )
 
-        self.log.debug(
-            f"Client PUT request got response ({get_response_content(response)}) with status "
-            f"({response.status_code}). "
-            f"Client: ({self})"
-            f"Request: (endpoint={endpoint}, payload={payload})"
-        )
+        if self.log.isEnabledFor(logging.DEBUG):
+            self.log.debug(
+                "Client PUT request got response (%s) with status (%s). "
+                "Client: (%s) Request: (endpoint=%s, payload=%s)",
+                describe_response_for_log(response),
+                response.status_code,
+                self,
+                endpoint,
+                payload,
+            )
 
         self._raise_if_known_error(response, urljoin(self.url, endpoint))
         response.raise_for_status()
@@ -1016,12 +1023,16 @@ class Client:
                 headers=self._get_headers(team_slug),
             )
 
-        self.log.debug(
-            f"Client POST request response ({get_response_content(response)}) with unexpected status "
-            f"({response.status_code}). "
-            f"Client: ({self})"
-            f"Request: (endpoint={endpoint}, payload={payload})"
-        )
+        if self.log.isEnabledFor(logging.DEBUG):
+            self.log.debug(
+                "Client POST request response (%s) with unexpected status (%s). "
+                "Client: (%s) Request: (endpoint=%s, payload=%s)",
+                describe_response_for_log(response),
+                response.status_code,
+                self,
+                endpoint,
+                payload,
+            )
 
         self._raise_if_known_error(response, urljoin(self.url, endpoint))
         response.raise_for_status()
@@ -1057,12 +1068,15 @@ class Client:
             headers=self._get_headers(team_slug),
         )
 
-        self.log.debug(
-            f"Client DELETE request response ({get_response_content(response)}) with unexpected status "
-            f"({response.status_code}). "
-            f"Client: ({self})"
-            f"Request: (endpoint={endpoint})"
-        )
+        if self.log.isEnabledFor(logging.DEBUG):
+            self.log.debug(
+                "Client DELETE request response (%s) with unexpected status (%s). "
+                "Client: (%s) Request: (endpoint=%s)",
+                describe_response_for_log(response),
+                response.status_code,
+                self,
+                endpoint,
+            )
 
         self._raise_if_known_error(response, urljoin(self.url, endpoint))
         response.raise_for_status()

--- a/darwin/utils/utils.py
+++ b/darwin/utils/utils.py
@@ -1533,6 +1533,55 @@ def get_response_content(response: Response) -> Any:
         return response.text
 
 
+def describe_response_for_log(response: Response) -> Any:
+    """
+    Return a representation of ``response`` suitable for inclusion in a log
+    message, without draining a streamed response body.
+
+    Rationale
+    ---------
+    Calling ``response.text`` or ``response.content`` on a ``stream=True``
+    response forces the full body to be read from the socket and decoded into
+    memory before the caller gets a chance to consume the stream. When such a
+    response is only being logged (typically at ``DEBUG`` level), that is both
+    wasteful and, for large binary downloads, actively harmful: the streaming
+    writer downstream receives an already-exhausted response and never writes
+    anything to disk.
+
+    Behaviour:
+
+    * JSON responses (by ``content-type``): returns parsed JSON. ``requests``
+      has already buffered the body for these.
+    * Non-JSON responses whose body has already been materialised
+      (``_content_consumed`` is truthy): returns ``response.text`` as before.
+    * Non-JSON responses whose body has not been consumed yet
+      (i.e. a streamed response): returns a short metadata-only string
+      describing the response, so logging never drains the stream.
+
+    Returns
+    -------
+    Any
+        Parsed JSON, decoded text, or a short metadata placeholder string.
+    """
+    if has_json_content_type(response):
+        return response.json()
+    # requests.Response uses ``_content=False`` as a sentinel meaning "body not
+    # yet read"; once the body is available it holds the raw bytes. Checking
+    # for bytes covers both the normal "already consumed" case and the case
+    # where a caller or test has set ``_content`` directly.
+    cached_content = getattr(response, "_content", False)
+    if getattr(response, "_content_consumed", False) or isinstance(
+        cached_content, (bytes, bytearray)
+    ):
+        return response.text
+    content_type = response.headers.get("content-type")
+    content_length = response.headers.get("content-length")
+    return (
+        f"<body not materialised; content-type={content_type!r} "
+        f"content-length={content_length}>"
+    )
+
+
 def _parse_version(data: dict) -> dt.AnnotationFileVersion:
     version_string = data.get("version", "1.0")
     major, minor, suffix = re.findall(r"^(\d+)\.(\d+)(.*)$", version_string)[0]

--- a/tests/darwin/client_test.py
+++ b/tests/darwin/client_test.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional
@@ -989,3 +990,103 @@ class TestGetAnnotatorsReport:
             },
             status=status_code,
         )
+
+
+@pytest.mark.usefixtures("file_read_write_test")
+class TestRawRequestDoesNotDrainStreamedBody:
+    """
+    Regression tests for a bug where the debug log inside the raw HTTP helpers
+    eagerly materialised the response body (via ``response.text``) before the
+    caller had a chance to consume the stream. For a ``stream=True`` download,
+    this drained the TLS socket into RAM and left the downstream streaming
+    writer with an already-exhausted response, causing the ``darwin dataset
+    pull`` CLI to appear to hang with memory climbing and disk usage flat.
+    """
+
+    @staticmethod
+    def _make_streamed_response(url: str, read_tripwire) -> Response:
+        response = Response()
+        response.status_code = 200
+        response.url = url
+        response.headers["content-type"] = "application/octet-stream"
+        response.headers["content-length"] = "1073741824"
+        response.raw = read_tripwire
+        assert response._content_consumed is False
+        return response
+
+    @staticmethod
+    def _with_log_level(log, level):
+        """Temporarily set ``log`` to ``level`` and restore on exit.
+
+        The ``darwin`` logger is a global singleton; leaking a level change
+        out of the test would break unrelated tests that rely on the default
+        level (see darwin/importer/importer.py:170, which only misbehaves
+        when INFO is enabled for ``darwin``).
+        """
+        from contextlib import contextmanager
+
+        @contextmanager
+        def _cm():
+            original = log.level
+            log.setLevel(level)
+            try:
+                yield
+            finally:
+                log.setLevel(original)
+
+        return _cm()
+
+    def test_get_at_debug_level_does_not_consume_streamed_body(
+        self, darwin_client: Client
+    ) -> None:
+        url = darwin_client.url + "/streamed-blob"
+
+        class _ExplodingRaw:
+            def __init__(self) -> None:
+                self.reads = 0
+
+            def read(self, *_args, **_kwargs):
+                self.reads += 1
+                raise AssertionError(
+                    "Streamed response body must not be read by the client"
+                    " before the caller consumes it"
+                )
+
+        raw = _ExplodingRaw()
+        response = self._make_streamed_response(url, raw)
+
+        with self._with_log_level(darwin_client.log, logging.DEBUG), patch.object(
+            darwin_client.session, "get", return_value=response
+        ) as mock:
+            returned = darwin_client._get_raw_from_full_url(url, stream=True)
+
+        mock.assert_called_once()
+        assert returned is response
+        assert response._content_consumed is False
+        assert raw.reads == 0
+
+    def test_get_below_debug_level_does_not_call_response_helpers(
+        self, darwin_client: Client
+    ) -> None:
+        """Covers the eager-f-string half of the bug: at INFO level nothing that
+        touches the response body should run as part of building the log
+        message. We stand in a sentinel ``raw`` object again to prove the
+        stream is untouched, and ensure the log itself is not emitted."""
+
+        url = darwin_client.url + "/streamed-blob-info-level"
+
+        class _ExplodingRaw:
+            def read(self, *_args, **_kwargs):
+                raise AssertionError("stream must not be read at INFO level")
+
+        response = self._make_streamed_response(url, _ExplodingRaw())
+
+        with self._with_log_level(darwin_client.log, logging.INFO), patch.object(
+            darwin_client.log, "debug", wraps=darwin_client.log.debug
+        ) as debug_spy, patch.object(
+            darwin_client.session, "get", return_value=response
+        ):
+            darwin_client._get_raw_from_full_url(url, stream=True)
+
+        assert response._content_consumed is False
+        debug_spy.assert_not_called()

--- a/tests/darwin/utils_test.py
+++ b/tests/darwin/utils_test.py
@@ -6,6 +6,7 @@ from requests import Response
 import darwin.datatypes as dt
 import darwin.exceptions as de
 from darwin.utils import (
+    describe_response_for_log,
     get_response_content,
     has_json_content_type,
     is_file_extension_allowed,
@@ -1148,6 +1149,43 @@ class TestParseDarwinJson:
         response.headers["content-type"] = "text/plain"
         response._content = b"hello"
         assert "hello" == get_response_content(response)
+
+
+class TestDescribeResponseForLog:
+    def test_returns_parsed_json_for_json_response(self):
+        response: Response = Response()
+        response.headers["content-type"] = "application/json"
+        response._content = b'{"key":"a"}'
+        assert {"key": "a"} == describe_response_for_log(response)
+
+    def test_returns_text_for_already_consumed_non_json_response(self):
+        response: Response = Response()
+        response.headers["content-type"] = "text/plain"
+        response._content = b"hello"
+        assert "hello" == describe_response_for_log(response)
+
+    def test_returns_placeholder_for_streamed_body_without_consuming_it(self):
+        class _ExplodingRaw:
+            """Raises if touched, to prove the helper never reads the stream."""
+
+            def read(self, *_args, **_kwargs):
+                raise AssertionError(
+                    "describe_response_for_log must not read the stream"
+                )
+
+        response: Response = Response()
+        response.headers["content-type"] = "application/octet-stream"
+        response.headers["content-length"] = "1073741824"
+        response.raw = _ExplodingRaw()
+        assert response._content_consumed is False
+
+        result = describe_response_for_log(response)
+
+        assert isinstance(result, str)
+        assert "body not materialised" in result
+        assert "application/octet-stream" in result
+        assert "1073741824" in result
+        assert response._content_consumed is False
 
 
 class TestParseDarwinRasterAnnotation:


### PR DESCRIPTION
## Summary

Every raw HTTP helper in `Client` (`_get_raw_from_full_url`, `_put_raw`, `_post_raw`, `_delete`) logged the response body inside an f-string `self.log.debug(...)`. Two problems compounded on top of that:

1. **Eager evaluation regardless of log level.** f-strings are evaluated every time the interpreter reaches them, so `get_response_content(response)` ran on every request even at INFO / WARNING.
2. **Stream drain on non-JSON bodies.** For non-JSON content, `get_response_content` falls through to `response.text`, which on a `stream=True` GET reads the full body from the socket and decodes it before returning. That silently neutralises `stream=True` and leaves the downstream streaming writer (`_write_file` in `download_manager.py`) with an already-consumed response.

In practice this made `darwin dataset pull` hang on image-heavy datasets: thousands of streamed tile/image GETs were being slurped into RAM by the debug log, one worker at a time.

### Repro / A-B evidence

Pull of `<team>/<dataset>:<release>` (29 items, 28.92 GB of NDPI whole-slide files), Python 3.12, darwin-py 3.5.1, same machine and network, back to back:

| | Before (`3.5.1`) | After (this PR) |
|---|---|---|
| Disk written after 6+ min | **1.24 MB** (effectively hung) | steady ~6–70 MB/s, finishes |
| Total wall time | never (memory climbs, disk flat) | **7 min 04 s** |
| Peak process-tree RSS | **374 MB** on a single worker, still climbing | **65.8 MB** across all workers combined |
| Final download integrity | n/a | **28,916,209,497 bytes**, byte-exact match to V7's items API |

## Fix

Two small layered changes, no public API change:

- `darwin/utils/utils.py`: new `describe_response_for_log` helper. Same shape as `get_response_content`, but:
  - JSON body → parsed JSON (already buffered by `requests`).
  - Non-JSON body already materialised → `response.text` (unchanged behaviour).
  - Non-JSON body not yet consumed (streamed response) → short `<body not materialised; content-type=... content-length=...>` string, without touching the stream.
- `darwin/client.py`: the four `self.log.debug(f"...")` calls in the raw HTTP helpers are rewritten to:
  ```python
  if self.log.isEnabledFor(logging.DEBUG):
      self.log.debug("... (%s) with status (%s). ...",
                     describe_response_for_log(response),
                     response.status_code, ...)
  ```
  The guard is what fixes the "eager at INFO" half of the bug; swapping the helper is what keeps DEBUG itself safe on streamed responses.

`get_response_content` is intentionally left untouched — `dataset/download_manager.py` still uses it in `Exception(...)` messages for 4xx error bodies, where materialising the body is what you want.

## Tests

New regression coverage:

- `tests/darwin/utils_test.py::TestDescribeResponseForLog` — three cases covering JSON, already-consumed non-JSON, and streamed body (asserts the raw stream is not touched and the placeholder string surfaces content-type/content-length).
- `tests/darwin/client_test.py::TestRawRequestDoesNotDrainStreamedBody` — two cases:
  - At `DEBUG`: calls `_get_raw_from_full_url(..., stream=True)` with a tripwire `raw` object that raises if read, asserts `response._content_consumed is False` after the call.
  - At `INFO`: same tripwire, plus asserts `log.debug` is not called at all.

Without the fix, the DEBUG-level test fails because `response.text` drains the tripwire; with it, both pass. Tests include teardown that restores the global `"darwin"` logger level so no other test suite is affected.

## Test plan

- [x] `poetry run pytest tests/darwin/utils_test.py::TestDescribeResponseForLog tests/darwin/client_test.py::TestRawRequestDoesNotDrainStreamedBody`
- [x] `poetry run pytest tests/darwin/utils_test.py tests/darwin/client_test.py` (86 passed)
- [x] Full suite excluding optional-extras modules (torch/medical): 1043 passed, 29 skipped — identical delta to the same baseline on `master` plus the 5 new tests
- [x] `poetry run ruff check darwin/client.py darwin/utils/utils.py tests/darwin/client_test.py tests/darwin/utils_test.py` — all clean
- [x] `poetry run black --check` on the four touched files — all clean
- [x] `poetry run isort --check-only` on the four touched files — all clean
- [x] End-to-end: real 28.92 GB dataset pull completes in 7 min 04 s, byte-exact, peak 66 MB RSS

## Out of scope

- No change to `darwin/dataset/download_manager.py` (its `get_response_content` calls are for error bodies, which should stay full-text).
- No change to `get_response_content`'s signature or behaviour. The existing `TestGetResponseContent` tests continue to pass unmodified.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to debug logging and add regression tests; behavior of request/response handling is unchanged except preventing accidental stream consumption and avoiding log message computation when DEBUG is off.
> 
> **Overview**
> Prevents `Client` raw HTTP helpers from **consuming streamed (`stream=True`) response bodies** during debug logging.
> 
> Adds `describe_response_for_log()` to safely summarize responses for logs (JSON parsed, already-buffered text returned, otherwise a metadata placeholder), and updates `_get_raw_from_full_url`, `_put_raw`, `_post_raw`, and `_delete` to guard logging with `isEnabledFor(logging.DEBUG)` and use `%s` formatting to avoid eager f-string evaluation.
> 
> Adds regression tests ensuring streamed bodies are not read at DEBUG and that response-body helpers/log emission are skipped below DEBUG.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e94c22844ba5bfdec04c2cefdc81ece3cd5d6f1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->