### PR TITLE
[DAR-7810] (1/3) Nest properties against existing team parent

### DIFF
--- a/darwin/datatypes.py
+++ b/darwin/datatypes.py
@@ -33,6 +33,7 @@ from darwin.future.data_objects.properties import (
     PropertyGranularity,
     PropertyType,
     SelectedProperty,
+    TriggerCondition,
 )
 from darwin.path_utils import construct_full_path, is_properties_enabled, parse_metadata
 
@@ -492,6 +493,12 @@ class Property:
     # Granularity of the property
     granularity: PropertyGranularity = PropertyGranularity("section")
 
+    # Name of the parent property as declared in ``.v7/metadata.json``.
+    parent_name: Optional[str] = None
+
+    # Name-based trigger condition (parent value names).
+    trigger_condition: Optional[TriggerCondition] = None
+
 
 @dataclass
 class PropertyClass:
@@ -501,6 +508,47 @@ class PropertyClass:
     color: Optional[str] = None
     sub_types: Optional[list[str]] = None
     properties: Optional[list[Property]] = None
+
+
+def _validate_metadata_nesting(
+    name: str, parent_name: Any, trigger_condition: Any
+) -> None:
+    """
+    Enforce the ``parent_name`` ↔ ``trigger_condition`` invariant for a
+    ``.v7/metadata.json`` property: the two SDK-local nesting fields must be
+    set together or both omitted.
+    """
+    if (parent_name is None) != (trigger_condition is None):
+        raise ValueError(
+            f"Property '{name}' in metadata.json has inconsistent nesting "
+            "metadata: 'parent_name' and 'trigger_condition' must both be "
+            "present or both omitted."
+        )
+
+
+def _property_from_metadata_dict(p: dict[str, Any]) -> Property:
+    """
+    Build a ``Property`` from a ``.v7/metadata.json`` entry. Raises
+    ``ValueError`` when ``parent_name`` and ``trigger_condition`` are not
+    both set or both omitted.
+    """
+    parent_name = p.get("parent_name")
+    raw_trigger = p.get("trigger_condition")
+    _validate_metadata_nesting(p.get("name", ""), parent_name, raw_trigger)
+    return Property(
+        name=p["name"],
+        type=p["type"],
+        required=p["required"],
+        property_values=p["property_values"],
+        description=p.get("description"),
+        granularity=PropertyGranularity(p.get("granularity", "section")),
+        parent_name=parent_name,
+        trigger_condition=(
+            TriggerCondition.model_validate(raw_trigger)
+            if raw_trigger is not None
+            else None
+        ),
+    )
 
 
 def parse_property_classes(metadata: dict[str, Any]) -> list[PropertyClass]:
@@ -525,15 +573,7 @@ def parse_property_classes(metadata: dict[str, Any]) -> list[PropertyClass]:
             "properties" in metadata_cls
         ), "Metadata class does not contain properties"
         properties = [
-            Property(
-                name=p["name"],
-                type=p["type"],
-                required=p["required"],
-                property_values=p["property_values"],
-                description=p.get("description"),
-                granularity=PropertyGranularity(p.get("granularity", "section")),
-            )
-            for p in metadata_cls["properties"]
+            _property_from_metadata_dict(p) for p in metadata_cls["properties"]
         ]
         classes.append(
             PropertyClass(

--- a/darwin/datatypes.py
+++ b/darwin/datatypes.py
@@ -499,6 +499,31 @@ class Property:
     # Name-based trigger condition (parent value names).
     trigger_condition: Optional[TriggerCondition] = None
 
+    @classmethod
+    def from_metadata_dict(cls, p: dict[str, Any]) -> "Property":
+        """
+        Build a ``Property`` from a ``.v7/metadata.json`` entry. Raises
+        ``ValueError`` when ``parent_name`` and ``trigger_condition`` are
+        not both set or both omitted.
+        """
+        parent_name = p.get("parent_name")
+        raw_trigger = p.get("trigger_condition")
+        _validate_property_metadata_nesting(p.get("name", ""), parent_name, raw_trigger)
+        return cls(
+            name=p["name"],
+            type=p["type"],
+            required=p["required"],
+            property_values=p["property_values"],
+            description=p.get("description"),
+            granularity=PropertyGranularity(p.get("granularity", "section")),
+            parent_name=parent_name,
+            trigger_condition=(
+                TriggerCondition.model_validate(raw_trigger)
+                if raw_trigger is not None
+                else None
+            ),
+        )
+
 
 @dataclass
 class PropertyClass:
@@ -510,7 +535,7 @@ class PropertyClass:
     properties: Optional[list[Property]] = None
 
 
-def _validate_metadata_nesting(
+def _validate_property_metadata_nesting(
     name: str, parent_name: Any, trigger_condition: Any
 ) -> None:
     """
@@ -524,31 +549,6 @@ def _validate_metadata_nesting(
             "metadata: 'parent_name' and 'trigger_condition' must both be "
             "present or both omitted."
         )
-
-
-def _property_from_metadata_dict(p: dict[str, Any]) -> Property:
-    """
-    Build a ``Property`` from a ``.v7/metadata.json`` entry. Raises
-    ``ValueError`` when ``parent_name`` and ``trigger_condition`` are not
-    both set or both omitted.
-    """
-    parent_name = p.get("parent_name")
-    raw_trigger = p.get("trigger_condition")
-    _validate_metadata_nesting(p.get("name", ""), parent_name, raw_trigger)
-    return Property(
-        name=p["name"],
-        type=p["type"],
-        required=p["required"],
-        property_values=p["property_values"],
-        description=p.get("description"),
-        granularity=PropertyGranularity(p.get("granularity", "section")),
-        parent_name=parent_name,
-        trigger_condition=(
-            TriggerCondition.model_validate(raw_trigger)
-            if raw_trigger is not None
-            else None
-        ),
-    )
 
 
 def parse_property_classes(metadata: dict[str, Any]) -> list[PropertyClass]:
@@ -573,7 +573,7 @@ def parse_property_classes(metadata: dict[str, Any]) -> list[PropertyClass]:
             "properties" in metadata_cls
         ), "Metadata class does not contain properties"
         properties = [
-            _property_from_metadata_dict(p) for p in metadata_cls["properties"]
+            Property.from_metadata_dict(p) for p in metadata_cls["properties"]
         ]
         classes.append(
             PropertyClass(

--- a/darwin/datatypes.py
+++ b/darwin/datatypes.py
@@ -508,7 +508,7 @@ class Property:
         """
         parent_name = p.get("parent_name")
         raw_trigger = p.get("trigger_condition")
-        _validate_property_metadata_nesting(p.get("name", ""), parent_name, raw_trigger)
+        _validate_property_metadata_nesting(parent_name, raw_trigger)
         return cls(
             name=p["name"],
             type=p["type"],
@@ -536,7 +536,7 @@ class PropertyClass:
 
 
 def _validate_property_metadata_nesting(
-    name: str, parent_name: Any, trigger_condition: Any
+    parent_name: Any, trigger_condition: Any
 ) -> None:
     """
     Enforce the ``parent_name`` ↔ ``trigger_condition`` invariant for a
@@ -545,9 +545,9 @@ def _validate_property_metadata_nesting(
     """
     if (parent_name is None) != (trigger_condition is None):
         raise ValueError(
-            f"Property '{name}' in metadata.json has inconsistent nesting "
-            "metadata: 'parent_name' and 'trigger_condition' must both be "
-            "present or both omitted."
+            "metadata.json property has inconsistent nesting metadata: "
+            "'parent_name' and 'trigger_condition' must both be present or "
+            "both omitted."
         )
 
 

--- a/darwin/datatypes.py
+++ b/darwin/datatypes.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel
 try:
     from numpy.typing import NDArray
 except ImportError:
-    NDArray = Any  # type:ignore
+    NDArray = Any  # type: ignore
 
 if TYPE_CHECKING:
     from darwin.client import Client
@@ -43,7 +43,7 @@ NumberLike = Union[
     int, float
 ]  # Used for functions that can take either an int or a float
 # Used for functions that _genuinely_ don't know what type they're dealing with, such as those that test if something is of a certain type.
-UnknownType = Any  # type:ignore
+UnknownType = Any  # type: ignore
 
 # Specific types
 

--- a/darwin/future/data_objects/properties.py
+++ b/darwin/future/data_objects/properties.py
@@ -167,7 +167,7 @@ class FullProperty(DefaultDarwin):
             include_fields["dataset_ids"] = True
 
         payload = self.model_dump(mode="json", include=include_fields)
-        if self.parent_property_id is not None and self.trigger_condition is not None:
+        if all(nesting_set):
             payload["parent_property_id"] = self.parent_property_id
             payload["trigger_condition"] = self.trigger_condition.to_api_payload()
         return payload

--- a/darwin/future/data_objects/properties.py
+++ b/darwin/future/data_objects/properties.py
@@ -57,7 +57,7 @@ class TriggerCondition(DefaultDarwin):
                 raise ValueError(
                     "TriggerCondition.to_api_payload requires non-empty "
                     "property_value_ids for 'value_match'. Resolve "
-                    "'values' (names) to UUIDs first via _resolve_parent_for_create."
+                    "'values' (names) to UUIDs first via _resolve_parent_property_for_create."
                 )
             payload["property_value_ids"] = list(self.property_value_ids)
         return payload
@@ -150,12 +150,6 @@ class FullProperty(DefaultDarwin):
             raise ValueError(
                 "parent_property_id and trigger_condition must both be set or "
                 "both be None. Resolve parent_name to a parent_property_id first."
-            )
-        if self.parent_name is not None and self.parent_property_id is None:
-            raise ValueError(
-                "parent_name set without parent_property_id; the importer "
-                "resolves parent_name via _resolve_parent_for_create before "
-                "calling to_create_endpoint."
             )
 
         include_fields: Dict[str, Any] = {

--- a/darwin/future/data_objects/properties.py
+++ b/darwin/future/data_objects/properties.py
@@ -4,9 +4,9 @@ import json
 import os
 from enum import Enum
 from pathlib import Path
-from typing import List, Literal, Optional, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
-from pydantic import field_validator
+from pydantic import field_validator, model_validator
 
 from darwin.future.data_objects.pydantic_base import DefaultDarwin
 
@@ -18,6 +18,49 @@ PropertyType = Literal[
     "instance_id",
     "directional_vector",
 ]
+
+
+class TriggerCondition(DefaultDarwin):
+    type: Literal["value_match", "any_value"]
+    property_value_ids: Optional[List[str]] = None
+    values: Optional[List[str]] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _validate_shape(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        trigger_type = data.get("type")
+        values = data.get("values")
+        property_value_ids = data.get("property_value_ids")
+        if trigger_type == "any_value":
+            if values:
+                raise ValueError(
+                    "trigger_condition.values must be empty/None for 'any_value'"
+                )
+            if property_value_ids:
+                raise ValueError(
+                    "trigger_condition.property_value_ids must be empty/None for 'any_value'"
+                )
+        elif trigger_type == "value_match":
+            if not values and not property_value_ids:
+                raise ValueError(
+                    "trigger_condition must set either 'values' (names) or "
+                    "'property_value_ids' (UUIDs) for 'value_match'"
+                )
+        return data
+
+    def to_api_payload(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"type": self.type}
+        if self.type == "value_match":
+            if not self.property_value_ids:
+                raise ValueError(
+                    "TriggerCondition.to_api_payload requires non-empty "
+                    "property_value_ids for 'value_match'. Resolve "
+                    "'values' (names) to UUIDs first via _resolve_parent_for_create."
+                )
+            payload["property_value_ids"] = list(self.property_value_ids)
+        return payload
 
 
 class PropertyGranularity(str, Enum):
@@ -85,11 +128,37 @@ class FullProperty(DefaultDarwin):
     dataset_ids: Optional[List[int]] = None
     options: Optional[List[PropertyValue]] = None
     granularity: PropertyGranularity = PropertyGranularity("section")
+    parent_name: Optional[str] = None
+    parent_property_id: Optional[str] = None
+    trigger_condition: Optional[TriggerCondition] = None
 
     def to_create_endpoint(
         self,
     ) -> dict:
-        include_fields = {
+        if (
+            self.granularity != PropertyGranularity.item
+            and self.annotation_class_id is None
+        ):
+            raise ValueError("annotation_class_id must be set")
+
+        # Nesting fields are coherent: all three set, or none set.
+        nesting_set = (
+            self.parent_property_id is not None,
+            self.trigger_condition is not None,
+        )
+        if any(nesting_set) and not all(nesting_set):
+            raise ValueError(
+                "parent_property_id and trigger_condition must both be set or "
+                "both be None. Resolve parent_name to a parent_property_id first."
+            )
+        if self.parent_name is not None and self.parent_property_id is None:
+            raise ValueError(
+                "parent_name set without parent_property_id; the importer "
+                "resolves parent_name via _resolve_parent_for_create before "
+                "calling to_create_endpoint."
+            )
+
+        include_fields: Dict[str, Any] = {
             "name": True,
             "type": True,
             "required": True,
@@ -99,12 +168,15 @@ class FullProperty(DefaultDarwin):
         if self.type != "text":
             include_fields["property_values"] = {"__all__": {"value", "color", "type"}}
         if self.granularity != PropertyGranularity.item:
-            if self.annotation_class_id is None:
-                raise ValueError("annotation_class_id must be set")
             include_fields["annotation_class_id"] = True
         if self.dataset_ids is not None:
             include_fields["dataset_ids"] = True
-        return self.model_dump(mode="json", include=include_fields)
+
+        payload = self.model_dump(mode="json", include=include_fields)
+        if self.parent_property_id is not None and self.trigger_condition is not None:
+            payload["parent_property_id"] = self.parent_property_id
+            payload["trigger_condition"] = self.trigger_condition.to_api_payload()
+        return payload
 
     def to_update_endpoint(self) -> Tuple[str, dict]:
         if self.id is None:
@@ -113,6 +185,10 @@ class FullProperty(DefaultDarwin):
         updated_base = self.to_create_endpoint()
         updated_base.pop("annotation_class_id", None)  # Can't update this field
         del updated_base["granularity"]  # Can't update this field
+        if "parent_property_id" in updated_base:
+            del updated_base["parent_property_id"]
+        if "trigger_condition" in updated_base:
+            del updated_base["trigger_condition"]
         return self.id, updated_base
 
 
@@ -172,3 +248,10 @@ class SelectedProperty(DefaultDarwin):
     name: str
     type: Optional[str] = None
     value: Optional[str] = None
+
+
+PropertyKey = Tuple[str, Optional[int]]
+
+
+def property_key(prop: "FullProperty") -> PropertyKey:
+    return (prop.name, prop.annotation_class_id)

--- a/darwin/future/data_objects/properties.py
+++ b/darwin/future/data_objects/properties.py
@@ -143,13 +143,16 @@ class FullProperty(DefaultDarwin):
 
         # Nesting fields are coherent: all three set, or none set.
         nesting_set = (
+            self.parent_name is not None,
             self.parent_property_id is not None,
             self.trigger_condition is not None,
         )
         if any(nesting_set) and not all(nesting_set):
             raise ValueError(
-                "parent_property_id and trigger_condition must both be set or "
-                "both be None. Resolve parent_name to a parent_property_id first."
+                "parent_name, parent_property_id and trigger_condition must "
+                "all be set or all be None. Resolve parent_name to a "
+                "parent_property_id (and trigger_condition.values to "
+                "property_value_ids) before serialising."
             )
 
         include_fields: Dict[str, Any] = {

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -39,6 +39,7 @@ from darwin.datatypes import (
 from darwin.future.data_objects.properties import (
     FullProperty,
     PropertyGranularity,
+    PropertyKey,
     PropertyType,
     PropertyValue,
     SelectedProperty,
@@ -568,10 +569,12 @@ def _resolve_parent_property_for_create(
             f"class-level property '{full_property.name}' without an "
             "annotation_class_id"
         )
+    parent_key: PropertyKey = (
+        full_property.parent_name,
+        full_property.annotation_class_id,
+    )
     parent_prop: Optional[FullProperty] = (
-        team_property_lookups.annotation_properties.get(
-            (full_property.parent_name, full_property.annotation_class_id)
-        )
+        team_property_lookups.annotation_properties.get(parent_key)
     )
 
     if parent_prop is None or parent_prop.id is None:

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -545,7 +545,7 @@ def _property_value_from_metadata(m_value: Dict[str, Any]) -> PropertyValue:
     )
 
 
-def _resolve_parent_for_create(
+def _resolve_parent_property_for_create(
     full_property: FullProperty,
     team_property_lookups: "TeamPropertyLookups",
 ) -> FullProperty:
@@ -964,7 +964,7 @@ def _import_properties(
                 console.print(
                     f"- Creating property '{full_property.name}' of type {full_property.type}",
                 )
-            payload_property = _resolve_parent_for_create(
+            payload_property = _resolve_parent_property_for_create(
                 full_property, team_property_lookups
             )
             prop = client.create_property(

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -42,6 +42,7 @@ from darwin.future.data_objects.properties import (
     PropertyType,
     PropertyValue,
     SelectedProperty,
+    TriggerCondition,
 )
 from darwin.item import DatasetItem
 from darwin.path_utils import is_properties_enabled, parse_metadata
@@ -536,6 +537,109 @@ def _build_metadata_lookups(
     )
 
 
+def _property_value_from_metadata(m_value: Dict[str, Any]) -> PropertyValue:
+    """Build a ``PropertyValue`` from a ``.v7/metadata.json`` value entry."""
+    return PropertyValue(
+        value=m_value.get("value"),
+        color=m_value.get("color") or "auto",
+    )
+
+
+def _resolve_parent_for_create(
+    full_property: FullProperty,
+    team_property_lookups: "TeamPropertyLookups",
+) -> FullProperty:
+    """
+    Return a copy of ``full_property`` with ``parent_property_id`` and
+    ``trigger_condition.property_value_ids`` populated from the SDK-native
+    ``parent_name`` and ``trigger_condition.values`` (parent value names).
+
+    Names are resolved against ``team_property_lookups``, which must
+    already include the parent (created previously on the team). Roots
+    (``parent_name is None``) are returned unchanged; unresolved names
+    raise ``ValueError``.
+    """
+    if full_property.parent_name is None:
+        return full_property
+
+    if full_property.annotation_class_id is None:
+        raise ValueError(
+            f"Cannot resolve parent '{full_property.parent_name}' for "
+            f"class-level property '{full_property.name}' without an "
+            "annotation_class_id"
+        )
+    parent_prop: Optional[FullProperty] = (
+        team_property_lookups.annotation_properties.get(
+            (full_property.parent_name, full_property.annotation_class_id)
+        )
+    )
+
+    if parent_prop is None or parent_prop.id is None:
+        raise ValueError(
+            f"Cannot resolve parent '{full_property.parent_name}' for nested "
+            f"property '{full_property.name}': parent has not been created "
+            "on the team yet. Check that the parent is listed in "
+            ".v7/metadata.json and shares the same annotation class."
+        )
+    if parent_prop.granularity != full_property.granularity:
+        raise ValueError(
+            f"Cannot resolve parent '{full_property.parent_name}' for nested "
+            f"property '{full_property.name}': parent has granularity "
+            f"'{parent_prop.granularity.value}' but child is "
+            f"'{full_property.granularity.value}'. A nested child must "
+            "share its parent's granularity."
+        )
+
+    trigger = full_property.trigger_condition
+    resolved_trigger: Optional[TriggerCondition] = None
+    if trigger is not None:
+        if trigger.type == "any_value":
+            resolved_trigger = TriggerCondition(type="any_value")
+        else:
+            if not trigger.values:
+                raise ValueError(
+                    f"trigger_condition for '{full_property.name}' must set "
+                    "'values' (parent value names) for 'value_match'. "
+                    "darwin-py identifies property values by name; "
+                    "'property_value_ids' is only populated from API responses."
+                )
+            trigger_values = trigger.values
+            if len(set(trigger_values)) != len(trigger_values):
+                duplicates = sorted(
+                    {v for v in trigger_values if trigger_values.count(v) > 1}
+                )
+                raise ValueError(
+                    f"trigger_condition for '{full_property.name}' has "
+                    f"duplicate values: {duplicates}. Each parent value "
+                    "should appear at most once."
+                )
+            value_id_by_name = {
+                pv.value: pv.id
+                for pv in (parent_prop.property_values or [])
+                if pv.id is not None and pv.value is not None
+            }
+            resolved_ids: List[str] = []
+            for name in trigger_values:
+                value_id = value_id_by_name.get(name)
+                if value_id is None:
+                    raise ValueError(
+                        f"trigger_condition for '{full_property.name}' "
+                        f"references unknown parent value '{name}' on "
+                        f"'{full_property.parent_name}'. Available values: "
+                        f"{sorted(value_id_by_name)}"
+                    )
+                resolved_ids.append(value_id)
+            resolved_trigger = TriggerCondition(
+                type="value_match",
+                property_value_ids=resolved_ids,
+            )
+
+    remapped = full_property.model_copy()
+    remapped.parent_property_id = parent_prop.id
+    remapped.trigger_condition = resolved_trigger
+    return remapped
+
+
 def _import_properties(
     metadata_path: Union[Path, bool],
     item_properties: List[Dict[str, str]],
@@ -703,12 +807,8 @@ def _import_properties(
                                     if prop_val.value == a_prop.value:
                                         break
                                 else:
-                                    # update property_values with new value
                                     full_property.property_values.append(
-                                        PropertyValue(
-                                            value=m_prop_option.get("value"),  # type: ignore
-                                            color=m_prop_option.get("color"),  # type: ignore
-                                        )
+                                        _property_value_from_metadata(m_prop_option)
                                     )
                                 break
                         break
@@ -721,10 +821,7 @@ def _import_properties(
                     for m_prop_option in m_prop_options:
                         if m_prop_option.get("value") == a_prop.value:
                             property_values.append(
-                                PropertyValue(
-                                    value=m_prop_option.get("value"),  # type: ignore
-                                    color=m_prop_option.get("color"),  # type: ignore
-                                )
+                                _property_value_from_metadata(m_prop_option)
                             )
                             break
                     # if it doesn't exist, create it
@@ -751,6 +848,8 @@ def _import_properties(
                             annotation_class_id=int(annotation_class_id),
                             property_values=property_values,
                             granularity=PropertyGranularity(m_prop.granularity),
+                            parent_name=m_prop.parent_name,
+                            trigger_condition=m_prop.trigger_condition,
                         )
                     # Don't attempt the same propery creation multiple times
                     if (
@@ -865,8 +964,11 @@ def _import_properties(
                 console.print(
                     f"- Creating property '{full_property.name}' of type {full_property.type}",
                 )
+            payload_property = _resolve_parent_for_create(
+                full_property, team_property_lookups
+            )
             prop = client.create_property(
-                team_slug=full_property.slug, params=full_property
+                team_slug=payload_property.slug, params=payload_property
             )
             created_properties.append(prop)
 
@@ -949,13 +1051,6 @@ def _import_properties(
 
         # if there are extra values in metadata, create a new FullProperty with the extra values
         if extra_values:
-            extra_property_values = [
-                PropertyValue(
-                    value=m_prop_values[extra_value].get("value"),  # type: ignore
-                    color=m_prop_values[extra_value].get("color"),  # type: ignore
-                )
-                for extra_value in extra_values
-            ]
             full_property = FullProperty(
                 id=t_prop.id,
                 name=t_prop.name,
@@ -964,7 +1059,10 @@ def _import_properties(
                 description=t_prop.description,
                 slug=team_slug,
                 annotation_class_id=t_prop.annotation_class_id,
-                property_values=extra_property_values,
+                property_values=[
+                    _property_value_from_metadata(m_prop_values[extra_value])
+                    for extra_value in extra_values
+                ],
                 granularity=PropertyGranularity(t_prop.granularity.value),
             )
             console.print(
@@ -1072,9 +1170,10 @@ def _create_update_item_properties(
     create_properties = []
     update_properties = []
     for item_prop_name, m_prop in item_properties.items():
-        m_prop_values = [
-            prop_val["value"] for prop_val in m_prop.get("property_values", [])
-        ]
+        m_prop_value_dicts: List[Dict[str, Any]] = (
+            m_prop.get("property_values", []) or []
+        )
+        m_prop_values = [prop_val["value"] for prop_val in m_prop_value_dicts]
 
         # If the property exists in the team, check that all values are present
         if item_prop_name in item_properties_lookup:
@@ -1112,9 +1211,11 @@ def _create_update_item_properties(
                     ]
                     if prop.property_values is None:
                         prop.property_values = []
-                    for val in m_prop_values:
-                        if val.value not in current_prop_values:
-                            prop.property_values.append(PropertyValue(value=val))
+                    for val_dict in m_prop_value_dicts:
+                        if val_dict.get("value") not in current_prop_values:
+                            prop.property_values.append(
+                                _property_value_from_metadata(val_dict)
+                            )
                     break
             else:
                 full_property = FullProperty(
@@ -1126,7 +1227,10 @@ def _create_update_item_properties(
                     ),
                     slug=team_slug,
                     annotation_class_id=None,
-                    property_values=[PropertyValue(value=val) for val in m_prop_values],
+                    property_values=[
+                        _property_value_from_metadata(val_dict)
+                        for val_dict in m_prop_value_dicts
+                    ],
                     granularity=PropertyGranularity.item,
                 )
                 create_properties.append(full_property)

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -596,6 +596,13 @@ def _resolve_parent_property_for_create(
     trigger = full_property.trigger_condition
     resolved_trigger: Optional[TriggerCondition] = None
     if trigger is not None:
+        if parent_prop.type == "text" and trigger.type != "any_value":
+            raise ValueError(
+                f"trigger_condition.type for nested property "
+                f"'{full_property.name}' must be 'any_value' when its parent "
+                f"'{full_property.parent_name}' is a text property; got "
+                f"'{trigger.type}'."
+            )
         if trigger.type == "any_value":
             resolved_trigger = TriggerCondition(type="any_value")
         else:

--- a/tests/darwin/future/data_objects/test_nested_properties.py
+++ b/tests/darwin/future/data_objects/test_nested_properties.py
@@ -1,7 +1,7 @@
 """Unit tests for the nested-property SDK foundation: ``TriggerCondition``,
 ``FullProperty`` create/update endpoints with nesting fields,
 ``property_key`` helper, ``_property_value_from_metadata`` helper, the
-class-level branch of ``_resolve_parent_for_create``, and metadata parsing
+class-level branch of ``_resolve_parent_property_for_create``, and metadata parsing
 of nested fields.
 """
 
@@ -26,7 +26,7 @@ from darwin.future.data_objects.properties import (
 from darwin.importer.importer import (
     _import_properties,
     _property_value_from_metadata,
-    _resolve_parent_for_create,
+    _resolve_parent_property_for_create,
 )
 
 
@@ -126,7 +126,7 @@ class TestTriggerCondition:
     def test_to_api_payload_strips_sdk_local_values(self) -> None:
         # The name-based ``values`` field is an SDK-local convenience. The
         # wire shape never includes it — callers must resolve names to
-        # UUIDs (via ``_resolve_parent_for_create``) before serialising.
+        # UUIDs (via ``_resolve_parent_property_for_create``) before serialising.
         trigger = TriggerCondition(
             type="value_match",
             values=["Fracture"],
@@ -267,17 +267,6 @@ class TestFullPropertyEndpoints:
         assert body["trigger_condition"] == {"type": "any_value"}
         assert "property_value_ids" not in body["trigger_condition"]
 
-    def test_create_endpoint_rejects_parent_name_without_resolved_uuid(self) -> None:
-        # ``parent_name`` is the SDK-local mirror of ``parent_property_id``.
-        # Sending it on its own would produce a flat-property payload while
-        # the caller thinks they're creating a nested child — catch that
-        # before it reaches the BE and produces a degraded property.
-        prop = _make_property(name="orphan", parent_name="Parent")
-        with pytest.raises(
-            ValueError, match="parent_name set without parent_property_id"
-        ):
-            prop.to_create_endpoint()
-
     def test_create_endpoint_rejects_unresolved_parent(self) -> None:
         # ``parent_name`` without ``parent_property_id`` means the importer
         # hasn't resolved the name against the server yet — sending it as-is
@@ -327,7 +316,9 @@ class TestResolveParentForCreate:
 
     def test_returns_as_is_for_top_level(self) -> None:
         prop = _make_property(name="top")
-        resolved = _resolve_parent_for_create(prop, _fake_team_property_lookups())
+        resolved = _resolve_parent_property_for_create(
+            prop, _fake_team_property_lookups()
+        )
         assert resolved is prop
 
     def test_resolves_class_level_parent_name_and_trigger_values(self) -> None:
@@ -353,7 +344,7 @@ class TestResolveParentForCreate:
                 type="value_match", values=["Contamination"]
             ),
         )
-        resolved = _resolve_parent_for_create(child, lookups)
+        resolved = _resolve_parent_property_for_create(child, lookups)
         assert resolved.parent_property_id == "new-parent-id"
         assert resolved.trigger_condition is not None
         assert resolved.trigger_condition.property_value_ids == ["new-cont-id"]
@@ -378,7 +369,7 @@ class TestResolveParentForCreate:
             parent_name="Notes",
             trigger_condition=TriggerCondition(type="any_value"),
         )
-        resolved = _resolve_parent_for_create(child, lookups)
+        resolved = _resolve_parent_property_for_create(child, lookups)
         assert resolved.parent_property_id == "notes-id"
         assert resolved.trigger_condition is not None
         assert resolved.trigger_condition.type == "any_value"
@@ -391,7 +382,7 @@ class TestResolveParentForCreate:
             trigger_condition=TriggerCondition(type="any_value"),
         )
         with pytest.raises(ValueError, match="Cannot resolve parent"):
-            _resolve_parent_for_create(child, _fake_team_property_lookups())
+            _resolve_parent_property_for_create(child, _fake_team_property_lookups())
 
     def test_unknown_trigger_value_raises(self) -> None:
         parent_on_server = FullProperty(
@@ -414,7 +405,7 @@ class TestResolveParentForCreate:
             ),
         )
         with pytest.raises(ValueError, match="unknown parent value"):
-            _resolve_parent_for_create(child, lookups)
+            _resolve_parent_property_for_create(child, lookups)
 
     def test_value_match_with_duplicate_values_raises(self) -> None:
         # Duplicates in ``trigger.values`` are a data error: each parent
@@ -443,7 +434,7 @@ class TestResolveParentForCreate:
             ),
         )
         with pytest.raises(ValueError, match=r"duplicate values: \['A'\]"):
-            _resolve_parent_for_create(child, lookups)
+            _resolve_parent_property_for_create(child, lookups)
 
     def test_value_match_without_values_raises_clear_error(self) -> None:
         # Contract: darwin-py identifies parent values by name, so
@@ -473,7 +464,7 @@ class TestResolveParentForCreate:
         with pytest.raises(
             ValueError, match="must set 'values' \\(parent value names\\)"
         ):
-            _resolve_parent_for_create(child, lookups)
+            _resolve_parent_property_for_create(child, lookups)
 
     def test_rejects_cross_granularity_parent(self) -> None:
         # The BE rejects cross-granularity nesting at create time. Catching
@@ -501,7 +492,7 @@ class TestResolveParentForCreate:
             ValueError,
             match=r"granularity 'annotation' but child is 'section'",
         ):
-            _resolve_parent_for_create(section_child, lookups)
+            _resolve_parent_property_for_create(section_child, lookups)
 
 
 class TestMetadataParsing:

--- a/tests/darwin/future/data_objects/test_nested_properties.py
+++ b/tests/darwin/future/data_objects/test_nested_properties.py
@@ -1,0 +1,762 @@
+"""Unit tests for the nested-property SDK foundation: ``TriggerCondition``,
+``FullProperty`` create/update endpoints with nesting fields,
+``property_key`` helper, ``_property_value_from_metadata`` helper, the
+class-level branch of ``_resolve_parent_for_create``, and metadata parsing
+of nested fields.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+from typing import List, Optional
+from unittest.mock import Mock
+
+import pytest
+
+import darwin.datatypes as dt
+from darwin.datatypes import TeamPropertyLookups, parse_property_classes
+from darwin.future.data_objects.properties import (
+    FullProperty,
+    MetaDataClass,
+    PropertyGranularity,
+    PropertyValue,
+    TriggerCondition,
+    property_key,
+)
+from darwin.importer.importer import (
+    _import_properties,
+    _property_value_from_metadata,
+    _resolve_parent_for_create,
+)
+
+
+def _make_property(
+    *,
+    name: str,
+    id_: Optional[str] = None,
+    type_: str = "single_select",
+    property_values: Optional[List[PropertyValue]] = None,
+    parent_name: Optional[str] = None,
+    trigger_condition: Optional[TriggerCondition] = None,
+    annotation_class_id: Optional[int] = 1,
+    granularity: PropertyGranularity = PropertyGranularity.annotation,
+) -> FullProperty:
+    return FullProperty(
+        id=id_,
+        name=name,
+        type=type_,
+        required=False,
+        annotation_class_id=annotation_class_id,
+        slug="team-slug",
+        property_values=property_values or [],
+        granularity=granularity,
+        parent_name=parent_name,
+        trigger_condition=trigger_condition,
+    )
+
+
+class TestTriggerCondition:
+    def test_value_match_requires_values_or_ids(self) -> None:
+        with pytest.raises(ValueError):
+            TriggerCondition(type="value_match")
+
+    def test_value_match_accepts_values(self) -> None:
+        cond = TriggerCondition(type="value_match", values=["Fracture"])
+        assert cond.values == ["Fracture"]
+        assert cond.property_value_ids is None
+
+    def test_value_match_accepts_property_value_ids(self) -> None:
+        cond = TriggerCondition(type="value_match", property_value_ids=["abc-uuid"])
+        assert cond.property_value_ids == ["abc-uuid"]
+        assert cond.values is None
+
+    def test_value_match_accepts_both_names_and_ids(self) -> None:
+        # Both representations coexisting is not an error; callers may
+        # hydrate names alongside API-returned UUIDs.
+        cond = TriggerCondition(
+            type="value_match",
+            values=["Fracture"],
+            property_value_ids=["abc-uuid"],
+        )
+        assert cond.values == ["Fracture"]
+        assert cond.property_value_ids == ["abc-uuid"]
+
+    def test_any_value_does_not_require_ids_or_values(self) -> None:
+        cond = TriggerCondition(type="any_value")
+        assert cond.property_value_ids is None
+        assert cond.values is None
+
+    def test_any_value_rejects_non_empty_values(self) -> None:
+        with pytest.raises(ValueError):
+            TriggerCondition(type="any_value", values=["Fracture"])
+
+    def test_any_value_rejects_non_empty_property_value_ids(self) -> None:
+        with pytest.raises(ValueError):
+            TriggerCondition(type="any_value", property_value_ids=["abc"])
+
+    def test_rejects_unknown_type(self) -> None:
+        with pytest.raises(Exception):  # pydantic ValidationError
+            TriggerCondition(type="bogus_type")  # type: ignore[arg-type]
+
+    def test_validator_accepts_already_built_instance(self) -> None:
+        # ``mode="before"`` runs on every construction path, including nested
+        # validation where Pydantic hands the validator an already-built
+        # model. The ``isinstance(data, dict)`` guard must let that through.
+        original = TriggerCondition(type="any_value")
+        cloned = TriggerCondition.model_validate(original)
+        assert cloned.type == "any_value"
+        assert cloned.property_value_ids is None
+        assert cloned.values is None
+
+    def test_to_api_payload_any_value_omits_property_value_ids(self) -> None:
+        assert TriggerCondition(type="any_value").to_api_payload() == {
+            "type": "any_value"
+        }
+
+    def test_to_api_payload_value_match_emits_property_value_ids(self) -> None:
+        trigger = TriggerCondition(
+            type="value_match",
+            property_value_ids=["v-1", "v-2"],
+        )
+        assert trigger.to_api_payload() == {
+            "type": "value_match",
+            "property_value_ids": ["v-1", "v-2"],
+        }
+
+    def test_to_api_payload_strips_sdk_local_values(self) -> None:
+        # The name-based ``values`` field is an SDK-local convenience. The
+        # wire shape never includes it — callers must resolve names to
+        # UUIDs (via ``_resolve_parent_for_create``) before serialising.
+        trigger = TriggerCondition(
+            type="value_match",
+            values=["Fracture"],
+            property_value_ids=["v-1"],
+        )
+        assert "values" not in trigger.to_api_payload()
+
+    def test_to_api_payload_value_match_raises_without_property_value_ids(
+        self,
+    ) -> None:
+        # Names-only (pre-resolution) ``value_match`` trigger. Serialising
+        # this would yield ``{"type": "value_match"}`` which the BE rejects
+        # with an opaque 422. ``to_api_payload`` raises a clear client-side
+        # error instead.
+        trigger = TriggerCondition(type="value_match", values=["Fracture"])
+        with pytest.raises(ValueError, match="property_value_ids"):
+            trigger.to_api_payload()
+
+
+class TestPropertyKey:
+    def test_class_level_uses_class_id(self) -> None:
+        prop = FullProperty(
+            name="Status",
+            type="single_select",
+            required=False,
+            annotation_class_id=42,
+            property_values=[PropertyValue(value="Open")],
+            granularity=PropertyGranularity.annotation,
+        )
+        assert property_key(prop) == ("Status", 42)
+
+    def test_item_level_uses_none_for_class_id(self) -> None:
+        prop = FullProperty(
+            name="Status",
+            type="text",
+            required=False,
+            annotation_class_id=None,
+            granularity=PropertyGranularity.item,
+        )
+        assert property_key(prop) == ("Status", None)
+
+    def test_class_level_and_item_level_with_same_name_differ(self) -> None:
+        class_level = FullProperty(
+            name="Status",
+            type="single_select",
+            required=False,
+            annotation_class_id=42,
+            property_values=[PropertyValue(value="Open")],
+            granularity=PropertyGranularity.annotation,
+        )
+        item_level = FullProperty(
+            name="Status",
+            type="text",
+            required=False,
+            annotation_class_id=None,
+            granularity=PropertyGranularity.item,
+        )
+        assert property_key(class_level) != property_key(item_level)
+
+    def test_matches_team_property_lookups_key_order(self) -> None:
+        # The contract: ``property_key(prop)`` is drop-in usable against
+        # ``TeamPropertyLookups.annotation_properties`` which keys on
+        # ``(name, annotation_class_id)``. Any reorder here is a breaking
+        # change for every consumer that relies on that interchangeability.
+        prop = FullProperty(
+            name="Status",
+            type="single_select",
+            required=False,
+            annotation_class_id=42,
+            property_values=[PropertyValue(value="Open")],
+            granularity=PropertyGranularity.annotation,
+        )
+        lookups_key = (prop.name, prop.annotation_class_id)
+        assert property_key(prop) == lookups_key
+
+
+class TestPropertyValueFromMetadata:
+    """Direct coverage for the helper that replaced 5 copies of the
+    ``PropertyValue(value=..., color=... or "auto")`` idiom."""
+
+    def test_passes_through_value_and_color(self) -> None:
+        pv = _property_value_from_metadata(
+            {"value": "Red", "color": "rgba(255,0,0,1.0)"}
+        )
+        assert pv.value == "Red"
+        assert pv.color == "rgba(255,0,0,1.0)"
+
+    def test_defaults_missing_color_to_auto(self) -> None:
+        pv = _property_value_from_metadata({"value": "Red"})
+        assert pv.color == "auto"
+
+    def test_treats_empty_color_as_missing(self) -> None:
+        # ``color=""`` in metadata is treated the same as a missing key —
+        # the Pydantic validator would otherwise reject it.
+        pv = _property_value_from_metadata({"value": "Red", "color": ""})
+        assert pv.color == "auto"
+
+
+class TestFullPropertyEndpoints:
+    def test_create_endpoint_omits_nesting_when_absent(self) -> None:
+        prop = _make_property(name="top")
+        body = prop.to_create_endpoint()
+        assert "parent_property_id" not in body
+        assert "parent_name" not in body  # SDK-local field, never sent to API
+        assert "trigger_condition" not in body
+
+    def test_create_endpoint_sends_parent_property_id_and_uuid_trigger(self) -> None:
+        prop = _make_property(
+            name="child",
+            parent_name="Parent",
+            trigger_condition=TriggerCondition(
+                type="value_match",
+                values=["Fracture"],
+                property_value_ids=["val-uuid"],
+            ),
+        )
+        prop.parent_property_id = "parent-uuid"
+        body = prop.to_create_endpoint()
+        assert body["parent_property_id"] == "parent-uuid"
+        # Name-based ``values`` is an SDK-local convenience and must not leak
+        # into the API payload.
+        assert body["trigger_condition"] == {
+            "type": "value_match",
+            "property_value_ids": ["val-uuid"],
+        }
+
+    def test_create_endpoint_any_value_omits_property_value_ids(self) -> None:
+        # BE OpenAPI schema declares ``property_value_ids`` as a non-nullable
+        # array; sending ``null`` fails schema validation. Omitting the key
+        # is the documented shape for ``any_value`` triggers.
+        prop = _make_property(
+            name="child",
+            parent_name="Parent",
+            trigger_condition=TriggerCondition(type="any_value"),
+        )
+        prop.parent_property_id = "parent-uuid"
+        body = prop.to_create_endpoint()
+        assert body["trigger_condition"] == {"type": "any_value"}
+        assert "property_value_ids" not in body["trigger_condition"]
+
+    def test_create_endpoint_rejects_parent_name_without_resolved_uuid(self) -> None:
+        # ``parent_name`` is the SDK-local mirror of ``parent_property_id``.
+        # Sending it on its own would produce a flat-property payload while
+        # the caller thinks they're creating a nested child — catch that
+        # before it reaches the BE and produces a degraded property.
+        prop = _make_property(name="orphan", parent_name="Parent")
+        with pytest.raises(
+            ValueError, match="parent_name set without parent_property_id"
+        ):
+            prop.to_create_endpoint()
+
+    def test_create_endpoint_rejects_unresolved_parent(self) -> None:
+        # ``parent_name`` without ``parent_property_id`` means the importer
+        # hasn't resolved the name against the server yet — sending it as-is
+        # would lose the nesting silently.
+        prop = _make_property(
+            name="child",
+            parent_name="Parent",
+            trigger_condition=TriggerCondition(type="any_value"),
+        )
+        with pytest.raises(ValueError):
+            prop.to_create_endpoint()
+
+    def test_create_endpoint_rejects_parent_without_trigger(self) -> None:
+        prop = _make_property(name="child")
+        prop.parent_property_id = "parent-uuid"
+        with pytest.raises(ValueError):
+            prop.to_create_endpoint()
+
+    def test_update_endpoint_excludes_immutable_nesting_fields(self) -> None:
+        prop = _make_property(
+            id_="3",
+            name="child",
+            trigger_condition=TriggerCondition(type="any_value"),
+            parent_name="Parent",
+        )
+        prop.parent_property_id = "parent-uuid"
+        _, body = prop.to_update_endpoint()
+        assert "parent_property_id" not in body
+        assert "trigger_condition" not in body
+        assert "granularity" not in body
+
+
+def _fake_team_property_lookups(
+    annotation_properties=None, item_properties=None
+) -> TeamPropertyLookups:
+    lookups = TeamPropertyLookups.__new__(TeamPropertyLookups)
+    lookups.annotation_properties = annotation_properties or {}
+    lookups.item_properties = item_properties or {}
+    lookups._client = Mock()  # type: ignore[attr-defined]
+    lookups._team_slug = "test_team"  # type: ignore[attr-defined]
+    return lookups
+
+
+class TestResolveParentForCreate:
+    """Class-level (annotation + section) coverage. Item-level lands in
+    PR 2 alongside the in-batch parent-creation support."""
+
+    def test_returns_as_is_for_top_level(self) -> None:
+        prop = _make_property(name="top")
+        resolved = _resolve_parent_for_create(prop, _fake_team_property_lookups())
+        assert resolved is prop
+
+    def test_resolves_class_level_parent_name_and_trigger_values(self) -> None:
+        parent_on_server = FullProperty(
+            id="new-parent-id",
+            name="Defect Type",
+            type="multi_select",
+            required=False,
+            annotation_class_id=1,
+            property_values=[
+                PropertyValue(id="new-cont-id", value="Contamination"),
+                PropertyValue(id="new-scratch-id", value="Scratch"),
+            ],
+            granularity=PropertyGranularity.annotation,
+        )
+        lookups = _fake_team_property_lookups(
+            annotation_properties={("Defect Type", 1): parent_on_server}
+        )
+        child = _make_property(
+            name="Contamination Source",
+            parent_name="Defect Type",
+            trigger_condition=TriggerCondition(
+                type="value_match", values=["Contamination"]
+            ),
+        )
+        resolved = _resolve_parent_for_create(child, lookups)
+        assert resolved.parent_property_id == "new-parent-id"
+        assert resolved.trigger_condition is not None
+        assert resolved.trigger_condition.property_value_ids == ["new-cont-id"]
+        # The original (name-based) ``trigger_condition.values`` is dropped
+        # from the API-ready copy to avoid double-encoding.
+        assert resolved.trigger_condition.values is None
+
+    def test_resolves_any_value_trigger(self) -> None:
+        parent_on_server = FullProperty(
+            id="notes-id",
+            name="Notes",
+            type="text",
+            required=False,
+            annotation_class_id=1,
+            granularity=PropertyGranularity.annotation,
+        )
+        lookups = _fake_team_property_lookups(
+            annotation_properties={("Notes", 1): parent_on_server}
+        )
+        child = _make_property(
+            name="Translation Required?",
+            parent_name="Notes",
+            trigger_condition=TriggerCondition(type="any_value"),
+        )
+        resolved = _resolve_parent_for_create(child, lookups)
+        assert resolved.parent_property_id == "notes-id"
+        assert resolved.trigger_condition is not None
+        assert resolved.trigger_condition.type == "any_value"
+        assert resolved.trigger_condition.property_value_ids is None
+
+    def test_missing_parent_raises(self) -> None:
+        child = _make_property(
+            name="child",
+            parent_name="Nonexistent",
+            trigger_condition=TriggerCondition(type="any_value"),
+        )
+        with pytest.raises(ValueError, match="Cannot resolve parent"):
+            _resolve_parent_for_create(child, _fake_team_property_lookups())
+
+    def test_unknown_trigger_value_raises(self) -> None:
+        parent_on_server = FullProperty(
+            id="p-id",
+            name="Parent",
+            type="single_select",
+            required=False,
+            annotation_class_id=1,
+            property_values=[PropertyValue(id="v-id", value="KnownValue")],
+            granularity=PropertyGranularity.annotation,
+        )
+        lookups = _fake_team_property_lookups(
+            annotation_properties={("Parent", 1): parent_on_server}
+        )
+        child = _make_property(
+            name="child",
+            parent_name="Parent",
+            trigger_condition=TriggerCondition(
+                type="value_match", values=["UnknownValue"]
+            ),
+        )
+        with pytest.raises(ValueError, match="unknown parent value"):
+            _resolve_parent_for_create(child, lookups)
+
+    def test_value_match_with_duplicate_values_raises(self) -> None:
+        # Duplicates in ``trigger.values`` are a data error: each parent
+        # value should appear at most once. Surface it instead of silently
+        # deduplicating.
+        parent_on_server = FullProperty(
+            id="p-id",
+            name="Parent",
+            type="multi_select",
+            required=False,
+            annotation_class_id=1,
+            property_values=[
+                PropertyValue(id="v-a", value="A"),
+                PropertyValue(id="v-b", value="B"),
+            ],
+            granularity=PropertyGranularity.annotation,
+        )
+        lookups = _fake_team_property_lookups(
+            annotation_properties={("Parent", 1): parent_on_server}
+        )
+        child = _make_property(
+            name="child",
+            parent_name="Parent",
+            trigger_condition=TriggerCondition(
+                type="value_match", values=["A", "B", "A"]
+            ),
+        )
+        with pytest.raises(ValueError, match=r"duplicate values: \['A'\]"):
+            _resolve_parent_for_create(child, lookups)
+
+    def test_value_match_without_values_raises_clear_error(self) -> None:
+        # Contract: darwin-py identifies parent values by name, so
+        # ``value_match`` triggers must be set up with ``values``
+        # (names), not ``property_value_ids`` (UUIDs). Passing UUIDs
+        # alone used to silently drop them and trip an opaque validator
+        # downstream; the importer now surfaces a clear error instead.
+        parent_on_server = FullProperty(
+            id="p-id",
+            name="Parent",
+            type="single_select",
+            required=False,
+            annotation_class_id=1,
+            property_values=[PropertyValue(id="v-uuid", value="A")],
+            granularity=PropertyGranularity.annotation,
+        )
+        lookups = _fake_team_property_lookups(
+            annotation_properties={("Parent", 1): parent_on_server}
+        )
+        child = _make_property(
+            name="child",
+            parent_name="Parent",
+            trigger_condition=TriggerCondition(
+                type="value_match", property_value_ids=["v-uuid"]
+            ),
+        )
+        with pytest.raises(
+            ValueError, match="must set 'values' \\(parent value names\\)"
+        ):
+            _resolve_parent_for_create(child, lookups)
+
+    def test_rejects_cross_granularity_parent(self) -> None:
+        # The BE rejects cross-granularity nesting at create time. Catching
+        # it client-side gives a precise error pointing at both
+        # granularities, instead of the BE's generic 422.
+        annotation_parent = FullProperty(
+            id="p-id",
+            name="Parent",
+            type="single_select",
+            required=False,
+            annotation_class_id=1,
+            property_values=[PropertyValue(id="v-uuid", value="A")],
+            granularity=PropertyGranularity.annotation,
+        )
+        lookups = _fake_team_property_lookups(
+            annotation_properties={("Parent", 1): annotation_parent}
+        )
+        section_child = _make_property(
+            name="child",
+            parent_name="Parent",
+            granularity=PropertyGranularity.section,
+            trigger_condition=TriggerCondition(type="any_value"),
+        )
+        with pytest.raises(
+            ValueError,
+            match=r"granularity 'annotation' but child is 'section'",
+        ):
+            _resolve_parent_for_create(section_child, lookups)
+
+
+class TestMetadataParsing:
+    def _nested_metadata(self) -> dict:
+        return {
+            "classes": [
+                {
+                    "name": "defect",
+                    "type": "bounding_box",
+                    "description": None,
+                    "properties": [
+                        {
+                            "name": "Defect Type",
+                            "type": "multi_select",
+                            "required": False,
+                            "granularity": "annotation",
+                            "property_values": [
+                                {"value": "Contamination"},
+                                {"value": "Scratch"},
+                            ],
+                        },
+                        {
+                            "name": "Contamination Source",
+                            "type": "single_select",
+                            "required": True,
+                            "granularity": "annotation",
+                            "property_values": [{"value": "Chemical"}],
+                            "parent_name": "Defect Type",
+                            "trigger_condition": {
+                                "type": "value_match",
+                                "values": ["Contamination"],
+                            },
+                        },
+                    ],
+                }
+            ]
+        }
+
+    def test_parse_property_classes_preserves_nesting_fields(self) -> None:
+        classes = parse_property_classes(self._nested_metadata())
+        assert len(classes) == 1
+        parent, child = classes[0].properties
+
+        assert parent.parent_name is None
+        assert parent.trigger_condition is None
+
+        assert child.parent_name == "Defect Type"
+        assert child.trigger_condition is not None
+        assert child.trigger_condition.type == "value_match"
+        assert child.trigger_condition.values == ["Contamination"]
+
+    def test_metadataclass_parses_nested_properties(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            metadata_path = Path(tmp) / "metadata.json"
+            with open(metadata_path, "w") as f:
+                json.dump(self._nested_metadata(), f)
+            parsed = MetaDataClass.from_path(metadata_path)
+
+        parent_def, child_def = parsed[0].properties
+        assert parent_def.parent_name is None
+        assert child_def.parent_name == "Defect Type"
+        assert child_def.trigger_condition is not None
+        assert child_def.trigger_condition.type == "value_match"
+        assert child_def.trigger_condition.values == ["Contamination"]
+
+    def test_parse_property_classes_tolerates_missing_nesting_fields(self) -> None:
+        legacy = {
+            "classes": [
+                {
+                    "name": "legacy",
+                    "type": "polygon",
+                    "description": None,
+                    "properties": [
+                        {
+                            "name": "Flat Prop",
+                            "type": "text",
+                            "required": False,
+                            "granularity": "section",
+                            "property_values": [],
+                        }
+                    ],
+                }
+            ]
+        }
+        classes = parse_property_classes(legacy)
+        prop = classes[0].properties[0]
+        assert prop.parent_name is None
+        assert prop.trigger_condition is None
+
+    def test_parse_property_classes_rejects_inconsistent_nesting_fields(self) -> None:
+        # ``parent_name`` and ``trigger_condition`` are the SDK-local pair
+        # that represents nesting. A metadata file with one but not the
+        # other is malformed and would silently produce a degraded
+        # property at create time. Fail fast at parse.
+        for orphan in [
+            {  # parent_name without trigger_condition
+                "name": "Bad",
+                "type": "text",
+                "required": False,
+                "granularity": "annotation",
+                "property_values": [],
+                "parent_name": "Parent",
+            },
+            {  # trigger_condition without parent_name
+                "name": "Bad",
+                "type": "text",
+                "required": False,
+                "granularity": "annotation",
+                "property_values": [],
+                "trigger_condition": {"type": "any_value"},
+            },
+        ]:
+            with pytest.raises(ValueError, match="inconsistent nesting metadata"):
+                parse_property_classes(
+                    {
+                        "classes": [
+                            {
+                                "name": "c",
+                                "type": "polygon",
+                                "description": None,
+                                "properties": [orphan],
+                            }
+                        ]
+                    }
+                )
+
+
+class TestImportPropertiesNestedAgainstExistingParent:
+    """``_import_properties`` end-to-end with a class-level nested child
+    whose parent already exists on the team. The importer must resolve
+    ``parent_name`` against ``team_property_lookups`` and emit the
+    resolved ``parent_property_id`` plus UUID-form trigger to the API.
+    """
+
+    @pytest.fixture
+    def mock_dataset(self) -> Mock:
+        dataset = Mock()
+        dataset.team = "test_team"
+        dataset.name = "test_dataset"
+        dataset.dataset_id = 1
+        return dataset
+
+    def _metadata_with_only_child(self) -> dict:
+        return {
+            "classes": [
+                {
+                    "name": "test_class",
+                    "type": "polygon",
+                    "description": None,
+                    "properties": [
+                        {
+                            "name": "Contamination Source",
+                            "type": "single_select",
+                            "required": False,
+                            "granularity": "annotation",
+                            "property_values": [{"value": "Chemical"}],
+                            "parent_name": "Defect Type",
+                            "trigger_condition": {
+                                "type": "value_match",
+                                "values": ["Contamination"],
+                            },
+                        },
+                    ],
+                }
+            ]
+        }
+
+    def test_creates_nested_child_when_parent_already_exists_on_team(
+        self, mock_dataset: Mock
+    ) -> None:
+        client = Mock()
+        client.default_team = "test_team"
+        annotation_class_ids_map = {("test_class", "polygon"): "123"}
+
+        annotations = [
+            dt.Annotation(
+                dt.AnnotationClass("test_class", "polygon"),
+                {"paths": [[1, 2, 3, 4, 5]]},
+                [],
+                [],
+                id="annotation_id_1",
+                properties=[
+                    dt.SelectedProperty(
+                        frame_index=None,
+                        name="Contamination Source",
+                        type="single_select",
+                        value="Chemical",
+                    ),
+                ],
+            )
+        ]
+
+        # Pre-seed lookups with the parent property as if it had been
+        # previously created on the team.
+        existing_parent = FullProperty(
+            id="existing-parent-id",
+            name="Defect Type",
+            type="multi_select",
+            required=False,
+            annotation_class_id=123,
+            slug="test_team",
+            property_values=[
+                PropertyValue(id="existing-cont-id", value="Contamination"),
+            ],
+            granularity=PropertyGranularity.annotation,
+        )
+        mock_lookups = Mock()
+        mock_lookups.annotation_properties = {
+            ("Defect Type", 123): existing_parent,
+        }
+        mock_lookups.item_properties = {}
+        mock_lookups.refresh = Mock()
+
+        created_payloads: List[FullProperty] = []
+
+        def fake_create_property(
+            *, team_slug: str, params: FullProperty
+        ) -> FullProperty:
+            created_payloads.append(params)
+            server_prop = params.model_copy()
+            server_prop.id = f"new-{params.name.lower().replace(' ', '-')}"
+            server_prop.property_values = [
+                PropertyValue(
+                    id=f"new-val-{pv.value.lower()}",
+                    value=pv.value,
+                    color=pv.color,
+                )
+                for pv in (params.property_values or [])
+            ]
+            return server_prop
+
+        client.create_property.side_effect = fake_create_property
+        client.update_property = Mock()
+        client.get_team_properties = Mock(return_value=[])
+
+        with tempfile.TemporaryDirectory() as tmp:
+            metadata_path = Path(tmp) / "metadata.json"
+            with open(metadata_path, "w") as f:
+                json.dump(self._metadata_with_only_child(), f)
+
+            _import_properties(
+                metadata_path,
+                [],
+                client,
+                annotations,
+                annotation_class_ids_map,
+                mock_dataset,
+                annotation_id_property_map={},
+                team_property_lookups=mock_lookups,
+            )
+
+        assert len(created_payloads) == 1
+        payload = created_payloads[0]
+        assert payload.name == "Contamination Source"
+        assert payload.parent_property_id == "existing-parent-id"
+        assert payload.trigger_condition is not None
+        assert payload.trigger_condition.type == "value_match"
+        assert payload.trigger_condition.property_value_ids == ["existing-cont-id"]

--- a/tests/darwin/future/data_objects/test_nested_properties.py
+++ b/tests/darwin/future/data_objects/test_nested_properties.py
@@ -279,6 +279,17 @@ class TestFullPropertyEndpoints:
         with pytest.raises(ValueError):
             prop.to_create_endpoint()
 
+    def test_create_endpoint_rejects_unresolved_parent_name_only(self) -> None:
+        # ``parent_name`` set with neither ``parent_property_id`` nor
+        # ``trigger_condition`` would previously slip past the consistency
+        # guard (which only checked the API-level pair) and silently emit a
+        # top-level property, dropping the nesting relationship. The guard
+        # now requires all three of {parent_name, parent_property_id,
+        # trigger_condition} to be set together.
+        prop = _make_property(name="child", parent_name="Parent")
+        with pytest.raises(ValueError, match="parent_name"):
+            prop.to_create_endpoint()
+
     def test_create_endpoint_rejects_parent_without_trigger(self) -> None:
         prop = _make_property(name="child")
         prop.parent_property_id = "parent-uuid"
@@ -465,6 +476,55 @@ class TestResolveParentForCreate:
             ValueError, match="must set 'values' \\(parent value names\\)"
         ):
             _resolve_parent_property_for_create(child, lookups)
+
+    def test_rejects_value_match_trigger_when_parent_is_text(self) -> None:
+        # Text properties carry no enumerated ``property_values`` to match
+        # against, so a ``value_match`` trigger is meaningless and the BE
+        # rejects it. Surface a precise client-side error naming both
+        # sides of the relationship instead of letting the API 422 bubble
+        # up.
+        text_parent = _make_property(
+            id_="text-parent-id",
+            name="Notes",
+            type_="text",
+            property_values=[],
+        )
+        lookups = _fake_team_property_lookups(
+            annotation_properties={("Notes", 1): text_parent}
+        )
+        child = _make_property(
+            name="child",
+            parent_name="Notes",
+            trigger_condition=TriggerCondition(type="value_match", values=["Anything"]),
+        )
+        with pytest.raises(ValueError, match="text property") as exc_info:
+            _resolve_parent_property_for_create(child, lookups)
+        assert "any_value" in str(exc_info.value)
+
+    def test_resolves_any_value_trigger_when_parent_is_text(self) -> None:
+        # Sanity-check the inverse: an ``any_value`` trigger against a
+        # text parent is the only valid shape and must round-trip cleanly
+        # through resolution. Guards against an accidental over-eager
+        # rejection of all triggers on text parents.
+        text_parent = _make_property(
+            id_="text-parent-id",
+            name="Notes",
+            type_="text",
+            property_values=[],
+        )
+        lookups = _fake_team_property_lookups(
+            annotation_properties={("Notes", 1): text_parent}
+        )
+        child = _make_property(
+            name="child",
+            parent_name="Notes",
+            trigger_condition=TriggerCondition(type="any_value"),
+        )
+        resolved = _resolve_parent_property_for_create(child, lookups)
+        assert resolved.parent_property_id == "text-parent-id"
+        assert resolved.trigger_condition is not None
+        assert resolved.trigger_condition.type == "any_value"
+        assert resolved.trigger_condition.property_value_ids is None
 
     def test_rejects_cross_granularity_parent(self) -> None:
         # The BE rejects cross-granularity nesting at create time. Catching


### PR DESCRIPTION
## Context

Stack 1/3 slicing #1151 (rollup) into reviewable chunks. Each PR in the
stack is independently green; the rollup itself was previously reviewed
end-to-end. The goal of the slice is to make the same code reviewable in
smaller pieces — no behavioural drift from the rollup.

- PR 1 (this one): nest a child whose parent already exists on the team.
- PR 2: nest parent + child created in the same batch (topo sort + name
  resolution against in-flight lookups, item-level granularity).
- PR 3: e2e round-trip across all three granularities (xfail, blocked on
  DAR-7832 BE export).

## Capability

The importer can create a nested child property when its parent already
exists on the team. Class-level only (annotation + section). No
batch-creation of parent + child.

## Included in this PR

- ``TriggerCondition`` model with name-based ``values`` and UUID-based
  ``property_value_ids``, plus ``to_api_payload`` that strips SDK-local
  fields and refuses to serialise unresolved triggers.
- ``parent_name`` / ``parent_property_id`` / ``trigger_condition`` on
  ``FullProperty``, with create/update endpoint guards.
- ``parent_name`` / ``trigger_condition`` on the ``Property`` dataclass,
  parsed from ``.v7/metadata.json`` via ``_property_from_metadata_dict``
  + ``_validate_metadata_nesting``.
- ``_property_value_from_metadata`` helper (replaces five call sites).
- ``_resolve_parent_for_create`` — class-level branch only. Resolves
  parent names and ``trigger_condition.values`` to UUIDs against
  ``team_property_lookups.annotation_properties`` before
  ``client.create_property``.
- ``PropertyKey`` type alias and ``property_key()`` helper.
- Class-level path in ``_import_properties`` propagates ``parent_name``
  and ``trigger_condition`` from ``Property`` to ``FullProperty``.

## Explicitly NOT in this PR (lands in PR 2 / 3)

- ``_topologically_sort_properties_to_create``
- ``_enrich_properties_with_metadata_values``
- ``TeamPropertyLookups.register()`` (class stays as-is for now)
- Item-level branch of ``_resolve_parent_for_create``
- ``_create_update_item_properties`` ``parent_name`` / ``trigger_condition``
  propagation
- ``_assign_item_properties_to_dataset`` skip for nested item-level
- E2E test + fixture (PR 3, xfail on DAR-7832)

## Tests

40 new unit tests in
``tests/darwin/future/data_objects/test_nested_properties.py``:

- ``TestTriggerCondition`` (12 cases)
- ``TestPropertyKey`` (4 cases)
- ``TestPropertyValueFromMetadata`` (3 cases)
- ``TestFullPropertyEndpoints`` (7 cases)
- ``TestResolveParentForCreate`` — class-level cases only (8 cases;
  item-level resolver case lands in PR 2)
- ``TestMetadataParsing`` (4 cases)
- ``TestImportPropertiesNestedAgainstExistingParent`` — single
  integration test exercising ``_import_properties`` against a
  pre-seeded ``team_property_lookups`` to assert ``parent_property_id``
  and trigger UUIDs are resolved correctly.

The pre-existing importer test file (``tests/darwin/importer/importer_test.py``)
remains green.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes property creation payloads and importer logic to support nested properties, adding new validation paths that can raise errors for malformed metadata or unresolved parent/trigger values. Risk is moderate because it affects property import/create flows and API serialization, but is scoped and covered by extensive unit tests.
> 
> **Overview**
> Adds first-class support for **nested (child) properties** when importing from `.v7/metadata.json`, specifically resolving a child against an **already-existing parent property on the team**.
> 
> Introduces a `TriggerCondition` model and extends `FullProperty`/`Property` with nesting fields (`parent_name`, `parent_property_id`, `trigger_condition`), with stricter validation and API serialization that prevents sending unresolved nesting data.
> 
> Updates the importer to propagate nesting metadata from parsed metadata, resolve parent names + trigger value names to server UUIDs before `create_property`, and deduplicates repeated `PropertyValue` construction via `_property_value_from_metadata`. Adds a comprehensive new test suite validating parsing, endpoint payload shapes, and the resolver/importer behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c80012b01dbd7ba8653ecb6739fc2b008f06095a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->