### PR TITLE
[DAR-7810] (3/3) E2E round-trip across all three nesting granularities

### DIFF
--- a/e2e_tests/cli/test_full_cycle.py
+++ b/e2e_tests/cli/test_full_cycle.py
@@ -579,10 +579,6 @@ def test_full_cycle_multi_channel_item(
     )
 
 
-@pytest.mark.xfail(
-    strict=False,
-    reason="Blocked on DAR-7832 (BE export does not yet emit nested metadata)",
-)
 def test_full_cycle_nested_properties(
     local_dataset: E2EDataset,
     config_values: ConfigValues,

--- a/e2e_tests/cli/test_full_cycle.py
+++ b/e2e_tests/cli/test_full_cycle.py
@@ -1,7 +1,11 @@
 import os
 import shutil
 from pathlib import Path
+from typing import Any, Dict, List
 
+import pytest
+
+from darwin.path_utils import parse_metadata
 from e2e_tests.helpers import (
     assert_cli,
     run_cli_command,
@@ -11,6 +15,60 @@ from e2e_tests.helpers import (
 from e2e_tests.objects import E2EDataset, ConfigValues
 from e2e_tests.cli.test_import import compare_annotations_export
 from e2e_tests.cli.test_push import extract_and_push
+
+
+def assert_nested_metadata_round_trips(
+    first_metadata_path: Path, second_metadata_path: Path
+) -> None:
+    """Assert nested property metadata survives a push/pull round-trip."""
+    first_metadata = parse_metadata(first_metadata_path)
+    second_metadata = parse_metadata(second_metadata_path)
+
+    first_flat: List[Dict[str, Any]] = [
+        {"class": klass["name"], **prop}
+        for klass in first_metadata.get("classes", [])
+        for prop in klass.get("properties", [])
+    ] + [{"class": None, **prop} for prop in first_metadata.get("properties", [])]
+    second_flat: List[Dict[str, Any]] = [
+        {"class": klass["name"], **prop}
+        for klass in second_metadata.get("classes", [])
+        for prop in klass.get("properties", [])
+    ] + [{"class": None, **prop} for prop in second_metadata.get("properties", [])]
+
+    second_by_key = {(p["class"], p["name"]): p for p in second_flat}
+
+    nested_children_first = [p for p in first_flat if p.get("parent_name") is not None]
+    assert nested_children_first, (
+        "Test setup error: first metadata export does not contain any nested "
+        "property (parent_name). The fixture must include at least one "
+        "nested property to make this assertion meaningful."
+    )
+
+    for child in nested_children_first:
+        key = (child["class"], child["name"])
+        assert (
+            key in second_by_key
+        ), f"Nested child property '{child['name']}' missing from second export"
+        second_child = second_by_key[key]
+
+        assert second_child.get("parent_name") == child["parent_name"], (
+            f"Child '{child['name']}' lost or changed its parent_name "
+            f"on round-trip: {child['parent_name']!r} -> "
+            f"{second_child.get('parent_name')!r}"
+        )
+
+        first_trigger = child.get("trigger_condition") or {}
+        second_trigger = second_child.get("trigger_condition") or {}
+        assert first_trigger.get("type") == second_trigger.get(
+            "type"
+        ), f"Trigger type of '{child['name']}' changed on round-trip"
+        if first_trigger.get("type") == "value_match":
+            assert set(first_trigger.get("values") or []) == set(
+                second_trigger.get("values") or []
+            ), (
+                f"value_match trigger values for '{child['name']}' changed "
+                "on round-trip"
+            )
 
 
 def copy_files_to_flat_directory(source_dir, target_dir):
@@ -519,3 +577,101 @@ def test_full_cycle_multi_channel_item(
         base_slot="image_1.jpg",
         unzip=False,
     )
+
+
+@pytest.mark.xfail(
+    strict=False,
+    reason="Blocked on DAR-7832 (BE export does not yet emit nested metadata)",
+)
+def test_full_cycle_nested_properties(
+    local_dataset: E2EDataset,
+    config_values: ConfigValues,
+):
+    """
+    Full round-trip for nested properties at item, section, and annotation
+    granularity. Designed to catch regressions in the importer's topological
+    sort and the BE export's metadata.json nesting fields.
+    """
+    item_type = "single_slotted"
+    annotation_format = "darwin"
+    first_release_name = "first_release"
+    second_release_name = "second_release"
+    pull_dir = Path(
+        f"{Path.home()}/.darwin/datasets/{config_values.team_slug}/{local_dataset.slug}"
+    )
+    annotations_import_dir = (
+        Path(__file__).parents[1]
+        / "data"
+        / "import"
+        / "image_annotations_with_nested_properties"
+    )
+
+    local_dataset.register_read_only_items(config_values, item_type)
+    result = run_cli_command(
+        f"darwin dataset import {local_dataset.name} {annotation_format} {annotations_import_dir}"
+    )
+    assert_cli(result, 0)
+
+    original_release = export_release(
+        annotation_format, local_dataset, config_values, release_name=first_release_name
+    )
+    result = run_cli_command(
+        f"darwin dataset pull {local_dataset.name}:{original_release.name}"
+    )
+    assert_cli(result, 0)
+
+    first_metadata_path = (
+        pull_dir
+        / "releases"
+        / first_release_name
+        / "annotations"
+        / ".v7"
+        / "metadata.json"
+    )
+    assert (
+        first_metadata_path.is_file()
+    ), f"Expected metadata.json to be present after pull at {first_metadata_path}"
+
+    local_dataset.delete_items(config_values)
+
+    result = run_cli_command(
+        f"darwin dataset push {local_dataset.name} {pull_dir}/images --preserve-folders"
+    )
+    assert_cli(result, 0)
+    wait_until_items_processed(config_values, local_dataset.id, timeout=60)
+    result = run_cli_command(
+        f"darwin dataset import {local_dataset.name} {annotation_format} "
+        f"{pull_dir}/releases/{first_release_name}/annotations"
+    )
+    assert_cli(result, 0)
+
+    shutil.rmtree(f"{pull_dir}/images")
+
+    new_release = export_release(
+        annotation_format,
+        local_dataset,
+        config_values,
+        release_name=second_release_name,
+    )
+    result = run_cli_command(
+        f"darwin dataset pull {local_dataset.name}:{new_release.name}"
+    )
+    assert_cli(result, 0)
+
+    second_metadata_path = (
+        pull_dir
+        / "releases"
+        / second_release_name
+        / "annotations"
+        / ".v7"
+        / "metadata.json"
+    )
+
+    compare_annotations_export(
+        Path(f"{pull_dir}/releases/{first_release_name}/annotations"),
+        Path(f"{pull_dir}/releases/{second_release_name}/annotations"),
+        item_type,
+        unzip=False,
+    )
+
+    assert_nested_metadata_round_trips(first_metadata_path, second_metadata_path)

--- a/e2e_tests/cli/test_full_cycle.py
+++ b/e2e_tests/cli/test_full_cycle.py
@@ -3,8 +3,6 @@ import shutil
 from pathlib import Path
 from typing import Any, Dict, List
 
-import pytest
-
 from darwin.path_utils import parse_metadata
 from e2e_tests.helpers import (
     assert_cli,

--- a/e2e_tests/data/import/image_annotations_with_nested_properties/.v7/metadata.json
+++ b/e2e_tests/data/import/image_annotations_with_nested_properties/.v7/metadata.json
@@ -1,0 +1,107 @@
+{
+  "version": "1.0",
+  "schema_ref": "https://darwin-public.s3.eu-west-1.amazonaws.com/darwin_json/metadata/1.0/schema.json",
+  "classes": [
+    {
+      "name": "nested_bbox",
+      "type": "bounding_box",
+      "description": null,
+      "color": "rgba(255,0,255,1.0)",
+      "sub_types": [],
+      "properties": [
+        {
+          "name": "annotation_level_child",
+          "type": "single_select",
+          "description": "",
+          "required": false,
+          "granularity": "annotation",
+          "property_values": [
+            {
+              "value": "Femur",
+              "color": "rgba(200,255,0,1.0)"
+            }
+          ],
+          "parent_name": "annotation_level_parent",
+          "trigger_condition": {
+            "type": "value_match",
+            "values": ["Fracture"]
+          }
+        },
+        {
+          "name": "section_level_child",
+          "type": "multi_select",
+          "description": "",
+          "required": false,
+          "granularity": "section",
+          "property_values": [
+            {
+              "value": "Rotated",
+              "color": "rgba(100,100,100,1.0)"
+            }
+          ],
+          "parent_name": "section_level_parent",
+          "trigger_condition": {
+            "type": "any_value"
+          }
+        },
+        {
+          "name": "annotation_level_parent",
+          "type": "single_select",
+          "description": "",
+          "required": false,
+          "granularity": "annotation",
+          "property_values": [
+            {
+              "value": "Fracture",
+              "color": "rgba(0,255,0,1.0)"
+            },
+            {
+              "value": "Normal",
+              "color": "rgba(0,0,255,1.0)"
+            }
+          ]
+        },
+        {
+          "name": "section_level_parent",
+          "type": "multi_select",
+          "description": "",
+          "required": false,
+          "granularity": "section",
+          "property_values": [
+            {
+              "value": "LeftHand",
+              "color": "rgba(200,100,0,1.0)"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "properties": [
+    {
+      "name": "item_level_child",
+      "type": "single_select",
+      "description": "",
+      "required": false,
+      "granularity": "item",
+      "property_values": [
+        {
+          "value": "Yes",
+          "color": "rgba(0,255,255,1.0)"
+        }
+      ],
+      "parent_name": "item_level_parent",
+      "trigger_condition": {
+        "type": "any_value"
+      }
+    },
+    {
+      "name": "item_level_parent",
+      "type": "text",
+      "description": "",
+      "required": false,
+      "granularity": "item",
+      "property_values": []
+    }
+  ]
+}

--- a/e2e_tests/data/import/image_annotations_with_nested_properties/.v7/metadata.json
+++ b/e2e_tests/data/import/image_annotations_with_nested_properties/.v7/metadata.json
@@ -3,7 +3,7 @@
   "schema_ref": "https://darwin-public.s3.eu-west-1.amazonaws.com/darwin_json/metadata/1.0/schema.json",
   "classes": [
     {
-      "name": "nested_bbox",
+      "name": "test_bounding_box_basic",
       "type": "bounding_box",
       "description": null,
       "color": "rgba(255,0,255,1.0)",

--- a/e2e_tests/data/import/image_annotations_with_nested_properties/image_1.json
+++ b/e2e_tests/data/import/image_annotations_with_nested_properties/image_1.json
@@ -38,7 +38,7 @@
         "y": 173.355
       },
       "id": "c0ffee00-dead-beef-cafe-babe00000001",
-      "name": "nested_bbox",
+      "name": "test_bounding_box_basic",
       "properties": [
         {
           "frame_index": 0,

--- a/e2e_tests/data/import/image_annotations_with_nested_properties/image_1.json
+++ b/e2e_tests/data/import/image_annotations_with_nested_properties/image_1.json
@@ -1,0 +1,77 @@
+{
+  "version": "2.0",
+  "schema_ref": "https://darwin-public.s3.eu-west-1.amazonaws.com/darwin_json/2.0/schema.json",
+  "item": {
+    "name": "image_1.jpg",
+    "path": "/",
+    "source_info": {
+      "dataset": {
+        "name": "nested_properties_dataset",
+        "slug": "nested_properties_dataset"
+      },
+      "team": {
+        "name": "E2E Testing",
+        "slug": "e2e-testing"
+      }
+    },
+    "slots": [
+      {
+        "type": "image",
+        "slot_name": "0",
+        "width": 1920,
+        "height": 1080,
+        "source_files": [
+          {
+            "file_name": "image_1.jpg",
+            "storage_key": "darwin-py/images/image_1.jpg"
+          }
+        ]
+      }
+    ]
+  },
+  "annotations": [
+    {
+      "bounding_box": {
+        "h": 58.941,
+        "w": 216.693,
+        "x": 280.449,
+        "y": 173.355
+      },
+      "id": "c0ffee00-dead-beef-cafe-babe00000001",
+      "name": "nested_bbox",
+      "properties": [
+        {
+          "frame_index": 0,
+          "name": "annotation_level_parent",
+          "value": "Fracture"
+        },
+        {
+          "frame_index": 0,
+          "name": "annotation_level_child",
+          "value": "Femur"
+        },
+        {
+          "frame_index": 0,
+          "name": "section_level_parent",
+          "value": "LeftHand"
+        },
+        {
+          "frame_index": 0,
+          "name": "section_level_child",
+          "value": "Rotated"
+        }
+      ],
+      "slot_names": ["0"]
+    }
+  ],
+  "properties": [
+    {
+      "name": "item_level_parent",
+      "value": "some contextual notes about the item"
+    },
+    {
+      "name": "item_level_child",
+      "value": "Yes"
+    }
+  ]
+}

--- a/tests/darwin/future/data_objects/test_nested_properties.py
+++ b/tests/darwin/future/data_objects/test_nested_properties.py
@@ -1182,6 +1182,87 @@ class TestAssignItemPropertiesToDataset:
         assert nested_child.dataset_ids == []
 
 
+class TestE2EFixture:
+    """
+    Smoke-tests that the E2E fixture
+    ``e2e_tests/data/import/image_annotations_with_nested_properties`` is
+    well-formed: every child references a parent by name that exists and
+    every ``value_match`` trigger names a value that exists on the parent.
+    """
+
+    def _fixture_root(self) -> Path:
+        return (
+            Path(__file__).resolve().parents[4]
+            / "e2e_tests"
+            / "data"
+            / "import"
+            / "image_annotations_with_nested_properties"
+        )
+
+    def test_metadata_fixture_is_self_consistent(self) -> None:
+        fixture = self._fixture_root() / ".v7" / "metadata.json"
+        assert fixture.is_file(), f"fixture missing: {fixture}"
+
+        with open(fixture) as f:
+            raw = json.load(f)
+        classes = parse_property_classes(raw)
+
+        class_level_granularities = {
+            prop.granularity.value
+            for klass in classes
+            for prop in (klass.properties or [])
+        }
+        assert "annotation" in class_level_granularities
+        assert "section" in class_level_granularities
+
+        item_granularities = {p["granularity"] for p in raw["properties"]}
+        assert item_granularities == {"item"}
+
+        # Class-level parent resolution by name.
+        for klass in classes:
+            by_name = {p.name: p for p in klass.properties or []}
+            children = [p for p in by_name.values() if p.parent_name is not None]
+            assert children, f"class '{klass.name}' has no nested children"
+            for child in children:
+                parent = by_name.get(child.parent_name)
+                assert parent is not None, (
+                    f"child '{child.name}' references missing parent "
+                    f"'{child.parent_name}' in class '{klass.name}'"
+                )
+                trigger = child.trigger_condition
+                assert trigger is not None
+                if trigger.type == "value_match":
+                    parent_value_names = {
+                        pv.get("value") for pv in (parent.property_values or [])
+                    }
+                    assert set(trigger.values or []).issubset(parent_value_names), (
+                        f"child '{child.name}' value_match references an "
+                        f"unknown parent value"
+                    )
+
+        # Item-level parent resolution by name.
+        item_props_by_name = {p["name"]: p for p in raw["properties"]}
+        item_children = [p for p in item_props_by_name.values() if p.get("parent_name")]
+        assert item_children, "item-level fixture must include nested children"
+        for child in item_children:
+            assert child["parent_name"] in item_props_by_name
+
+    def test_annotation_fixture_references_known_properties(self) -> None:
+        fixture_root = self._fixture_root()
+        metadata = json.loads((fixture_root / ".v7" / "metadata.json").read_text())
+        class_prop_names = {
+            p["name"] for k in metadata["classes"] for p in k["properties"]
+        }
+        item_prop_names = {p["name"] for p in metadata["properties"]}
+
+        annotation_file = json.loads((fixture_root / "image_1.json").read_text())
+        for annotation in annotation_file["annotations"]:
+            for selected in annotation.get("properties", []):
+                assert selected["name"] in class_prop_names
+        for selected in annotation_file.get("properties", []):
+            assert selected["name"] in item_prop_names
+
+
 class TestImportPropertiesNestedInOneBatch:
     """
     Exercises ``_import_properties`` end-to-end with a nested hierarchy


### PR DESCRIPTION
## Context

Stack 3/3 slicing #1151 (rollup). Stacked on #1160 (which is stacked on
#1159).

- PR 1 (#1159): nest a child whose parent already exists on the team.
- PR 2 (#1160): nest parent + child created in the same batch.
- PR 3 (this one): e2e round-trip across all three granularities
  (xfail, blocked on DAR-7832 BE export).

## Capability

Full e2e round-trip exercising nested properties at item, section, and
annotation granularities: push annotations → export → pull → re-push →
export → assert every nested child's ``parent_name`` and
``trigger_condition`` survives the round-trip.

The new ``test_full_cycle_nested_properties`` is gated with
``@pytest.mark.xfail(strict=False, reason=...)`` because the BE export
does not yet emit the nesting fields in ``metadata.json``. Once
DAR-7832 lands, the test will start passing — ``strict=False`` lets
CI auto-promote (xpass → expected pass) without a follow-up code change.

## Files added

- ``e2e_tests/data/import/image_annotations_with_nested_properties/.v7/metadata.json``
  — fixture with class-level (annotation + section) and item-level
  nested properties.
- ``e2e_tests/data/import/image_annotations_with_nested_properties/image_1.json``
  — annotation file referencing the fixture's properties.
- ``e2e_tests/cli/test_full_cycle.py``:
  - ``parse_metadata`` import.
  - ``assert_nested_metadata_round_trips`` helper.
  - ``test_full_cycle_nested_properties`` (xfail).
- ``TestE2EFixture`` smoke tests in
  ``tests/darwin/future/data_objects/test_nested_properties.py``
  (run in unit-test CI) that fail-fast if the fixture drifts.

## Review

Recommended: review #1159 and #1160 first.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to new E2E/unit tests and test fixtures, with no production logic modifications.
> 
> **Overview**
> Adds an end-to-end CLI test that imports annotations with **nested properties** (item, section, and annotation granularities), performs a push/pull/export round-trip, and asserts `metadata.json` preserves each child property’s `parent_name` and `trigger_condition`.
> 
> Introduces a new import fixture (`image_annotations_with_nested_properties`) containing nested property definitions plus an example annotation file, and adds unit “smoke tests” to fail fast if the fixture becomes internally inconsistent or references unknown properties.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c622bc567e57cff1f566bf5687caf205c991f090. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->