### PR TITLE
feat(coco): export raster mask annotations as COCO RLE instances (DAR-7915)

### DIFF
--- a/darwin/exporter/formats/coco.py
+++ b/darwin/exporter/formats/coco.py
@@ -1,7 +1,7 @@
 from datetime import date
 from operator import itemgetter
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 from zlib import crc32
 
 import numpy as np
@@ -160,11 +160,25 @@ def _build_annotations(
 ) -> Iterator[Optional[Dict[str, Any]]]:
     annotation_id = 0
     for annotation_file in annotation_files:
+        raster_context = _build_raster_context(annotation_file)
         for annotation in annotation_file.annotations:
+            annotation_type = annotation.annotation_class.annotation_type
+            if annotation_type == "raster_layer":
+                # Raster layers are exported through their mask annotations.
+                continue
             annotation_id += 1
-            annotation_data = _build_annotation(
-                annotation_file, annotation_id, annotation, categories
-            )
+            if annotation_type == "mask":
+                annotation_data = _build_mask_annotation(
+                    annotation_file,
+                    annotation_id,
+                    annotation,
+                    categories,
+                    raster_context,
+                )
+            else:
+                annotation_data = _build_annotation(
+                    annotation_file, annotation_id, annotation, categories
+                )
             if annotation_data:
                 yield annotation_data
 
@@ -261,6 +275,81 @@ def _build_annotation(
         )
     else:
         print(f"skipping unsupported annotation_type '{annotation_type}'")
+
+
+def _build_raster_context(
+    annotation_file: dt.AnnotationFile,
+) -> Dict[str, Tuple[np.ndarray, int]]:
+    """
+    Maps each mask annotation id to its decoded raster label map and pixel label.
+
+    Each ``raster_layer`` in the file is decoded exactly once into a 2D array of
+    per-pixel labels; ``mask_annotation_ids_mapping`` ties mask annotation ids to
+    those labels.
+    """
+    context: Dict[str, Tuple[np.ndarray, int]] = {}
+    height = annotation_file.image_height
+    width = annotation_file.image_width
+    for annotation in annotation_file.annotations:
+        if annotation.annotation_class.annotation_type != "raster_layer":
+            continue
+        if isinstance(annotation, dt.VideoAnnotation):
+            print("skipping video raster_layer annotation")
+            continue
+        if not height or not width:
+            print(
+                f"skipping raster_layer in '{annotation_file.filename}': unknown image dimensions"
+            )
+            continue
+        dense_rle = annotation.data["dense_rle"]
+        values = np.array(dense_rle[0::2], dtype=np.int32)
+        counts = np.array(dense_rle[1::2], dtype=np.int64)
+        labels = np.repeat(values, counts)
+        if labels.size != height * width:
+            print(
+                f"skipping raster_layer in '{annotation_file.filename}': dense_rle covers "
+                f"{labels.size} pixels, expected {height * width}"
+            )
+            continue
+        label_map = labels.reshape(height, width)
+        for mask_id, label in annotation.data["mask_annotation_ids_mapping"].items():
+            context[mask_id] = (label_map, int(label))
+    return context
+
+
+def _build_mask_annotation(
+    annotation_file: dt.AnnotationFile,
+    annotation_id: int,
+    annotation: dt.Annotation,
+    categories: Dict[str, int],
+    raster_context: Dict[str, Tuple[np.ndarray, int]],
+) -> Optional[Dict[str, Any]]:
+    if annotation.id not in raster_context:
+        print(
+            f"skipping mask annotation '{annotation.id}' with no raster_layer coverage"
+        )
+        return None
+    label_map, label = raster_context[annotation.id]
+    binary_mask = (label_map == label).astype(np.uint8)
+    ys, xs = np.nonzero(binary_mask)
+    if xs.size == 0:
+        print(f"skipping empty mask annotation '{annotation.id}'")
+        return None
+    min_x, min_y = int(xs.min()), int(ys.min())
+    max_x, max_y = int(xs.max()), int(ys.max())
+    return {
+        "id": annotation_id,
+        "image_id": _build_image_id(annotation_file),
+        "category_id": categories[annotation.annotation_class.name],
+        "segmentation": {
+            "counts": rle_encode(binary_mask),
+            "size": [annotation_file.image_height, annotation_file.image_width],
+        },
+        "area": int(binary_mask.sum()),
+        "bbox": [min_x, min_y, max_x - min_x + 1, max_y - min_y + 1],
+        "iscrowd": 0,
+        "extra": _build_extra(annotation),
+    }
 
 
 def _build_extra(annotation: dt.Annotation) -> Dict[str, Any]:

--- a/darwin/exporter/formats/coco.py
+++ b/darwin/exporter/formats/coco.py
@@ -301,7 +301,22 @@ def _build_raster_context(
                 f"skipping raster_layer in '{annotation_file.filename}': unknown image dimensions"
             )
             continue
-        dense_rle = annotation.data["dense_rle"]
+        dense_rle = annotation.data.get("dense_rle")
+        mask_annotation_ids_mapping = annotation.data.get(
+            "mask_annotation_ids_mapping"
+        )
+        if dense_rle is None or mask_annotation_ids_mapping is None:
+            print(
+                f"skipping raster_layer in '{annotation_file.filename}': missing "
+                "dense_rle or mask_annotation_ids_mapping"
+            )
+            continue
+        if len(dense_rle) % 2 != 0:
+            print(
+                f"skipping raster_layer in '{annotation_file.filename}': dense_rle has "
+                "odd length"
+            )
+            continue
         values = np.array(dense_rle[0::2], dtype=np.int32)
         counts = np.array(dense_rle[1::2], dtype=np.int64)
         labels = np.repeat(values, counts)
@@ -312,7 +327,7 @@ def _build_raster_context(
             )
             continue
         label_map = labels.reshape(height, width)
-        for mask_id, label in annotation.data["mask_annotation_ids_mapping"].items():
+        for mask_id, label in mask_annotation_ids_mapping.items():
             context[mask_id] = (label_map, int(label))
     return context
 

--- a/darwin/exporter/formats/coco.py
+++ b/darwin/exporter/formats/coco.py
@@ -63,6 +63,7 @@ def _calculate_categories(annotation_files: List[dt.AnnotationFile]) -> Dict[str
                 in [
                     "polygon",
                     "bounding_box",
+                    "mask",
                 ]
             ):
                 categories[annotation_class.name] = _calculate_category_id(

--- a/darwin/exporter/formats/coco.py
+++ b/darwin/exporter/formats/coco.py
@@ -303,10 +303,16 @@ def _build_raster_context(
             continue
         dense_rle = annotation.data.get("dense_rle")
         mask_annotation_ids_mapping = annotation.data.get("mask_annotation_ids_mapping")
-        if dense_rle is None or mask_annotation_ids_mapping is None:
+        if dense_rle is None:
             print(
                 f"skipping raster_layer in '{annotation_file.filename}': missing "
-                "dense_rle or mask_annotation_ids_mapping"
+                "dense_rle"
+            )
+            continue
+        if mask_annotation_ids_mapping is None:
+            print(
+                f"skipping raster_layer in '{annotation_file.filename}': missing "
+                "mask_annotation_ids_mapping"
             )
             continue
         if len(dense_rle) % 2 != 0:
@@ -315,9 +321,15 @@ def _build_raster_context(
                 "odd length"
             )
             continue
-        values = np.array(dense_rle[0::2], dtype=np.int32)
-        counts = np.array(dense_rle[1::2], dtype=np.int64)
-        labels = np.repeat(values, counts)
+        try:
+            values = np.array(dense_rle[0::2], dtype=np.int32)
+            counts = np.array(dense_rle[1::2], dtype=np.int64)
+            labels = np.repeat(values, counts)
+        except (ValueError, TypeError):
+            print(
+                f"skipping raster_layer in '{annotation_file.filename}': invalid dense_rle"
+            )
+            continue
         if labels.size != height * width:
             print(
                 f"skipping raster_layer in '{annotation_file.filename}': dense_rle covers "

--- a/darwin/exporter/formats/coco.py
+++ b/darwin/exporter/formats/coco.py
@@ -302,9 +302,7 @@ def _build_raster_context(
             )
             continue
         dense_rle = annotation.data.get("dense_rle")
-        mask_annotation_ids_mapping = annotation.data.get(
-            "mask_annotation_ids_mapping"
-        )
+        mask_annotation_ids_mapping = annotation.data.get("mask_annotation_ids_mapping")
         if dense_rle is None or mask_annotation_ids_mapping is None:
             print(
                 f"skipping raster_layer in '{annotation_file.filename}': missing "

--- a/tests/darwin/exporter/formats/export_coco_test.py
+++ b/tests/darwin/exporter/formats/export_coco_test.py
@@ -242,6 +242,35 @@ class TestBuildRasterAnnotations:
 
         assert annotations == []
 
+    def test_raster_layer_with_negative_count_dense_rle_is_skipped(self):
+        mask_cat = dt.Annotation(dt.AnnotationClass("cat", "mask"), {}, [], id="uuid-1")
+        raster_layer = dt.Annotation(
+            dt.AnnotationClass("__raster_layer__", "raster_layer"),
+            {
+                "dense_rle": [0, -1, 1, 13],
+                "mask_annotation_ids_mapping": {"uuid-1": 1},
+                "total_pixels": 12,
+            },
+            [],
+            id="uuid-raster",
+        )
+        annotation_file = dt.AnnotationFile(
+            path=Path("test.json"),
+            filename="test.json",
+            annotation_classes={
+                dt.AnnotationClass("cat", "mask"),
+                dt.AnnotationClass("__raster_layer__", "raster_layer"),
+            },
+            annotations=[mask_cat, raster_layer],
+            image_height=3,
+            image_width=4,
+        )
+        categories = coco._calculate_categories([annotation_file])
+
+        annotations = list(coco._build_annotations([annotation_file], categories))
+
+        assert annotations == []
+
 
 class TestRasterMaskEndToEnd:
     def test_darwin_json_to_coco_export_cycle(self, tmp_path: Path):
@@ -287,6 +316,9 @@ class TestRasterMaskEndToEnd:
         assert result["images"][0]["height"] == 3
         assert result["images"][0]["width"] == 4
 
+        # Safe to key by first RLE count: cat's first count (3) and dog's
+        # first count (1) differ in this fixture, so each maps to exactly
+        # one annotation.
         by_first_count = {
             a["segmentation"]["counts"][0]: a for a in result["annotations"]
         }
@@ -300,3 +332,4 @@ class TestRasterMaskEndToEnd:
         assert dog_ann["segmentation"] == {"counts": [1, 2, 2, 1, 6], "size": [3, 4]}
         assert dog_ann["bbox"] == [0, 1, 2, 2]
         assert dog_ann["area"] == 3
+        assert dog_ann["iscrowd"] == 0

--- a/tests/darwin/exporter/formats/export_coco_test.py
+++ b/tests/darwin/exporter/formats/export_coco_test.py
@@ -190,3 +190,64 @@ class TestBuildRasterAnnotations:
         assert {c["name"] for c in output["categories"]} == {"cat", "dog"}
         assert len(output["annotations"]) == 2
         assert len(output["images"]) == 1
+
+    def test_raster_layer_with_odd_length_dense_rle_is_skipped(self):
+        mask_cat = dt.Annotation(
+            dt.AnnotationClass("cat", "mask"), {}, [], id="uuid-1"
+        )
+        raster_layer = dt.Annotation(
+            dt.AnnotationClass("__raster_layer__", "raster_layer"),
+            {
+                "dense_rle": [0, 1, 1, 2, 3],
+                "mask_annotation_ids_mapping": {"uuid-1": 1},
+                "total_pixels": 12,
+            },
+            [],
+            id="uuid-raster",
+        )
+        annotation_file = dt.AnnotationFile(
+            path=Path("test.json"),
+            filename="test.json",
+            annotation_classes={
+                dt.AnnotationClass("cat", "mask"),
+                dt.AnnotationClass("__raster_layer__", "raster_layer"),
+            },
+            annotations=[mask_cat, raster_layer],
+            image_height=3,
+            image_width=4,
+        )
+        categories = coco._calculate_categories([annotation_file])
+
+        annotations = list(coco._build_annotations([annotation_file], categories))
+
+        assert annotations == []
+
+    def test_raster_layer_missing_dense_rle_is_skipped(self):
+        mask_cat = dt.Annotation(
+            dt.AnnotationClass("cat", "mask"), {}, [], id="uuid-1"
+        )
+        raster_layer = dt.Annotation(
+            dt.AnnotationClass("__raster_layer__", "raster_layer"),
+            {
+                "mask_annotation_ids_mapping": {"uuid-1": 1},
+                "total_pixels": 12,
+            },
+            [],
+            id="uuid-raster",
+        )
+        annotation_file = dt.AnnotationFile(
+            path=Path("test.json"),
+            filename="test.json",
+            annotation_classes={
+                dt.AnnotationClass("cat", "mask"),
+                dt.AnnotationClass("__raster_layer__", "raster_layer"),
+            },
+            annotations=[mask_cat, raster_layer],
+            image_height=3,
+            image_width=4,
+        )
+        categories = coco._calculate_categories([annotation_file])
+
+        annotations = list(coco._build_annotations([annotation_file], categories))
+
+        assert annotations == []

--- a/tests/darwin/exporter/formats/export_coco_test.py
+++ b/tests/darwin/exporter/formats/export_coco_test.py
@@ -6,6 +6,27 @@ import darwin.datatypes as dt
 from darwin.exporter.formats import coco
 
 
+class TestCalculateCategories:
+    def test_includes_mask_classes_but_not_raster_layer(self):
+        annotation_file = dt.AnnotationFile(
+            path=Path("test.json"),
+            filename="test.json",
+            annotation_classes={
+                dt.AnnotationClass("cat", "mask"),
+                dt.AnnotationClass("box", "bounding_box"),
+                dt.AnnotationClass("__raster_layer__", "raster_layer"),
+                dt.AnnotationClass("label", "tag"),
+            },
+            annotations=[],
+            image_height=3,
+            image_width=4,
+        )
+
+        categories = coco._calculate_categories([annotation_file])
+
+        assert set(categories.keys()) == {"cat", "box"}
+
+
 class TestBuildAnnotations:
     @pytest.fixture
     def annotation_file(self) -> dt.AnnotationFile:

--- a/tests/darwin/exporter/formats/export_coco_test.py
+++ b/tests/darwin/exporter/formats/export_coco_test.py
@@ -1,8 +1,10 @@
+import json
 from pathlib import Path
 
 import pytest
 
 import darwin.datatypes as dt
+from darwin.exporter import exporter
 from darwin.exporter.formats import coco
 
 
@@ -251,3 +253,64 @@ class TestBuildRasterAnnotations:
         annotations = list(coco._build_annotations([annotation_file], categories))
 
         assert annotations == []
+
+
+class TestRasterMaskEndToEnd:
+    def test_darwin_json_to_coco_export_cycle(self, tmp_path: Path):
+        darwin_json = {
+            "version": "2.0",
+            "schema_ref": "https://darwin-public.s3.eu-west-1.amazonaws.com/darwin_json/2.0/schema.json",
+            "item": {
+                "name": "test.png",
+                "path": "/",
+                "slots": [
+                    {"type": "image", "slot_name": "0", "width": 4, "height": 3}
+                ],
+            },
+            "annotations": [
+                {"id": "uuid-1", "name": "cat", "slot_names": ["0"], "mask": {}},
+                {"id": "uuid-2", "name": "dog", "slot_names": ["0"], "mask": {}},
+                {
+                    "id": "uuid-raster",
+                    "name": "__raster_layer__",
+                    "slot_names": ["0"],
+                    "raster_layer": {
+                        "dense_rle": [0, 1, 1, 2, 0, 1, 2, 1, 1, 1, 0, 2, 2, 2, 0, 2],
+                        "mask_annotation_ids_mapping": {"uuid-1": 1, "uuid-2": 2},
+                        "total_pixels": 12,
+                    },
+                },
+            ],
+        }
+        src = tmp_path / "annotations"
+        out = tmp_path / "out"
+        src.mkdir()
+        out.mkdir()
+        (src / "test.json").write_text(json.dumps(darwin_json))
+
+        dt_gen = exporter.darwin_to_dt_gen(
+            list(src.glob("*.json")), split_sequences=False
+        )
+        coco.export(dt_gen, out)
+
+        result = json.loads((out / "output.json").read_text())
+
+        assert {c["name"] for c in result["categories"]} == {"cat", "dog"}
+        assert len(result["annotations"]) == 2
+        assert len(result["images"]) == 1
+        assert result["images"][0]["height"] == 3
+        assert result["images"][0]["width"] == 4
+
+        by_first_count = {
+            a["segmentation"]["counts"][0]: a for a in result["annotations"]
+        }
+        cat_ann = by_first_count[3]
+        assert cat_ann["segmentation"] == {"counts": [3, 2, 1, 1, 5], "size": [3, 4]}
+        assert cat_ann["bbox"] == [1, 0, 2, 2]
+        assert cat_ann["area"] == 3
+        assert cat_ann["iscrowd"] == 0
+
+        dog_ann = by_first_count[1]
+        assert dog_ann["segmentation"] == {"counts": [1, 2, 2, 1, 6], "size": [3, 4]}
+        assert dog_ann["bbox"] == [0, 1, 2, 2]
+        assert dog_ann["area"] == 3

--- a/tests/darwin/exporter/formats/export_coco_test.py
+++ b/tests/darwin/exporter/formats/export_coco_test.py
@@ -92,3 +92,101 @@ class TestBuildAnnotations:
         assert coco._build_annotation(annotation_file, "test-id", bbox, categories)[
             "extra"
         ] == {"instance_id": 1}
+
+
+class TestBuildRasterAnnotations:
+    @pytest.fixture
+    def raster_annotation_file(self) -> dt.AnnotationFile:
+        mask_cat = dt.Annotation(
+            dt.AnnotationClass("cat", "mask"), {}, [], id="uuid-1"
+        )
+        mask_dog = dt.Annotation(
+            dt.AnnotationClass("dog", "mask"), {}, [], id="uuid-2"
+        )
+        raster_layer = dt.Annotation(
+            dt.AnnotationClass("__raster_layer__", "raster_layer"),
+            {
+                "dense_rle": [0, 1, 1, 2, 0, 1, 2, 1, 1, 1, 0, 2, 2, 2, 0, 2],
+                "mask_annotation_ids_mapping": {"uuid-1": 1, "uuid-2": 2},
+                "total_pixels": 12,
+            },
+            [],
+            id="uuid-raster",
+        )
+        return dt.AnnotationFile(
+            path=Path("test.json"),
+            filename="test.json",
+            annotation_classes={
+                dt.AnnotationClass("cat", "mask"),
+                dt.AnnotationClass("dog", "mask"),
+                dt.AnnotationClass("__raster_layer__", "raster_layer"),
+            },
+            annotations=[mask_cat, mask_dog, raster_layer],
+            image_height=3,
+            image_width=4,
+        )
+
+    def test_exports_one_coco_annotation_per_mask_instance(
+        self, raster_annotation_file: dt.AnnotationFile
+    ):
+        categories = coco._calculate_categories([raster_annotation_file])
+        annotations = list(
+            coco._build_annotations([raster_annotation_file], categories)
+        )
+
+        assert len(annotations) == 2
+
+        cat_ann = next(
+            a for a in annotations if a["category_id"] == categories["cat"]
+        )
+        assert cat_ann["segmentation"] == {"counts": [3, 2, 1, 1, 5], "size": [3, 4]}
+        assert cat_ann["bbox"] == [1, 0, 2, 2]
+        assert cat_ann["area"] == 3
+        assert cat_ann["iscrowd"] == 0
+
+        dog_ann = next(
+            a for a in annotations if a["category_id"] == categories["dog"]
+        )
+        assert dog_ann["segmentation"] == {"counts": [1, 2, 2, 1, 6], "size": [3, 4]}
+        assert dog_ann["bbox"] == [0, 1, 2, 2]
+        assert dog_ann["area"] == 3
+
+    def test_raster_layer_itself_is_not_exported(
+        self, raster_annotation_file: dt.AnnotationFile
+    ):
+        categories = coco._calculate_categories([raster_annotation_file])
+        annotations = list(
+            coco._build_annotations([raster_annotation_file], categories)
+        )
+
+        raster_category_id = coco._calculate_category_id(
+            dt.AnnotationClass("__raster_layer__", "raster_layer")
+        )
+        assert all(a["category_id"] != raster_category_id for a in annotations)
+
+    def test_mask_without_raster_coverage_is_skipped(self):
+        orphan_mask = dt.Annotation(
+            dt.AnnotationClass("cat", "mask"), {}, [], id="uuid-orphan"
+        )
+        annotation_file = dt.AnnotationFile(
+            path=Path("test.json"),
+            filename="test.json",
+            annotation_classes={dt.AnnotationClass("cat", "mask")},
+            annotations=[orphan_mask],
+            image_height=3,
+            image_width=4,
+        )
+        categories = coco._calculate_categories([annotation_file])
+
+        annotations = list(coco._build_annotations([annotation_file], categories))
+
+        assert annotations == []
+
+    def test_full_build_json_populates_categories_and_annotations(
+        self, raster_annotation_file: dt.AnnotationFile
+    ):
+        output = coco._build_json([raster_annotation_file])
+
+        assert {c["name"] for c in output["categories"]} == {"cat", "dog"}
+        assert len(output["annotations"]) == 2
+        assert len(output["images"]) == 1

--- a/tests/darwin/exporter/formats/export_coco_test.py
+++ b/tests/darwin/exporter/formats/export_coco_test.py
@@ -99,12 +99,8 @@ class TestBuildAnnotations:
 class TestBuildRasterAnnotations:
     @pytest.fixture
     def raster_annotation_file(self) -> dt.AnnotationFile:
-        mask_cat = dt.Annotation(
-            dt.AnnotationClass("cat", "mask"), {}, [], id="uuid-1"
-        )
-        mask_dog = dt.Annotation(
-            dt.AnnotationClass("dog", "mask"), {}, [], id="uuid-2"
-        )
+        mask_cat = dt.Annotation(dt.AnnotationClass("cat", "mask"), {}, [], id="uuid-1")
+        mask_dog = dt.Annotation(dt.AnnotationClass("dog", "mask"), {}, [], id="uuid-2")
         raster_layer = dt.Annotation(
             dt.AnnotationClass("__raster_layer__", "raster_layer"),
             {
@@ -138,17 +134,13 @@ class TestBuildRasterAnnotations:
 
         assert len(annotations) == 2
 
-        cat_ann = next(
-            a for a in annotations if a["category_id"] == categories["cat"]
-        )
+        cat_ann = next(a for a in annotations if a["category_id"] == categories["cat"])
         assert cat_ann["segmentation"] == {"counts": [3, 2, 1, 1, 5], "size": [3, 4]}
         assert cat_ann["bbox"] == [1, 0, 2, 2]
         assert cat_ann["area"] == 3
         assert cat_ann["iscrowd"] == 0
 
-        dog_ann = next(
-            a for a in annotations if a["category_id"] == categories["dog"]
-        )
+        dog_ann = next(a for a in annotations if a["category_id"] == categories["dog"])
         assert dog_ann["segmentation"] == {"counts": [1, 2, 2, 1, 6], "size": [3, 4]}
         assert dog_ann["bbox"] == [0, 1, 2, 2]
         assert dog_ann["area"] == 3
@@ -194,9 +186,7 @@ class TestBuildRasterAnnotations:
         assert len(output["images"]) == 1
 
     def test_raster_layer_with_odd_length_dense_rle_is_skipped(self):
-        mask_cat = dt.Annotation(
-            dt.AnnotationClass("cat", "mask"), {}, [], id="uuid-1"
-        )
+        mask_cat = dt.Annotation(dt.AnnotationClass("cat", "mask"), {}, [], id="uuid-1")
         raster_layer = dt.Annotation(
             dt.AnnotationClass("__raster_layer__", "raster_layer"),
             {
@@ -225,9 +215,7 @@ class TestBuildRasterAnnotations:
         assert annotations == []
 
     def test_raster_layer_missing_dense_rle_is_skipped(self):
-        mask_cat = dt.Annotation(
-            dt.AnnotationClass("cat", "mask"), {}, [], id="uuid-1"
-        )
+        mask_cat = dt.Annotation(dt.AnnotationClass("cat", "mask"), {}, [], id="uuid-1")
         raster_layer = dt.Annotation(
             dt.AnnotationClass("__raster_layer__", "raster_layer"),
             {
@@ -263,9 +251,7 @@ class TestRasterMaskEndToEnd:
             "item": {
                 "name": "test.png",
                 "path": "/",
-                "slots": [
-                    {"type": "image", "slot_name": "0", "width": 4, "height": 3}
-                ],
+                "slots": [{"type": "image", "slot_name": "0", "width": 4, "height": 3}],
             },
             "annotations": [
                 {"id": "uuid-1", "name": "cat", "slot_names": ["0"], "mask": {}},


### PR DESCRIPTION
## Summary
- The COCO exporter silently dropped `mask`/`raster_layer` annotations, producing empty `categories`/`annotations` for datasets annotated with the raster/brush tool (DAR-7915, closes #1173).
- Mask annotation classes are now included in COCO `categories`.
- Each `raster_layer`'s dense RLE is decoded once per file; every `mask` annotation is exported as a COCO instance annotation with uncompressed column-major RLE `segmentation`, `bbox`, pixel `area`, and `iscrowd: 0`. The conversion is lossless (no polygon approximation) and adds no new dependencies (`upolygon.rle_encode` already emits COCO-compliant counts).
- Malformed raster layers (missing fields, odd-length/invalid `dense_rle`, pixel-count mismatch, video annotations) are skipped with a printed message instead of aborting the export.

## Behaviour notes
- `mask` classes now appear in `categories` for all exports (previously absent).
- Annotation ids in files mixing raster layers with other types shift slightly: `raster_layer` entries no longer consume an id (ids only need to be unique in COCO; affected datasets previously exported empty output anyway).

## Test plan
- [x] `pytest tests/darwin/exporter/formats/export_coco_test.py` — 12 tests: hand-computed RLE counts/bboxes/areas on a 3×4 label map, raster-layer exclusion, orphan mask, malformed `dense_rle` (odd-length, missing field, negative count) skip paths
- [x] End-to-end cycle test committed: Darwin 2.0 JSON → `darwin_to_dt_gen` → `coco.export` → assertions on `output.json` (red-checked: fails on master's exporter, passes here)
- [x] Full suite: 756 passed, 29 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)