### PR TITLE
[DAR-7917] Fix long filename COCO import retry

### DIFF
--- a/darwin/client.py
+++ b/darwin/client.py
@@ -1090,7 +1090,7 @@ class Client:
         if response.status_code == 404:
             raise NotFound(url)
 
-        if response.status_code == 413:
+        if response.status_code in (413, 414):
             raise RequestEntitySizeExceeded(url)
 
         if has_json_content_type(response):

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -242,6 +242,37 @@ def _get_files_for_parsing(file_paths: List[PathLike]) -> List[Path]:
     return [file for files in packed_files for file in files]
 
 
+def _chunk_filenames_for_url(
+    filenames: Iterable[str], max_items_per_chunk: Optional[int] = None
+) -> Generator[List[str], None, None]:
+    if max_items_per_chunk is not None and max_items_per_chunk <= 0:
+        raise ValueError("max_items_per_chunk must be greater than 0")
+
+    current_chunk: List[str] = []
+    current_length = BASE_URL_LENGTH
+
+    for filename in filenames:
+        filename_length = len(filename) + FILENAME_OVERHEAD
+        exceeds_item_limit = (
+            max_items_per_chunk is not None
+            and len(current_chunk) >= max_items_per_chunk
+        )
+        exceeds_url_limit = (
+            current_chunk and current_length + filename_length > MAX_URL_LENGTH
+        )
+
+        if exceeds_item_limit or exceeds_url_limit:
+            yield current_chunk
+            current_chunk = []
+            current_length = BASE_URL_LENGTH
+
+        current_chunk.append(filename)
+        current_length += filename_length
+
+    if current_chunk:
+        yield current_chunk
+
+
 def _build_attribute_lookup(dataset: "RemoteDataset") -> Dict[str, Unknown]:
     attributes: List[Dict[str, Unknown]] = dataset.fetch_remote_attributes()
     lookup: Dict[str, Unknown] = {}
@@ -283,8 +314,7 @@ def _get_remote_files_ready_for_import(
     """
     remote_files = {}
     remote_files_not_ready_for_import = {}
-    for i in range(0, len(filenames), chunk_size):
-        chunk = filenames[i : i + chunk_size]
+    for chunk in _chunk_filenames_for_url(filenames, chunk_size):
         for remote_file in dataset.fetch_remote_files(
             {"types": "image,playback_video,video_frame", "item_names": chunk}
         ):
@@ -2694,24 +2724,7 @@ def _get_remote_files_targeted_by_import(
     remote_filepaths = [file.full_path for file in maybe_parsed_files]
 
     all_remote_files: List[DatasetItem] = []
-    current_chunk: List[str] = []
-    current_length = BASE_URL_LENGTH
-    max_chunk_length = MAX_URL_LENGTH - BASE_URL_LENGTH
-
-    for filename in remote_filenames:
-        filename_length = len(filename) + FILENAME_OVERHEAD
-        if current_length + filename_length > max_chunk_length and current_chunk:
-            remote_files = dataset.fetch_remote_files(
-                filters={"item_names": current_chunk}
-            )
-            all_remote_files.extend(remote_files)
-            current_chunk = []
-            current_length = BASE_URL_LENGTH
-
-        current_chunk.append(filename)
-        current_length += filename_length
-
-    if current_chunk:
+    for current_chunk in _chunk_filenames_for_url(remote_filenames):
         remote_files = dataset.fetch_remote_files(filters={"item_names": current_chunk})
         all_remote_files.extend(remote_files)
 

--- a/darwin/importer/importer.py
+++ b/darwin/importer/importer.py
@@ -242,37 +242,6 @@ def _get_files_for_parsing(file_paths: List[PathLike]) -> List[Path]:
     return [file for files in packed_files for file in files]
 
 
-def _chunk_filenames_for_url(
-    filenames: Iterable[str], max_items_per_chunk: Optional[int] = None
-) -> Generator[List[str], None, None]:
-    if max_items_per_chunk is not None and max_items_per_chunk <= 0:
-        raise ValueError("max_items_per_chunk must be greater than 0")
-
-    current_chunk: List[str] = []
-    current_length = BASE_URL_LENGTH
-
-    for filename in filenames:
-        filename_length = len(filename) + FILENAME_OVERHEAD
-        exceeds_item_limit = (
-            max_items_per_chunk is not None
-            and len(current_chunk) >= max_items_per_chunk
-        )
-        exceeds_url_limit = (
-            current_chunk and current_length + filename_length > MAX_URL_LENGTH
-        )
-
-        if exceeds_item_limit or exceeds_url_limit:
-            yield current_chunk
-            current_chunk = []
-            current_length = BASE_URL_LENGTH
-
-        current_chunk.append(filename)
-        current_length += filename_length
-
-    if current_chunk:
-        yield current_chunk
-
-
 def _build_attribute_lookup(dataset: "RemoteDataset") -> Dict[str, Unknown]:
     attributes: List[Dict[str, Unknown]] = dataset.fetch_remote_attributes()
     lookup: Dict[str, Unknown] = {}
@@ -314,7 +283,8 @@ def _get_remote_files_ready_for_import(
     """
     remote_files = {}
     remote_files_not_ready_for_import = {}
-    for chunk in _chunk_filenames_for_url(filenames, chunk_size):
+    for i in range(0, len(filenames), chunk_size):
+        chunk = filenames[i : i + chunk_size]
         for remote_file in dataset.fetch_remote_files(
             {"types": "image,playback_video,video_frame", "item_names": chunk}
         ):
@@ -2724,7 +2694,24 @@ def _get_remote_files_targeted_by_import(
     remote_filepaths = [file.full_path for file in maybe_parsed_files]
 
     all_remote_files: List[DatasetItem] = []
-    for current_chunk in _chunk_filenames_for_url(remote_filenames):
+    current_chunk: List[str] = []
+    current_length = BASE_URL_LENGTH
+    max_chunk_length = MAX_URL_LENGTH - BASE_URL_LENGTH
+
+    for filename in remote_filenames:
+        filename_length = len(filename) + FILENAME_OVERHEAD
+        if current_length + filename_length > max_chunk_length and current_chunk:
+            remote_files = dataset.fetch_remote_files(
+                filters={"item_names": current_chunk}
+            )
+            all_remote_files.extend(remote_files)
+            current_chunk = []
+            current_length = BASE_URL_LENGTH
+
+        current_chunk.append(filename)
+        current_length += filename_length
+
+    if current_chunk:
         remote_files = dataset.fetch_remote_files(filters={"item_names": current_chunk})
         all_remote_files.extend(remote_files)
 

--- a/tests/darwin/client_test.py
+++ b/tests/darwin/client_test.py
@@ -20,7 +20,7 @@ from darwin.config import Config
 from darwin.dataset.remote_dataset import RemoteDataset
 from darwin.dataset.remote_dataset_v2 import RemoteDatasetV2
 from darwin.datatypes import Feature, JSONFreeForm, ObjectStore
-from darwin.exceptions import NameTaken, NotFound
+from darwin.exceptions import NameTaken, NotFound, RequestEntitySizeExceeded
 from darwin.future.data_objects.properties import FullProperty
 from darwin.future.tests.core.fixtures import *  # noqa: F401, F403
 from tests.fixtures import *  # noqa: F401, F403
@@ -38,6 +38,17 @@ def darwin_client(
         ["teams", team_slug_darwin_json_v2, "datasets_dir"], str(darwin_datasets_path)
     )
     return Client(config)
+
+
+@pytest.mark.usefixtures("file_read_write_test")
+def test__raise_if_known_error_maps_414_to_request_entity_size_exceeded(
+    darwin_client: Client,
+) -> None:
+    response = Response()
+    response.status_code = 414
+
+    with pytest.raises(RequestEntitySizeExceeded):
+        darwin_client._raise_if_known_error(response, "http://localhost/api/items")
 
 
 @pytest.mark.usefixtures("file_read_write_test")

--- a/tests/darwin/importer/importer_test.py
+++ b/tests/darwin/importer/importer_test.py
@@ -20,6 +20,7 @@ from darwin.future.data_objects.properties import (
 from darwin.importer import get_importer
 from darwin.importer.importer import (
     BASE_URL_LENGTH,
+    FILENAME_OVERHEAD,
     MAX_URL_LENGTH,
     _assign_item_properties_to_dataset,
     _build_attribute_lookup,
@@ -314,6 +315,45 @@ def test__get_remote_files_ready_for_import_succeeds() -> None:
         result = _get_remote_files_ready_for_import(mock_dataset, filenames)
         assert result == expected_result
         assert mock_get_slot_names.call_count == 5
+
+
+def test__get_remote_files_ready_for_import_chunks_long_filenames_by_url_length() -> (
+    None
+):
+    mock_dataset = Mock()
+    filenames = [
+        f"{index:04d}-00494c6f-05a3-4342-a2a9-676998ec9e42-LA2695-2026-06-16T17:57:23.780Z.png"
+        for index in range(513)
+    ]
+
+    def fetch_remote_files(filters):
+        chunk = filters["item_names"]
+        return [
+            Mock(
+                full_path=filename,
+                id=f"{filename}_id",
+                layout=None,
+                slots=[],
+                status="new",
+            )
+            for filename in chunk
+        ]
+
+    mock_dataset.fetch_remote_files.side_effect = fetch_remote_files
+
+    result = _get_remote_files_ready_for_import(mock_dataset, filenames)
+
+    assert len(result) == 513
+    assert mock_dataset.fetch_remote_files.call_count > 1
+    for call in mock_dataset.fetch_remote_files.call_args_list:
+        filters = call.args[0]
+        chunk = filters["item_names"]
+        chunk_url_length = BASE_URL_LENGTH + sum(
+            len(filename) + FILENAME_OVERHEAD for filename in chunk
+        )
+        assert filters["types"] == "image,playback_video,video_frame"
+        assert len(chunk) <= 100
+        assert chunk_url_length <= MAX_URL_LENGTH
 
 
 def test__get_remote_files_ready_for_import_defaults_layout_for_multislot() -> None:

--- a/tests/darwin/importer/importer_test.py
+++ b/tests/darwin/importer/importer_test.py
@@ -322,7 +322,10 @@ def test__get_remote_files_ready_for_import_chunks_long_filenames_by_url_length(
 ):
     mock_dataset = Mock()
     filenames = [
-        f"{index:04d}-00494c6f-05a3-4342-a2a9-676998ec9e42-LA2695-2026-06-16T17:57:23.780Z.png"
+        (
+            f"{index:04d}-00494c6f-05a3-4342-a2a9-676998ec9e42-"
+            "LA2695-2026-06-16T17:57:23.780Z.png"
+        )
         for index in range(513)
     ]
 

--- a/tests/darwin/importer/importer_test.py
+++ b/tests/darwin/importer/importer_test.py
@@ -628,8 +628,7 @@ def test_properties_import_is_always_synchronous():
 
 def test_import_annotations_retries_remote_file_lookup_with_smaller_chunks() -> None:
     filename = (
-        "00494c6f-05a3-4342-a2a9-676998ec9e42-"
-        "LA2695-2026-06-16T17:57:23.780Z.png"
+        "00494c6f-05a3-4342-a2a9-676998ec9e42-" "LA2695-2026-06-16T17:57:23.780Z.png"
     )
     annotation_file = dt.AnnotationFile(
         path=Path("prelabel.json"),

--- a/tests/darwin/importer/importer_test.py
+++ b/tests/darwin/importer/importer_test.py
@@ -20,7 +20,6 @@ from darwin.future.data_objects.properties import (
 from darwin.importer import get_importer
 from darwin.importer.importer import (
     BASE_URL_LENGTH,
-    FILENAME_OVERHEAD,
     MAX_URL_LENGTH,
     _assign_item_properties_to_dataset,
     _build_attribute_lookup,
@@ -315,48 +314,6 @@ def test__get_remote_files_ready_for_import_succeeds() -> None:
         result = _get_remote_files_ready_for_import(mock_dataset, filenames)
         assert result == expected_result
         assert mock_get_slot_names.call_count == 5
-
-
-def test__get_remote_files_ready_for_import_chunks_long_filenames_by_url_length() -> (
-    None
-):
-    mock_dataset = Mock()
-    filenames = [
-        (
-            f"{index:04d}-00494c6f-05a3-4342-a2a9-676998ec9e42-"
-            "LA2695-2026-06-16T17:57:23.780Z.png"
-        )
-        for index in range(513)
-    ]
-
-    def fetch_remote_files(filters):
-        chunk = filters["item_names"]
-        return [
-            Mock(
-                full_path=filename,
-                id=f"{filename}_id",
-                layout=None,
-                slots=[],
-                status="new",
-            )
-            for filename in chunk
-        ]
-
-    mock_dataset.fetch_remote_files.side_effect = fetch_remote_files
-
-    result = _get_remote_files_ready_for_import(mock_dataset, filenames)
-
-    assert len(result) == 513
-    assert mock_dataset.fetch_remote_files.call_count > 1
-    for call in mock_dataset.fetch_remote_files.call_args_list:
-        filters = call.args[0]
-        chunk = filters["item_names"]
-        chunk_url_length = BASE_URL_LENGTH + sum(
-            len(filename) + FILENAME_OVERHEAD for filename in chunk
-        )
-        assert filters["types"] == "image,playback_video,video_frame"
-        assert len(chunk) <= 100
-        assert chunk_url_length <= MAX_URL_LENGTH
 
 
 def test__get_remote_files_ready_for_import_defaults_layout_for_multislot() -> None:
@@ -667,6 +624,77 @@ def test_properties_import_is_always_synchronous():
 
         mock_submit.assert_called_once()
         assert mock_submit.mock_calls[-1].args[2].__name__ == "import_annotation"
+
+
+def test_import_annotations_retries_remote_file_lookup_with_smaller_chunks() -> None:
+    filename = (
+        "00494c6f-05a3-4342-a2a9-676998ec9e42-"
+        "LA2695-2026-06-16T17:57:23.780Z.png"
+    )
+    annotation_file = dt.AnnotationFile(
+        path=Path("prelabel.json"),
+        filename=filename,
+        annotation_classes=set(),
+        annotations=[],
+        remote_path="/",
+    )
+    remote_file_lookup = {
+        annotation_file.full_path: {
+            "item_id": "item_id",
+            "slot_names": ["0"],
+            "layout": None,
+        }
+    }
+
+    dataset = Mock()
+    dataset.version = 2
+    dataset.team = "test_team"
+    dataset.identifier = "test_team/test_dataset"
+    dataset.client = Mock()
+    dataset.fetch_remote_classes.return_value = [
+        {
+            "id": "global_class_id",
+            "name": "__raster_layer__",
+            "available": True,
+            "annotation_types": ["raster_layer"],
+        }
+    ]
+    dataset.fetch_remote_attributes.return_value = []
+
+    importer = Mock()
+    importer.__module__ = "darwin.importer.formats.coco"
+
+    team_property_lookups = Mock()
+    team_property_lookups.item_properties = {}
+
+    with (
+        patch(
+            "darwin.importer.importer._get_remote_files_targeted_by_import",
+            return_value=[],
+        ),
+        patch("darwin.importer.importer._find_and_parse") as find_and_parse,
+        patch(
+            "darwin.importer.importer._get_remote_files_ready_for_import",
+            side_effect=[RequestEntitySizeExceeded(), remote_file_lookup],
+        ) as get_remote_files_ready_for_import,
+        patch(
+            "darwin.importer.importer.TeamPropertyLookups.from_team",
+            return_value=team_property_lookups,
+        ),
+    ):
+        find_and_parse.return_value = [annotation_file]
+
+        import_annotations(
+            dataset=dataset,
+            importer=importer,
+            file_paths=[Path("prelabel.json")],
+            append=True,
+            use_multi_cpu=False,
+        )
+
+    assert [
+        call.args[2] for call in get_remote_files_ready_for_import.call_args_list
+    ] == [100, 92]
 
 
 def test__is_skeleton_class() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Problem
`darwin dataset import` can fail for COCO files with hundreds of long image filenames because item lookup requests can exceed URL limits and receive HTTP 414. The importer already has retry logic that reduces the remote-file lookup chunk size when `RequestEntitySizeExceeded` is raised, but the client only mapped HTTP 413 to that exception.

# Solution
- Map HTTP 414 to `RequestEntitySizeExceeded`, matching existing HTTP 413 behavior.
- Leave the importer chunking/retry implementation unchanged so the existing smaller-chunk retry path handles long filename batches.
- Add focused regression coverage for 414 error mapping and the existing importer retry behavior.

# Changelog
Fix COCO annotation imports for datasets containing many long item names by treating HTTP 414 as the existing retryable request-size error.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DAR-7917](https://linear.app/v7labs/issue/DAR-7917/bug-darwin-py-coco-import-fails-with-http-414-when-matching-items-by)

<div><a href="https://cursor.com/agents/bc-aa788b19-ccb6-464d-a362-13857ec3d722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa788b19-ccb6-464d-a362-13857ec3d722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

