### PR TITLE
[DAR-7877] Write class lists under `subset_folder_name` and harden `make_class_lists`

### DIFF
--- a/darwin/dataset/remote_dataset.py
+++ b/darwin/dataset/remote_dataset.py
@@ -3,6 +3,7 @@ import shutil
 import tempfile
 import time
 import zipfile
+from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
 from typing import (
@@ -334,6 +335,12 @@ class RemoteDataset(ABC):
                     metadata_dir.mkdir(parents=True, exist_ok=True)
                     shutil.move(str(metadata_file), str(metadata_dir / "metadata.json"))
 
+                # Collect class names per annotation type as we walk the JSONs,
+                # so we don't have to re-parse every annotation file three more
+                # times (once per type) in a separate pass.
+                supported_class_types = ("tag", "polygon", "bounding_box")
+                classes_by_type: Dict[str, set] = defaultdict(set)
+
                 # Move the annotations into the right folder and rename them to have the image
                 # original filename as contained in the json
                 for annotation_path in tmp_dir.glob("*.json"):
@@ -353,6 +360,11 @@ class RemoteDataset(ABC):
                             raise MissingDependency(
                                 "Missing Dependency: OpenCV required for Video Extraction. Install with `pip install darwin-py\[ocv]`"
                             ) from e
+                    for ann in annotation.annotations:
+                        atype = ann.annotation_class.annotation_type
+                        if atype in supported_class_types:
+                            classes_by_type[atype].add(ann.annotation_class.name)
+
                     filename = Path(annotation.filename).stem
                     if filename in stems:
                         stems[filename] += 1
@@ -365,8 +377,22 @@ class RemoteDataset(ABC):
                     )
                     shutil.move(str(annotation_path), str(destination_name))
 
-        # Extract the list of classes and create the text files
-        make_class_lists(release_dir)
+        # Write the class lists next to the annotations we just produced.
+        # Using ``annotations_dir.parent`` keeps the output co-located with
+        # the corresponding ``annotations/`` folder, which is what every
+        # downstream helper expects -- and crucially it works when
+        # ``subset_folder_name`` is set, where the annotations live under
+        # ``<release_dir>/<subset_folder_name>/annotations`` rather than
+        # directly under ``<release_dir>``.
+        lists_path = annotations_dir.parent / "lists"
+        lists_path.mkdir(exist_ok=True)
+        for atype in supported_class_types:
+            class_names = classes_by_type.get(atype)
+            if not class_names:
+                continue
+            (lists_path / f"classes_{atype}.txt").write_text(
+                "\n".join(sorted(class_names))
+            )
 
         if release.latest and is_unix_like_os():
             try:

--- a/darwin/dataset/utils.py
+++ b/darwin/dataset/utils.py
@@ -127,13 +127,22 @@ def make_class_lists(release_path: Path) -> None:
     ----------
     release_path : Path
         Path to the location of the dataset on the file system.
+
+    Notes
+    -----
+    Silently no-ops when ``release_path`` is ``None`` or when the expected
+    ``annotations`` directory is missing. This makes the helper safe to call
+    on releases that were pulled into a custom subset folder (in which case
+    the caller should pass the subset-aware path) or on empty exports.
     """
-    assert release_path is not None
+    if release_path is None:
+        return
     if isinstance(release_path, str):
         release_path = Path(release_path)
 
     annotations_path = release_path / "annotations"
-    assert annotations_path.exists()
+    if not annotations_path.exists():
+        return
     lists_path = release_path / "lists"
     lists_path.mkdir(exist_ok=True)
 

--- a/tests/darwin/dataset/dataset_utils_test.py
+++ b/tests/darwin/dataset/dataset_utils_test.py
@@ -16,6 +16,7 @@ from darwin.dataset.utils import (
     get_annotations,
     get_external_file_type,
     get_release_path,
+    make_class_lists,
     parse_external_file_path,
     sanitize_filename,
 )
@@ -367,6 +368,19 @@ def _create_annotation_file(annotation_path: Path, filename: str, payload: Dict)
     with open(annotation_path / filename, "w") as f:
         op = json.dumps(payload).decode("utf-8")
         f.write(op)
+
+
+class TestMakeClassLists:
+    def test_no_ops_when_release_path_is_none(self):
+        # Must not raise; previously this asserted on ``release_path is not None``.
+        make_class_lists(None)  # type: ignore[arg-type]
+
+    def test_no_ops_when_annotations_dir_is_missing(self, tmp_path: Path):
+        # Previously raised ``AssertionError`` (which is what surfaced when
+        # callers invoked it with a release root after ``pull`` had placed
+        # the annotations inside a ``subset_folder_name`` subdirectory).
+        make_class_lists(tmp_path)
+        assert not (tmp_path / "lists").exists()
 
 
 class TestGetReleasePath:

--- a/tests/darwin/dataset/remote_dataset_test.py
+++ b/tests/darwin/dataset/remote_dataset_test.py
@@ -1258,6 +1258,57 @@ class TestPull:
                 )
                 assert metadata_path.exists()
 
+    @patch("platform.system", return_value="Linux")
+    def test_writes_class_lists_under_subset_folder(
+        self, system_mock: MagicMock, remote_dataset: RemoteDataset
+    ):
+        """Regression test: pulling with ``subset_folder_name`` used to raise
+        ``AssertionError`` from ``make_class_lists`` because the class-list
+        helper was given the release root rather than the subset-aware path.
+        The pull should now succeed and write ``classes_*.txt`` next to the
+        subset's ``annotations/`` directory."""
+        stub_release_response = Release(
+            "dataset-slug",
+            "team-slug",
+            "0.1.0",
+            "release-name",
+            ReleaseStatus("complete"),
+            "http://darwin-fake-url.com",
+            datetime.now(),
+            None,
+            None,
+            True,
+            True,
+            "json",
+        )
+
+        def fake_download_zip(self, path):
+            zip: Path = Path("tests/dataset.zip")
+            shutil.copy(zip, path)
+            return path
+
+        with patch.object(
+            RemoteDataset, "get_release", return_value=stub_release_response
+        ):
+            with patch.object(Release, "download_zip", new=fake_download_zip):
+                remote_dataset.pull(
+                    only_annotations=True,
+                    subset_folder_name="my_subset",
+                )
+
+        subset_dir: Path = (
+            remote_dataset.local_path / "releases" / "release-name" / "my_subset"
+        )
+        assert (subset_dir / "annotations").is_dir()
+        assert (subset_dir / "lists").is_dir()
+        # The test fixture contains a single annotation with a "car" class
+        # tagged as both polygon and bounding_box, so at least one
+        # ``classes_*.txt`` file must have been written.
+        class_files = list((subset_dir / "lists").glob("classes_*.txt"))
+        assert class_files, "expected class list files under the subset folder"
+        for class_file in class_files:
+            assert "car" in class_file.read_text().splitlines()
+
     @patch("time.sleep", return_value=None)
     def test_num_retries(self, mock_sleep, remote_dataset, pending_release):
         with patch.object(remote_dataset, "get_release", return_value=pending_release):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Problem

Calling `RemoteDataset.pull()` with a `subset_folder_name` argument always raises:

```
File ".../darwin/dataset/remote_dataset.py", line 369, in pull
  make_class_lists(release_dir)
File ".../darwin/dataset/utils.py", line 136, in make_class_lists
  assert annotations_path.exists()
AssertionError
```

The export itself completes because the assertion fires only after every annotation JSON has already been moved to disk — but the traceback is surfaced to callers, the `latest` symlink and the image-download step that follow `make_class_lists()` are skipped, and the `lists/classes_*.txt` files are never produced.

Root cause: when `subset_folder_name` is set, `pull()` writes the annotations into `<release_dir>/<subset_folder_name>/annotations/`, but it then calls `make_class_lists(release_dir)`, which looks for `<release_dir>/annotations/` — a directory that doesn't exist in that flow. `make_class_lists()` asserts on its absence instead of degrading gracefully.

# Solution

Two changes, both small and contained:

1. **`darwin/dataset/remote_dataset.py` — class lists in `pull()`**
   - Collect class names per annotation type (`tag`, `polygon`, `bounding_box`) **inline** while `pull()` is already iterating over every annotation JSON to move/rename it. This removes the extra full-disk re-walk that `make_class_lists()` was doing (which re-parsed every JSON three more times, once per type).
   - Write the resulting `classes_*.txt` files into `annotations_dir.parent / "lists"`. That lives at `<release_dir>/<subset_folder_name>/lists/` when a subset folder is used, and at `<release_dir>/lists/` otherwise — i.e. always next to the matching `annotations/` directory, which is what every downstream helper (`get_classes`, `available_annotation_types`, `get_classes_from_file`) already expects.

2. **`darwin/dataset/utils.py` — harden `make_class_lists()`**
   - Replace the two `assert`s with early `return`s so the helper silently no-ops on a missing/`None` release path or a missing `annotations/` directory. Asserts are the wrong tool here (they vanish under `python -O`) and a missing annotations dir is a legitimate runtime condition rather than an invariant violation.
   - Kept the function on the module API since `split_video_annotations()` and external callers still use it.

No public API changes. No on-disk layout changes. The only observable behavioural differences are:
- `pull(subset_folder_name=...)` no longer raises and now correctly emits `classes_*.txt` under the subset folder.
- `make_class_lists()` no longer raises `AssertionError` on a missing annotations directory.

# Changelog

- Fixed `RemoteDataset.pull()` raising `AssertionError` and skipping post-export steps when `subset_folder_name` is provided.
- `classes_*.txt` files are now written next to the produced `annotations/` folder, including when a `subset_folder_name` is used.
- `make_class_lists()` no longer raises on a missing annotations directory; it silently no-ops, making it safe to call on empty/partial releases.
- Internal: class extraction is now performed in a single pass over the annotation JSONs during `pull()`, replacing the previous three-pass post-walk.

### Tests
- Added `TestPull::test_writes_class_lists_under_subset_folder` regression test confirming that `pull(subset_folder_name="my_subset")` succeeds and produces `classes_*.txt` under `<release>/my_subset/lists/`.
- Added `TestMakeClassLists` covering the no-op behaviour when the release path is `None` or the annotations directory is missing.
- All existing `tests/darwin/dataset/` tests continue to pass (201 passed, 23 skipped).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88cf4ed5-9c6e-40ca-a953-f7a0206d8d11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88cf4ed5-9c6e-40ca-a953-f7a0206d8d11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

