### PR TITLE
Support importing annotations to an annotation group

### DIFF
--- a/darwin/datatypes.py
+++ b/darwin/datatypes.py
@@ -248,6 +248,9 @@ class Annotation:
     # Properties of this annotation.
     properties: Optional[list[SelectedProperty]] = None
 
+    # The annotation group ID
+    annotation_group_id: Optional[str] = None
+
     def get_sub(self, annotation_type: str) -> Optional[SubAnnotation]:
         """
         Returns the first SubAnnotation that matches the given type.
@@ -304,6 +307,9 @@ class VideoAnnotation:
 
     # Properties of this annotation.
     properties: Optional[list[SelectedProperty]] = None
+
+    # The annotation group ID
+    annotation_group_id: Optional[str] = None
 
     #: A list of ``HiddenArea``\'s.
     hidden_areas: List[HiddenArea] = field(default_factory=list)

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -1913,9 +1913,17 @@ def _import_annotations(
     errors: dt.ErrorList = []
     success: dt.Success = dt.Success.SUCCESS
 
-    raster_layer: Optional[dt.Annotation] = None
-    raster_layer_dense_rle_ids: Optional[Set[str]] = None
-    raster_layer_dense_rle_ids_frames: Optional[Dict[int, Set[str]]] = None
+    # Build a map of raster_layers by annotation_group_id to support multiple raster_layers
+    raster_layers_by_group: Dict[Optional[str], dt.Annotation] = {}
+    raster_layer_dense_rle_ids_by_group: Dict[Optional[str], Set[str]] = {}
+    raster_layer_dense_rle_ids_frames_by_group: Dict[Optional[str], Dict[int, Set[str]]] = {}
+
+    # First pass: collect all raster_layers
+    for annotation in annotations:
+        if annotation.annotation_class.annotation_type == "raster_layer":
+            group_id = annotation.annotation_group_id
+            raster_layers_by_group[group_id] = annotation
+
     serialized_annotations = []
     annotation_class_ids_map: AnnotationClassIdsMap = {}
     for annotation in annotations:
@@ -1951,16 +1959,15 @@ def _import_annotations(
 
         # check if the mask is empty (i.e. masks that do not have a corresponding raster layer) if so, skip import of the mask
         if annotation_type == "mask":
-            if raster_layer is None:
-                raster_layer = next(
-                    (
-                        a
-                        for a in annotations
-                        if a.annotation_class.annotation_type == "raster_layer"
-                    ),
-                    None,
-                )
+            # Find the raster_layer that matches this mask's annotation_group_id
+            group_id = annotation.annotation_group_id
+            raster_layer = raster_layers_by_group.get(group_id)
+
             if raster_layer:
+                # Get or initialize the dense_rle_ids for this specific raster_layer group
+                raster_layer_dense_rle_ids = raster_layer_dense_rle_ids_by_group.get(group_id)
+                raster_layer_dense_rle_ids_frames = raster_layer_dense_rle_ids_frames_by_group.get(group_id)
+
                 (
                     raster_layer_dense_rle_ids,
                     raster_layer_dense_rle_ids_frames,
@@ -1970,6 +1977,10 @@ def _import_annotations(
                     raster_layer_dense_rle_ids,
                     raster_layer_dense_rle_ids_frames,
                 )
+
+                # Store back the updated dense_rle_ids for this group
+                raster_layer_dense_rle_ids_by_group[group_id] = raster_layer_dense_rle_ids
+                raster_layer_dense_rle_ids_frames_by_group[group_id] = raster_layer_dense_rle_ids_frames
 
         actors: List[dt.DictFreeForm] = []
         actors.extend(_handle_annotators(import_annotators, annotation=annotation))
@@ -1988,6 +1999,9 @@ def _import_annotations(
         }
 
         serial_obj["id"] = annotation.id
+
+        if annotation.annotation_group_id is not None:
+            serial_obj["annotation_group_id"] = annotation.annotation_group_id
 
         if actors:
             serial_obj["actors"] = actors  # type: ignore

--- a/darwin/utils/utils.py
+++ b/darwin/utils/utils.py
@@ -914,6 +914,8 @@ def _parse_darwin_annotation(
 
     if "id" in annotation:
         main_annotation.id = annotation["id"]
+    if "annotation_group_id" in annotation:
+        main_annotation.annotation_group_id = annotation["annotation_group_id"]
     _apply_sub_annotations(annotation, main_annotation)
 
     return main_annotation
@@ -1085,6 +1087,9 @@ def _parse_darwin_video_annotation(annotation: dict) -> Optional[dt.VideoAnnotat
     if "id" in annotation:
         main_annotation.id = annotation["id"]
 
+    if "annotation_group_id" in annotation:
+        main_annotation.annotation_group_id = annotation["annotation_group_id"]
+
     if "annotators" in annotation:
         main_annotation.annotators = _parse_annotators(annotation["annotators"])
 
@@ -1206,6 +1211,7 @@ def _parse_darwin_raster_annotation(annotation: dict) -> Optional[dt.Annotation]
         },
         slot_names=slot_names or [],
         id=id,
+        annotation_group_id=annotation.get("annotation_group_id"),
     )
     _apply_sub_annotations(annotation, new_annotation)
 
@@ -1229,6 +1235,7 @@ def _parse_darwin_mask_annotation(annotation: dict) -> Optional[dt.Annotation]:
         mask,
         slot_names=slot_names or [],
         id=id,
+        annotation_group_id=annotation.get("annotation_group_id"),
     )
     _apply_sub_annotations(annotation, new_annotation)
 


### PR DESCRIPTION
# Problem
(describe the problem here)

# Solution
(Overview of the solution logic)

# Changelog
(Will appear in release docs)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes annotation import payloads and mask↔raster-layer matching logic, which could affect segmentation imports or cause annotations to be associated with the wrong raster layer/group if group IDs are missing or duplicated.
> 
> **Overview**
> Adds end-to-end support for `annotation_group_id` on annotations and video annotations, including parsing it from Darwin JSON and serializing it into the import payload.
> 
> Updates the importer’s mask handling to support **multiple** `raster_layer` annotations by grouping them by `annotation_group_id`, so empty-mask checks and raster-layer lookups are performed within the correct group instead of assuming a single raster layer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed81c669b24cb661206dac54824fac133749262a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->