### PR TITLE
chore(client): use canonical /v3/.../reports/jobs URL for annotator report job

### DIFF
--- a/darwin/client.py
+++ b/darwin/client.py
@@ -667,13 +667,14 @@ class Client:
         the_team_slug: str = the_team.slug
 
         response_data = self._post(
-            f"/v3/teams/{the_team_slug}/reports/annotator/jobs",
+            f"/v3/teams/{the_team_slug}/reports/jobs",
             {
                 "start": start.isoformat(timespec="seconds"),
                 "stop": stop.isoformat(timespec="seconds"),
                 "dataset_ids": dataset_ids,
                 "group_by": [option.value for option in group_by],
                 "format": "csv",
+                "type": "annotator",
                 "metrics": [
                     "active_time",
                     "total_annotations",
@@ -699,7 +700,7 @@ class Client:
         retry=retry_if_exception_type(JobPendingException),
     )
     def poll_pending_report_job(self, team_slug: str, job_id: str) -> ReportJob:
-        job_status_url = f"/v3/teams/{team_slug}/reports/annotator/jobs/{job_id}"
+        job_status_url = f"/v3/teams/{team_slug}/reports/jobs/{job_id}"
 
         response_data = self._get(job_status_url, team_slug)
         report_job = ReportJob.model_validate(response_data)

--- a/tests/darwin/client_test.py
+++ b/tests/darwin/client_test.py
@@ -759,8 +759,7 @@ class TestGetAnnotatorsReport:
 
         start_job_endpoint_mock = responses.add(
             responses.POST,
-            darwin_client.url
-            + f"/v3/teams/{team_slug_darwin_json_v2}/reports/annotator/jobs",
+            darwin_client.url + f"/v3/teams/{team_slug_darwin_json_v2}/reports/jobs",
             status=400,
         )
 
@@ -939,7 +938,7 @@ class TestGetAnnotatorsReport:
     ):
         return responses.add(
             responses.POST,
-            url + f"/v3/teams/{team_slug}/reports/annotator/jobs",
+            url + f"/v3/teams/{team_slug}/reports/jobs",
             json={
                 "id": job_id,
                 "status": "pending",
@@ -956,6 +955,7 @@ class TestGetAnnotatorsReport:
                         "dataset_ids": [dataset_id],
                         "group_by": ["annotators"],
                         "format": "csv",
+                        "type": "annotator",
                         "metrics": [
                             "active_time",
                             "total_annotations",
@@ -980,7 +980,7 @@ class TestGetAnnotatorsReport:
     ):
         return responses.add(
             responses.GET,
-            url + f"/v3/teams/{team_slug}/reports/annotator/jobs/{job_id}",
+            url + f"/v3/teams/{team_slug}/reports/jobs/{job_id}",
             json={
                 "id": job_id,
                 "status": job_status,


### PR DESCRIPTION
## Summary

`Client.get_annotators_report` currently calls the legacy alias paths:

- `POST /v3/teams/{team_slug}/reports/annotator/jobs`
- `GET  /v3/teams/{team_slug}/reports/annotator/jobs/{job_id}`

The backend mounts those only as backward-compatibility aliases of the canonical:

- `POST /v3/teams/{team_slug}/reports/jobs`
- `GET  /v3/teams/{team_slug}/reports/jobs/{job_id}`

Both resolve to the same controller actions today, but the alias paths are being removed from the public OpenAPI spec ([darwin-backend#6159](https://github.com/v7labs/darwin-backend/pull/6159) — they were emitting duplicate entries in the docs sidebar) and will eventually be dropped from the router once telemetry on the alias paths trails to zero.

CloudWatch logs over the last 30 days confirm this SDK is the only remaining caller of the alias paths (`python-requests/2.33.1`, one production team).

## Changes

- `darwin/client.py`
  - `get_annotators_report`: POST now targets `/v3/teams/{team_slug}/reports/jobs`. Payload also includes an explicit `\"type\": \"annotator\"` — the canonical endpoint defaults this field to `\"annotator\"` today, but sending it explicitly makes the intent clear and protects against any future change to the default.
  - `poll_pending_report_job`: GET now targets `/v3/teams/{team_slug}/reports/jobs/{job_id}`.
- `tests/darwin/client_test.py`
  - Updated `job_start_endpoint_mock`, `job_status_endpoint_mock`, and the standalone 400-path mock to expect the canonical URL.
  - Updated the create-job payload matcher to expect the new `\"type\": \"annotator\"` field.

## TDD trail

1. Started with 10 report tests passing on `master`.
2. Updated the test expectations to the canonical URL + new payload shape → 6/10 failed (`ConnectionError: the call doesn't match any registered mock` — request still hit `/reports/annotator/jobs`).
3. Updated `client.py` to use canonical URLs and add `\"type\": \"annotator\"` → all 10 report tests pass.

## Test plan

- [x] \`pytest tests/darwin/client_test.py -k report\` → 10 passed.
- [x] \`pytest tests/darwin/client_test.py\` → 36 passed.
- [x] \`pytest tests/ --ignore=tests/e2e\` → 746 passed, 29 skipped, no regressions.
- [x] \`black --check darwin/client.py tests/darwin/client_test.py\` → clean.
- [x] \`ruff check darwin/client.py tests/darwin/client_test.py\` → clean.
- [x] \`mypy darwin/client.py\` → 15 pre-existing errors at unrelated lines (49–132, 1021, 1189–1218); none at the lines I touched (670, 702).

## Rollout

- Merge + release a new `darwin-py` minor version.
- Coordinate upgrade with the one production team still hitting the alias URLs.
- Once their telemetry shows traffic only on canonical paths, the backend can drop the alias routes entirely.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small SDK-side URL/payload update for report-job creation/polling, with tests updated to match; primary risk is incompatibility if a deployment expects the legacy alias paths.
> 
> **Overview**
> Updates `Client.get_annotators_report` and `poll_pending_report_job` to use the canonical `POST/GET /v3/teams/{team_slug}/reports/jobs` endpoints instead of the legacy `/reports/annotator/jobs` alias.
> 
> The report-job create payload now sends an explicit `"type": "annotator"`, and the affected tests/mocks are updated to assert the new URLs and request body.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f25e548f53f2069c014d55895f16e011d1a1c86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->