### PR TITLE
[DAR-7821] Expose `--no-multi-processed` flag on `darwin dataset pull`

### DIFF
--- a/darwin/cli.py
+++ b/darwin/cli.py
@@ -175,6 +175,7 @@ def _run(args: Namespace, parser: ArgumentParser) -> None:
                 args.retry_timeout,
                 args.retry_interval,
                 args.team,
+                multi_processed=not args.no_multi_processed,
             )
         elif args.action == "import":
             f.dataset_import(

--- a/darwin/cli_functions.py
+++ b/darwin/cli_functions.py
@@ -1517,7 +1517,7 @@ def print_new_version_info(client: Optional[Client] = None) -> None:
     if not client or not client.newer_darwin_version:
         return
 
-    (a, b, c) = tuple(client.newer_darwin_version)
+    a, b, c = tuple(client.newer_darwin_version)
 
     console = Console(theme=_console_theme(), stderr=True)
     console.print(

--- a/darwin/cli_functions.py
+++ b/darwin/cli_functions.py
@@ -364,6 +364,7 @@ def pull_dataset(
     retry_timeout: int = 600,
     retry_interval: int = 10,
     team: Optional[str] = None,
+    multi_processed: bool = True,
 ) -> None:
     """
     Downloads a remote dataset (images and annotations) in the datasets directory.
@@ -392,6 +393,9 @@ def pull_dataset(
         If retrying, time to wait between retries of checking if the release is ready for download.
     team: Optional[str]
         Specify the team to use for the operation.
+    multi_processed: bool
+        If True (default), uses multiprocessing to download files in parallel.
+        If False, the dataset is downloaded on a single process.
     """
     identifier: DatasetIdentifier = DatasetIdentifier.parse(dataset_slug)
     if team:
@@ -427,6 +431,7 @@ def pull_dataset(
             retry=retry,
             retry_timeout=retry_timeout,
             retry_interval=retry_interval,
+            multi_processed=multi_processed,
         )
         print_new_version_info(client)
     except NotFound:

--- a/darwin/options.py
+++ b/darwin/options.py
@@ -290,6 +290,13 @@ class Options:
             help="Repeatedly try to download the release if it is still processing.",
         )
         parser_pull.add_argument(
+            "--no-multi-processed",
+            action="store_true",
+            default=False,
+            help="Disables multiprocessing when downloading the dataset. "
+            "By default, downloads run in parallel across multiple processes.",
+        )
+        parser_pull.add_argument(
             "--retry-timeout",
             type=int,
             default=600,

--- a/tests/darwin/cli_functions_test.py
+++ b/tests/darwin/cli_functions_test.py
@@ -665,6 +665,52 @@ class TestPullDataset:
             ]
             assert called_identifier.team_slug == "old-team"
 
+    def test_forwards_multi_processed_default_true_to_remote_dataset_pull(
+        self, remote_dataset: RemoteDataset
+    ):
+        dataset_identifier = "old-team/test-dataset:xyz"
+
+        with (
+            patch("darwin.cli_functions.os.getenv", return_value=None),
+            patch("darwin.cli_functions.Config") as config_cls_mock,
+            patch("darwin.cli_functions.Client.from_config") as from_config_mock,
+        ):
+            config_inst = config_cls_mock.return_value
+            config_inst.get.return_value = "team_specific_key"
+
+            client_mock = from_config_mock.return_value
+            client_mock.get_remote_dataset.return_value = remote_dataset
+            client_mock.newer_darwin_version = None
+
+            with patch.object(remote_dataset, "get_release"):
+                with patch.object(remote_dataset, "pull") as pull_mock:
+                    pull_dataset(dataset_identifier)
+
+            assert pull_mock.call_args.kwargs["multi_processed"] is True
+
+    def test_forwards_multi_processed_false_when_disabled(
+        self, remote_dataset: RemoteDataset
+    ):
+        dataset_identifier = "old-team/test-dataset:xyz"
+
+        with (
+            patch("darwin.cli_functions.os.getenv", return_value=None),
+            patch("darwin.cli_functions.Config") as config_cls_mock,
+            patch("darwin.cli_functions.Client.from_config") as from_config_mock,
+        ):
+            config_inst = config_cls_mock.return_value
+            config_inst.get.return_value = "team_specific_key"
+
+            client_mock = from_config_mock.return_value
+            client_mock.get_remote_dataset.return_value = remote_dataset
+            client_mock.newer_darwin_version = None
+
+            with patch.object(remote_dataset, "get_release"):
+                with patch.object(remote_dataset, "pull") as pull_mock:
+                    pull_dataset(dataset_identifier, multi_processed=False)
+
+            assert pull_mock.call_args.kwargs["multi_processed"] is False
+
 
 class TestPullDatasetTeamAuthSelection:
     def test_prefers_config_over_env_when_team_specified(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Problem
The SDK's `RemoteDataset.pull(...)` already accepts a `multi_processed: bool = True` parameter that toggles whether downloads run in parallel via `multiprocessing.Pool` or single-threaded inside `exhaust_generator(...)`.

Users running `darwin dataset pull` on memory-constrained machines have no way to opt out of multiprocessing from the CLI. With the default parallel downloads, peak memory usage can spike significantly, and users hitting this problem had to drop down to the SDK to pass `multi_processed=False`, which might not be straightforward for non-developers.

# Solution
Surface the existing SDK parameter via a new `--no-multi-processed` flag on the `pull` subcommand. The change is intentionally minimal — it is purely plumbing on top of an SDK code path that already exists and is already exercised:

- `darwin/options.py` — adds a `--no-multi-processed` flag to the `pull` argparse subparser. Defaults to `False` (i.e. multiprocessing remains on), matching today's behavior.
- `darwin/cli.py` — forwards `not args.no_multi_processed` as `multi_processed=...` into `pull_dataset(...)`.
- `darwin/cli_functions.py` — `pull_dataset(...)` now accepts a `multi_processed: bool = True` keyword and passes it through to `RemoteDataset.pull(...)`.
- `tests/darwin/cli_functions_test.py` — two new unit tests assert the value is forwarded correctly in both the default and `--no-multi-processed` cases.

Default behavior is preserved (`multi_processed=True`), so existing CLI invocations and existing tests are unaffected.

Verified locally:
- `darwin dataset pull --help` lists the new flag.
- `pytest tests/darwin/cli_functions_test.py` — 27 passed (25 previously existing + 2 new).
- The 9 failures observed when running the full `tests/darwin` suite reproduce on `master` as well; they are pre-existing environment/optional-dependency issues (`nibabel`, `scipy`, `medical` extras) and are unrelated to this change.

# Changelog
- Added `--no-multi-processed` flag to `darwin dataset pull` to disable parallel multiprocessing when downloading dataset files (mirrors the existing SDK `multi_processed` parameter; default behavior unchanged).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b16f60ff-f121-426b-8ac2-0782842440d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b16f60ff-f121-426b-8ac2-0782842440d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

