### PR TITLE
fix(properties): accept audio property type when listing team properties

### DIFF
--- a/darwin/future/data_objects/properties.py
+++ b/darwin/future/data_objects/properties.py
@@ -14,6 +14,7 @@ PropertyType = Literal[
     "multi_select",
     "single_select",
     "text",
+    "audio",
     "attributes",
     "instance_id",
     "directional_vector",

--- a/darwin/future/tests/core/properties/test_get.py
+++ b/darwin/future/tests/core/properties/test_get.py
@@ -37,6 +37,32 @@ def test_get_team_properties(
 
 
 @responses.activate
+def test_get_team_properties_parses_audio_type(
+    base_client: ClientCore, base_property_object: FullProperty
+) -> None:
+    # Regression: a team with an `audio` property must not break listing team
+    # properties (which every darwin-py annotation import does via
+    # TeamPropertyLookups.from_team). Reproduces the ValidationError customers
+    # hit once an audio class exists in the workspace.
+    audio_property = base_property_object.model_copy(deep=True)
+    audio_property.type = "audio"
+    audio_property.options = None
+    audio_property.property_values = None
+    response_data = {"properties": [audio_property.model_dump(mode="json")]}
+    responses.add(
+        responses.GET,
+        f"{base_client.config.base_url}api/v2/teams/{base_client.config.default_team}/properties",
+        json=response_data,
+        status=200,
+    )
+
+    properties = get_team_properties(base_client)
+
+    assert len(properties) == 1
+    assert properties[0].type == "audio"
+
+
+@responses.activate
 def test_get_team_full_properties(
     base_client: ClientCore, base_property_object: FullProperty
 ) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = "MIT"
 name = "darwin-py"
 readme = "README.md"
 repository = "https://github.com/v7labs/darwin-py"
-version = "3.5.3"
+version = "3.5.4"
 [[tool.poetry.packages]]
 include = "darwin"
 


### PR DESCRIPTION
## Problem

A customer hit this `ValidationError` running `darwin dataset import` (bbox annotations — unrelated to audio) once their workspace contained an **audio** class:

```
ValidationError: 1 validation error for FullProperty
type
  Input should be 'multi_select', 'single_select', 'text', 'attributes', 'instance_id' or
  'directional_vector' [type=literal_error, input_value='audio', input_type=str]
```

Every darwin-py annotation import calls `TeamPropertyLookups.from_team` → `get_team_properties` → `GET /v2/teams/:slug/properties`, then validates each property with `FullProperty.model_validate`. The new **audio item-level property type** (v7labs/darwin-backend#6209 / v7labs/darwin-frontend#10068) makes the backend return `type: "audio"`, which `FullProperty.type`'s `PropertyType` Literal didn't include — so listing team properties raised, and **all imports for that team broke**, regardless of what was being imported.

This is impactful for teams that import large volumes of pre-annotations (e.g. Helsing) and also create audio classes.

## Fix

Add `"audio"` to the `PropertyType` Literal in `darwin/future/data_objects/properties.py`.

## Testing (TDD)

- Added `test_get_team_properties_parses_audio_type` reproducing the exact failing path (`get_team_properties` returning a `type: "audio"` property). Confirmed **RED** before the fix (same `ValidationError`) → **GREEN** after.
- Full `darwin/future/tests/core/properties/` suite green (8 passed); importer property tests green (14 passed). `black`/`ruff` clean on changed files.

## Note (separate, pre-existing)

`PropertyType` also omits `"boolean"`, though the backend supports boolean properties — so a team with a boolean property would hit the same crash. Not addressed here to keep this fix scoped to the reported audio regression; worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Linear: DAR-7928 (related: DAR-7921)