### PR TITLE
feat(importer): coco_masks format — import COCO RLE as raster masks (PY-118)

### DIFF
--- a/darwin/importer/formats/__init__.py
+++ b/darwin/importer/formats/__init__.py
@@ -4,6 +4,7 @@ from typing import List
 # https://docs.v7labs.com/docs/import-1
 supported_formats: List[str] = [
     "coco",
+    "coco_masks",
     "dataloop",
     "csv_tags",
     "csv_tags_video",

--- a/darwin/importer/formats/coco.py
+++ b/darwin/importer/formats/coco.py
@@ -97,7 +97,11 @@ def parse_json(
         annotation["segmentation"]
         if image_id not in image_annotations:
             image_annotations[image_id] = []
-        if rle_as_masks and isinstance(annotation["segmentation"], dict):
+        if (
+            rle_as_masks
+            and isinstance(annotation["segmentation"], dict)
+            and "counts" in annotation["segmentation"]
+        ):
             image_rle_annotations.setdefault(image_id, []).append(annotation)
         else:
             image_annotations[image_id].extend(
@@ -233,33 +237,39 @@ def _build_mask_annotations(
     next_label = 1
 
     for annotation in rle_annotations:
-        segmentation = annotation["segmentation"]
-        seg_height, seg_width = segmentation["size"]
-        if height is None or width is None or label_map is None:
-            height, width = seg_height, seg_width
-            label_map = np.zeros((height, width), dtype=np.int32)
-        elif (seg_height, seg_width) != (height, width):
-            logger.warning(
-                f"Skipping RLE annotation {annotation.get('id')}: size "
-                f"{segmentation['size']} does not match image size [{height}, {width}]"
+        try:
+            segmentation = annotation["segmentation"]
+            seg_height, seg_width = segmentation["size"]
+            if height is None or width is None or label_map is None:
+                height, width = seg_height, seg_width
+                label_map = np.zeros((height, width), dtype=np.int32)
+            elif (seg_height, seg_width) != (height, width):
+                logger.warning(
+                    f"Skipping RLE annotation {annotation.get('id')}: size "
+                    f"{segmentation['size']} does not match image size [{height}, {width}]"
+                )
+                continue
+            counts = segmentation["counts"]
+            if not isinstance(counts, list):
+                counts = decode_binary_rle(counts)
+            if sum(counts) != height * width:
+                logger.warning(
+                    f"Skipping RLE annotation {annotation.get('id')}: counts cover "
+                    f"{sum(counts)} pixels, expected {height * width}"
+                )
+                continue
+            binary = np.array(rle_decode(counts, [width, height])).reshape(
+                height, width
             )
+            category = category_lookup_table[annotation["category_id"]]
+            mask = dt.make_mask(category["name"])
+            mask.id = str(uuid4())
+            label_map[binary > 0] = next_label
+            painted_masks.append((mask, next_label))
+            next_label += 1
+        except Exception as e:
+            logger.warning(f"Skipping RLE annotation {annotation.get('id')}: {e}")
             continue
-        counts = segmentation["counts"]
-        if not isinstance(counts, list):
-            counts = decode_binary_rle(counts)
-        if sum(counts) != height * width:
-            logger.warning(
-                f"Skipping RLE annotation {annotation.get('id')}: counts cover "
-                f"{sum(counts)} pixels, expected {height * width}"
-            )
-            continue
-        binary = np.array(rle_decode(counts, [width, height])).reshape(height, width)
-        category = category_lookup_table[annotation["category_id"]]
-        mask = dt.make_mask(category["name"])
-        mask.id = str(uuid4())
-        label_map[binary > 0] = next_label
-        painted_masks.append((mask, next_label))
-        next_label += 1
 
     if label_map is None:
         return []

--- a/darwin/importer/formats/coco.py
+++ b/darwin/importer/formats/coco.py
@@ -45,7 +45,9 @@ def parse_path(path: Path) -> Optional[List[dt.AnnotationFile]]:
 
 
 def parse_json(
-    path: Path, data: Dict[str, dt.UnknownType]
+    path: Path,
+    data: Dict[str, dt.UnknownType],
+    rle_as_masks: bool = False,
 ) -> Iterator[dt.AnnotationFile]:
     """
     Parses the given ``json`` structure into an ``Iterator[dt.AnnotationFile]``.
@@ -56,6 +58,10 @@ def parse_json(
         The ``Path`` where file containing the ``data`` is.
     data : Dict[str, Any]
         The ``json`` data to process.
+    rle_as_masks : bool, default: False
+        If ``True``, RLE segmentations are imported as Darwin raster ``mask``
+        annotations (plus one ``raster_layer`` per image) instead of being
+        converted to polygons.
 
     Returns
     -------
@@ -72,6 +78,7 @@ def parse_json(
         category["id"]: category for category in tag_categories
     }
     image_annotations: Dict[str, dt.UnknownType] = {}
+    image_rle_annotations: Dict[str, List[Dict[str, dt.UnknownType]]] = {}
 
     for image in data["images"]:
         image_id = image["id"]
@@ -90,8 +97,16 @@ def parse_json(
         annotation["segmentation"]
         if image_id not in image_annotations:
             image_annotations[image_id] = []
+        if rle_as_masks and isinstance(annotation["segmentation"], dict):
+            image_rle_annotations.setdefault(image_id, []).append(annotation)
+        else:
+            image_annotations[image_id].extend(
+                parse_annotation(annotation, category_lookup_table)
+            )
+
+    for image_id, rle_annotations in image_rle_annotations.items():
         image_annotations[image_id].extend(
-            parse_annotation(annotation, category_lookup_table)
+            _build_mask_annotations(rle_annotations, category_lookup_table)
         )
 
     for image_id in image_annotations.keys():

--- a/darwin/importer/formats/coco.py
+++ b/darwin/importer/formats/coco.py
@@ -109,8 +109,14 @@ def parse_json(
             )
 
     for image_id, rle_annotations in image_rle_annotations.items():
+        image = image_lookup_table[int(image_id)]
         image_annotations[image_id].extend(
-            _build_mask_annotations(rle_annotations, category_lookup_table)
+            _build_mask_annotations(
+                rle_annotations,
+                category_lookup_table,
+                image_height=image.get("height"),
+                image_width=image.get("width"),
+            )
         )
 
     for image_id in image_annotations.keys():
@@ -222,6 +228,8 @@ def _encode_dense_rle(label_map: "np.ndarray") -> List[int]:
 def _build_mask_annotations(
     rle_annotations: List[Dict[str, dt.UnknownType]],
     category_lookup_table: Dict[str, dt.UnknownType],
+    image_height: Optional[int] = None,
+    image_width: Optional[int] = None,
 ) -> List[dt.Annotation]:
     """
     Converts one image's COCO RLE annotations into Darwin ``mask`` annotations
@@ -229,10 +237,21 @@ def _build_mask_annotations(
 
     Overlaps are resolved by annotation order: later annotations paint over
     earlier ones. Masks left without any visible pixel are dropped.
+
+    When ``image_height``/``image_width`` are both provided (the COCO image
+    record's authoritative dimensions), they set the canvas up front, and
+    every RLE's own ``segmentation["size"]`` is validated against them. This
+    prevents a malformed leading RLE (e.g. with the wrong ``size``) from
+    silently setting the wrong canvas and causing later, valid RLEs to be
+    skipped as "mismatched". When either dimension is ``None``, the first
+    RLE's ``size`` is used as the canvas, preserving prior behavior for
+    direct callers that don't pass image dimensions.
     """
-    height: Optional[int] = None
-    width: Optional[int] = None
+    height: Optional[int] = image_height
+    width: Optional[int] = image_width
     label_map: Optional[np.ndarray] = None
+    if height is not None and width is not None:
+        label_map = np.zeros((height, width), dtype=np.int32)
     painted_masks: List[Tuple[dt.Annotation, int]] = []
     next_label = 1
 

--- a/darwin/importer/formats/coco.py
+++ b/darwin/importer/formats/coco.py
@@ -1,7 +1,9 @@
 from logging import getLogger
 from pathlib import Path
-from typing import Dict, Iterator, List, Optional
+from typing import Dict, Iterator, List, Optional, Tuple
+from uuid import uuid4
 
+import numpy as np
 import orjson as json
 from upolygon import find_contours, rle_decode
 
@@ -184,6 +186,93 @@ def parse_annotation(
         return [dt.make_polygon(category["name"], point_paths)]
     else:
         return []
+
+
+def _encode_dense_rle(label_map: "np.ndarray") -> List[int]:
+    """Encodes a 2D label map into Darwin's row-major [value, count, ...] dense RLE."""
+    flat = label_map.flatten()
+    boundaries = np.flatnonzero(flat[1:] != flat[:-1]) + 1
+    starts = np.concatenate(([0], boundaries))
+    lengths = np.diff(np.concatenate((starts, [flat.size])))
+    dense_rle: List[int] = []
+    for value, length in zip(flat[starts], lengths):
+        dense_rle.extend((int(value), int(length)))
+    return dense_rle
+
+
+def _build_mask_annotations(
+    rle_annotations: List[Dict[str, dt.UnknownType]],
+    category_lookup_table: Dict[str, dt.UnknownType],
+) -> List[dt.Annotation]:
+    """
+    Converts one image's COCO RLE annotations into Darwin ``mask`` annotations
+    plus a single ``raster_layer`` annotation.
+
+    Overlaps are resolved by annotation order: later annotations paint over
+    earlier ones. Masks left without any visible pixel are dropped.
+    """
+    height: Optional[int] = None
+    width: Optional[int] = None
+    label_map: Optional[np.ndarray] = None
+    painted_masks: List[Tuple[dt.Annotation, int]] = []
+    next_label = 1
+
+    for annotation in rle_annotations:
+        segmentation = annotation["segmentation"]
+        seg_height, seg_width = segmentation["size"]
+        if height is None or width is None or label_map is None:
+            height, width = seg_height, seg_width
+            label_map = np.zeros((height, width), dtype=np.int32)
+        elif (seg_height, seg_width) != (height, width):
+            logger.warning(
+                f"Skipping RLE annotation {annotation.get('id')}: size "
+                f"{segmentation['size']} does not match image size [{height}, {width}]"
+            )
+            continue
+        counts = segmentation["counts"]
+        if not isinstance(counts, list):
+            counts = decode_binary_rle(counts)
+        if sum(counts) != height * width:
+            logger.warning(
+                f"Skipping RLE annotation {annotation.get('id')}: counts cover "
+                f"{sum(counts)} pixels, expected {height * width}"
+            )
+            continue
+        binary = np.array(rle_decode(counts, [width, height])).reshape(height, width)
+        category = category_lookup_table[annotation["category_id"]]
+        mask = dt.make_mask(category["name"])
+        mask.id = str(uuid4())
+        label_map[binary > 0] = next_label
+        painted_masks.append((mask, next_label))
+        next_label += 1
+
+    if label_map is None:
+        return []
+
+    visible_labels = set(np.unique(label_map))
+    mask_annotation_ids_mapping: Dict[str, int] = {}
+    visible_masks: List[dt.Annotation] = []
+    for mask, label in painted_masks:
+        if label not in visible_labels:
+            logger.warning(
+                f"Skipping mask '{mask.annotation_class.name}': fully occluded by "
+                "later annotations"
+            )
+            continue
+        mask_annotation_ids_mapping[mask.id] = label
+        visible_masks.append(mask)
+
+    if not visible_masks:
+        return []
+
+    raster_layer = dt.make_raster_layer(
+        "__raster_layer__",
+        mask_annotation_ids_mapping,
+        int(height * width),
+        _encode_dense_rle(label_map),
+    )
+    raster_layer.id = str(uuid4())
+    return visible_masks + [raster_layer]
 
 
 def _decode_file(current_encoding: str, path: Path):

--- a/darwin/importer/formats/coco_masks.py
+++ b/darwin/importer/formats/coco_masks.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+from typing import List, Optional
+
+import darwin.datatypes as dt
+from darwin.importer.formats import coco
+from darwin.utils import attempt_decode
+
+
+def parse_path(path: Path) -> Optional[List[dt.AnnotationFile]]:
+    """
+    Parses the given ``coco`` file like the ``coco`` importer, but imports RLE
+    segmentations as Darwin raster ``mask`` annotations (plus one
+    ``raster_layer`` per image) instead of converting them to polygons.
+    Polygon segmentations are imported as polygons, unchanged.
+
+    Parameters
+    ----------
+    path : Path
+        The ``Path`` to the ``coco`` file.
+
+    Returns
+    -------
+    Optional[List[dt.AnnotationFile]]
+        Returns ``None`` if the given file is not in ``json`` format, or
+        ``List[dt.AnnotationFile]`` otherwise.
+    """
+    if path.suffix != ".json":
+        return None
+    data = attempt_decode(path)
+    return list(coco.parse_json(path, data, rle_as_masks=True))

--- a/tests/darwin/importer/formats/import_coco_masks_test.py
+++ b/tests/darwin/importer/formats/import_coco_masks_test.py
@@ -1,0 +1,116 @@
+from darwin.importer.formats import coco
+
+CAT_RLE = {"counts": [3, 2, 1, 1, 5], "size": [3, 4]}
+DOG_RLE = {"counts": [1, 2, 2, 1, 6], "size": [3, 4]}
+CANONICAL_DENSE_RLE = [0, 1, 1, 2, 0, 1, 2, 1, 1, 1, 0, 2, 2, 2, 0, 2]
+
+CATEGORIES = {10: {"id": 10, "name": "cat"}, 20: {"id": 20, "name": "dog"}}
+
+
+def _rle_annotation(annotation_id, category_id, segmentation, iscrowd=0):
+    return {
+        "id": annotation_id,
+        "image_id": 1,
+        "category_id": category_id,
+        "iscrowd": iscrowd,
+        "segmentation": segmentation,
+        "bbox": [],
+        "area": 0,
+    }
+
+
+class TestBuildMaskAnnotations:
+    def test_two_instances_synthesize_masks_and_raster_layer(self):
+        annotations = coco._build_mask_annotations(
+            [
+                _rle_annotation(100, 10, CAT_RLE),
+                _rle_annotation(200, 20, DOG_RLE),
+            ],
+            CATEGORIES,
+        )
+
+        assert len(annotations) == 3
+        cat_mask, dog_mask, raster_layer = annotations
+
+        assert cat_mask.annotation_class.name == "cat"
+        assert cat_mask.annotation_class.annotation_type == "mask"
+        assert dog_mask.annotation_class.name == "dog"
+        assert dog_mask.annotation_class.annotation_type == "mask"
+        assert cat_mask.id and dog_mask.id and cat_mask.id != dog_mask.id
+
+        assert raster_layer.annotation_class.name == "__raster_layer__"
+        assert raster_layer.annotation_class.annotation_type == "raster_layer"
+        assert raster_layer.data["total_pixels"] == 12
+        assert raster_layer.data["dense_rle"] == CANONICAL_DENSE_RLE
+        assert raster_layer.data["mask_annotation_ids_mapping"] == {
+            cat_mask.id: 1,
+            dog_mask.id: 2,
+        }
+
+    def test_overlap_later_annotation_wins(self):
+        # A = 2x2 top-left block, B = 2x2 block at rows 1-2 / cols 1-2.
+        # They overlap at pixel (1,1); B is later so it wins there.
+        # Expected label map (row-major):
+        #   1 1 0 0
+        #   1 2 2 0
+        #   0 2 2 0
+        a_rle = {"counts": [0, 2, 1, 2, 7], "size": [3, 4]}
+        b_rle = {"counts": [4, 2, 1, 2, 3], "size": [3, 4]}
+
+        annotations = coco._build_mask_annotations(
+            [_rle_annotation(1, 10, a_rle), _rle_annotation(2, 20, b_rle)],
+            CATEGORIES,
+        )
+
+        raster_layer = annotations[-1]
+        assert raster_layer.data["dense_rle"] == [
+            1,
+            2,
+            0,
+            2,
+            1,
+            1,
+            2,
+            2,
+            0,
+            2,
+            2,
+            2,
+            0,
+            1,
+        ]
+
+    def test_fully_occluded_mask_is_dropped(self):
+        # A = single pixel (0,0); B = 2x2 top-left block covering it entirely.
+        a_rle = {"counts": [0, 1, 11], "size": [3, 4]}
+        b_rle = {"counts": [0, 2, 1, 2, 7], "size": [3, 4]}
+
+        annotations = coco._build_mask_annotations(
+            [_rle_annotation(1, 10, a_rle), _rle_annotation(2, 20, b_rle)],
+            CATEGORIES,
+        )
+
+        assert len(annotations) == 2  # dog mask + raster layer only
+        dog_mask, raster_layer = annotations
+        assert dog_mask.annotation_class.name == "dog"
+        assert raster_layer.data["mask_annotation_ids_mapping"] == {dog_mask.id: 2}
+        assert 1 not in raster_layer.data["dense_rle"][0::2]
+
+    def test_size_mismatch_and_bad_counts_are_skipped_not_raised(self):
+        wrong_size = {"counts": [0, 4], "size": [2, 2]}
+        wrong_total = {"counts": [3, 2], "size": [3, 4]}
+
+        annotations = coco._build_mask_annotations(
+            [
+                _rle_annotation(1, 10, CAT_RLE),
+                _rle_annotation(2, 20, wrong_size),
+                _rle_annotation(3, 20, wrong_total),
+            ],
+            CATEGORIES,
+        )
+
+        assert len(annotations) == 2  # cat mask + raster layer
+        assert annotations[0].annotation_class.name == "cat"
+
+    def test_no_annotations_returns_empty(self):
+        assert coco._build_mask_annotations([], CATEGORIES) == []

--- a/tests/darwin/importer/formats/import_coco_masks_test.py
+++ b/tests/darwin/importer/formats/import_coco_masks_test.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
 
+from darwin.exporter import exporter as darwin_exporter
+from darwin.exporter.formats import coco as coco_exporter
 from darwin.importer.formats import coco
 
 CAT_RLE = {"counts": [3, 2, 1, 1, 5], "size": [3, 4]}
@@ -230,3 +232,75 @@ class TestCocoMasksParsePath:
             a.annotation_class.annotation_type for a in annotation_files[0].annotations
         ]
         assert types == ["polygon"]  # classic behavior: RLE polygonized
+
+
+class TestRoundTrip:
+    def test_darwin_masks_survive_coco_round_trip(self, tmp_path: Path):
+        darwin_json = {
+            "version": "2.0",
+            "schema_ref": "https://darwin-public.s3.eu-west-1.amazonaws.com/darwin_json/2.0/schema.json",
+            "item": {
+                "name": "test.png",
+                "path": "/",
+                "slots": [{"type": "image", "slot_name": "0", "width": 4, "height": 3}],
+            },
+            "annotations": [
+                {"id": "uuid-1", "name": "cat", "slot_names": ["0"], "mask": {}},
+                {"id": "uuid-2", "name": "dog", "slot_names": ["0"], "mask": {}},
+                {
+                    "id": "uuid-raster",
+                    "name": "__raster_layer__",
+                    "slot_names": ["0"],
+                    "raster_layer": {
+                        "dense_rle": CANONICAL_DENSE_RLE,
+                        "mask_annotation_ids_mapping": {"uuid-1": 1, "uuid-2": 2},
+                        "total_pixels": 12,
+                    },
+                },
+            ],
+        }
+        src = tmp_path / "annotations"
+        out = tmp_path / "out"
+        src.mkdir()
+        out.mkdir()
+        (src / "test.json").write_text(json.dumps(darwin_json))
+
+        # Darwin -> COCO (PR #1177 exporter)
+        dt_gen = darwin_exporter.darwin_to_dt_gen(
+            list(src.glob("*.json")), split_sequences=False
+        )
+        coco_exporter.export(dt_gen, out)
+
+        # COCO -> Darwin (coco_masks importer)
+        from darwin.importer.formats import coco_masks
+
+        annotation_files = coco_masks.parse_path(out / "output.json")
+
+        assert annotation_files is not None and len(annotation_files) == 1
+        annotation_file = annotation_files[0]
+        assert annotation_file.filename == "test.png"
+
+        masks = [
+            a
+            for a in annotation_file.annotations
+            if a.annotation_class.annotation_type == "mask"
+        ]
+        raster_layers = [
+            a
+            for a in annotation_file.annotations
+            if a.annotation_class.annotation_type == "raster_layer"
+        ]
+        assert len(masks) == 2
+        assert len(raster_layers) == 1
+        raster_layer = raster_layers[0]
+
+        # The label map survives the full cycle EXACTLY: same dense RLE,
+        # same total_pixels, same class->label association.
+        assert raster_layer.data["dense_rle"] == CANONICAL_DENSE_RLE
+        assert raster_layer.data["total_pixels"] == 12
+
+        mapping = raster_layer.data["mask_annotation_ids_mapping"]
+        label_by_class = {
+            mask.annotation_class.name: mapping[mask.id] for mask in masks
+        }
+        assert label_by_class == {"cat": 1, "dog": 2}

--- a/tests/darwin/importer/formats/import_coco_masks_test.py
+++ b/tests/darwin/importer/formats/import_coco_masks_test.py
@@ -1,3 +1,6 @@
+import json
+from pathlib import Path
+
 from darwin.importer.formats import coco
 
 CAT_RLE = {"counts": [3, 2, 1, 1, 5], "size": [3, 4]}
@@ -114,3 +117,116 @@ class TestBuildMaskAnnotations:
 
     def test_no_annotations_returns_empty(self):
         assert coco._build_mask_annotations([], CATEGORIES) == []
+
+
+def _coco_json(annotations, categories=None):
+    return {
+        "images": [{"id": 1, "file_name": "test.png", "height": 3, "width": 4}],
+        "categories": categories
+        or [
+            {"id": 10, "name": "cat", "supercategory": "root"},
+            {"id": 20, "name": "dog", "supercategory": "root"},
+        ],
+        "annotations": annotations,
+    }
+
+
+class TestCocoMasksParsePath:
+    def test_rle_annotations_import_as_masks(self, tmp_path: Path):
+        from darwin.importer.formats import coco_masks
+
+        coco_file = tmp_path / "coco.json"
+        coco_file.write_text(
+            json.dumps(
+                _coco_json(
+                    [
+                        _rle_annotation(100, 10, CAT_RLE),
+                        _rle_annotation(200, 20, DOG_RLE),
+                    ]
+                )
+            )
+        )
+
+        annotation_files = coco_masks.parse_path(coco_file)
+
+        assert annotation_files is not None and len(annotation_files) == 1
+        annotation_file = annotation_files[0]
+        assert annotation_file.filename == "test.png"
+
+        types = [
+            a.annotation_class.annotation_type for a in annotation_file.annotations
+        ]
+        assert types.count("mask") == 2
+        assert types.count("raster_layer") == 1
+
+        raster_layer = next(
+            a
+            for a in annotation_file.annotations
+            if a.annotation_class.annotation_type == "raster_layer"
+        )
+        assert raster_layer.data["dense_rle"] == CANONICAL_DENSE_RLE
+        assert raster_layer.data["total_pixels"] == 12
+
+    def test_polygon_annotations_still_import_as_polygons(self, tmp_path: Path):
+        from darwin.importer.formats import coco_masks
+
+        polygon_annotation = {
+            "id": 300,
+            "image_id": 1,
+            "category_id": 10,
+            "iscrowd": 0,
+            "segmentation": [[0.0, 0.0, 2.0, 0.0, 2.0, 2.0]],
+            "bbox": [0, 0, 2, 2],
+            "area": 2,
+        }
+        coco_file = tmp_path / "coco.json"
+        coco_file.write_text(
+            json.dumps(
+                _coco_json([polygon_annotation, _rle_annotation(100, 20, DOG_RLE)])
+            )
+        )
+
+        annotation_files = coco_masks.parse_path(coco_file)
+
+        types = [
+            a.annotation_class.annotation_type for a in annotation_files[0].annotations
+        ]
+        assert types.count("polygon") == 1
+        assert types.count("mask") == 1
+        assert types.count("raster_layer") == 1
+
+    def test_iscrowd_rle_imports_as_mask_instead_of_being_skipped(self, tmp_path: Path):
+        from darwin.importer.formats import coco_masks
+
+        coco_file = tmp_path / "coco.json"
+        coco_file.write_text(
+            json.dumps(_coco_json([_rle_annotation(100, 10, CAT_RLE, iscrowd=1)]))
+        )
+
+        annotation_files = coco_masks.parse_path(coco_file)
+
+        types = [
+            a.annotation_class.annotation_type for a in annotation_files[0].annotations
+        ]
+        assert types.count("mask") == 1
+        assert types.count("raster_layer") == 1
+
+    def test_registered_with_get_importer(self):
+        from darwin.importer import get_importer
+        from darwin.importer.formats import coco_masks, supported_formats
+
+        assert "coco_masks" in supported_formats
+        assert get_importer("coco_masks") is coco_masks.parse_path
+
+    def test_classic_coco_importer_unchanged(self, tmp_path: Path):
+        coco_file = tmp_path / "coco.json"
+        coco_file.write_text(
+            json.dumps(_coco_json([_rle_annotation(100, 10, CAT_RLE)]))
+        )
+
+        annotation_files = coco.parse_path(coco_file)
+
+        types = [
+            a.annotation_class.annotation_type for a in annotation_files[0].annotations
+        ]
+        assert types == ["polygon"]  # classic behavior: RLE polygonized

--- a/tests/darwin/importer/formats/import_coco_masks_test.py
+++ b/tests/darwin/importer/formats/import_coco_masks_test.py
@@ -120,6 +120,34 @@ class TestBuildMaskAnnotations:
     def test_no_annotations_returns_empty(self):
         assert coco._build_mask_annotations([], CATEGORIES) == []
 
+    def test_missing_size_is_skipped_not_raised(self):
+        missing_size = {"counts": [3, 2, 1, 1, 5]}
+
+        annotations = coco._build_mask_annotations(
+            [
+                _rle_annotation(1, 10, CAT_RLE),
+                _rle_annotation(2, 20, missing_size),
+            ],
+            CATEGORIES,
+        )
+
+        assert len(annotations) == 2  # cat mask + raster layer only
+        assert annotations[0].annotation_class.name == "cat"
+        assert annotations[-1].annotation_class.annotation_type == "raster_layer"
+
+    def test_unknown_category_id_is_skipped_not_raised(self):
+        annotations = coco._build_mask_annotations(
+            [
+                _rle_annotation(1, 10, CAT_RLE),
+                _rle_annotation(2, 99, DOG_RLE),
+            ],
+            CATEGORIES,
+        )
+
+        assert len(annotations) == 2  # cat mask + raster layer only
+        assert annotations[0].annotation_class.name == "cat"
+        assert annotations[-1].annotation_class.annotation_type == "raster_layer"
+
 
 def _coco_json(annotations, categories=None):
     return {
@@ -212,6 +240,36 @@ class TestCocoMasksParsePath:
         ]
         assert types.count("mask") == 1
         assert types.count("raster_layer") == 1
+
+    def test_empty_dict_segmentation_stays_on_classic_path(self, tmp_path: Path):
+        from darwin.importer.formats import coco_masks
+
+        coco_file = tmp_path / "coco.json"
+        coco_file.write_text(
+            json.dumps(
+                _coco_json(
+                    [
+                        {
+                            "id": 400,
+                            "image_id": 1,
+                            "category_id": 10,
+                            "iscrowd": 0,
+                            "segmentation": {},
+                            "bbox": [1, 1, 2, 2],
+                            "area": 4,
+                        }
+                    ]
+                )
+            )
+        )
+
+        annotation_files = coco_masks.parse_path(coco_file)
+
+        assert annotation_files is not None and len(annotation_files) == 1
+        types = [
+            a.annotation_class.annotation_type for a in annotation_files[0].annotations
+        ]
+        assert types == ["bounding_box"]
 
     def test_registered_with_get_importer(self):
         from darwin.importer import get_importer

--- a/tests/darwin/importer/formats/import_coco_masks_test.py
+++ b/tests/darwin/importer/formats/import_coco_masks_test.py
@@ -148,6 +148,54 @@ class TestBuildMaskAnnotations:
         assert annotations[0].annotation_class.name == "cat"
         assert annotations[-1].annotation_class.annotation_type == "raster_layer"
 
+    def test_image_dims_authority_ignores_malformed_leading_rle_size(self):
+        # A malformed FIRST RLE claims a 2x2 canvas, but the image record is
+        # actually 3x4 (image_height=3, image_width=4). The image dims must
+        # win: the wrong-size RLE is skipped, and the valid CAT_RLE (which
+        # matches the real 3x4 canvas) is kept instead of being skipped as
+        # "mismatched" against a bogus 2x2 canvas set by the first RLE.
+        #
+        # CAT_RLE decodes (row-major, on a 3x4 canvas) to:
+        #   0 1 1 0
+        #   0 1 0 0
+        #   0 0 0 0
+        # i.e. flat = [0,1,1,0, 0,1,0,0, 0,0,0,0]
+        # Dense RLE (value,count pairs) of that flat sequence:
+        #   0x1, 1x2, 0x2, 1x1, 0x6
+        # => [0, 1, 1, 2, 0, 2, 1, 1, 0, 6]
+        wrong_size_first = {"counts": [0, 4], "size": [2, 2]}
+
+        annotations = coco._build_mask_annotations(
+            [
+                _rle_annotation(1, 99, wrong_size_first),
+                _rle_annotation(2, 10, CAT_RLE),
+            ],
+            CATEGORIES,
+            image_height=3,
+            image_width=4,
+        )
+
+        assert len(annotations) == 2  # cat mask + raster layer
+        cat_mask, raster_layer = annotations
+        assert cat_mask.annotation_class.name == "cat"
+        assert raster_layer.data["total_pixels"] == 12
+        assert raster_layer.data["dense_rle"] == [0, 1, 1, 2, 0, 2, 1, 1, 0, 6]
+
+    def test_without_image_dims_first_rle_size_remains_authority(self):
+        # Backward-compat: when image_height/image_width are not supplied
+        # (positional call, as existing direct-unit callers do), the FIRST
+        # RLE's own "size" continues to set the canvas, exactly as before.
+        wrong_size_only = {"counts": [0, 4], "size": [2, 2]}
+
+        annotations = coco._build_mask_annotations(
+            [_rle_annotation(1, 10, wrong_size_only)],
+            CATEGORIES,
+        )
+
+        assert len(annotations) == 2  # single mask + raster layer
+        raster_layer = annotations[-1]
+        assert raster_layer.data["total_pixels"] == 4
+
 
 def _coco_json(annotations, categories=None):
     return {


### PR DESCRIPTION
## Summary
- Adds a `coco_masks` import format (`darwin dataset import <dataset> coco_masks <files>`): RLE segmentations become Darwin raster masks (`mask` + `raster_layer`) instead of being lossily contour-traced to polygons (which drops holes). Polygon segmentations, bbox-only annotations, and tags import exactly as with `coco`.
- The classic `coco` importer is byte-for-byte unchanged — no behavior change for existing users; the variant-format-name approach mirrors the exporter's `coco`/`mask`/`semantic_mask`/`instance_mask` convention.
- Overlapping RLE instances are flattened deterministically: later annotations paint over earlier ones (Darwin raster layers assign each pixel one label); fully occluded masks are dropped with a warning.
- In `coco_masks` mode, RLE annotations import regardless of `iscrowd` (a crowd region is exactly a raster mask), and RLE-derived masks are appended after an image's polygon annotations (source interleaving not preserved) — both intentional behavior deltas vs classic.
- Malformed RLE (missing/mismatched `size`, bad `counts`, unknown `category_id`) is skipped with a warning, never raised.
- Completes the importer half of PY-118 (exporter half: #1177) and closes the loop: **Darwin masks → COCO export → `coco_masks` import round-trips the dense RLE label map byte-identically** (test included; the classic importer demonstrably cannot — it polygonizes the same file).

## Stacked on #1177
Base branch is `dar-7915-coco-exporter-silently-drops-raster-mask-raster_layer` — merge #1177 first; GitHub will retarget this PR to master automatically.

## Test plan
- [x] Synthesis unit tests: hand-computed dense RLE on a 3×4 label map, overlap later-wins, full-occlusion drop, size/counts-mismatch + missing-size + unknown-category skips, empty input
- [x] `parse_path` tests: masks + raster layer produced, polygon passthrough, empty-dict segmentation stays on the classic bbox path, iscrowd RLE as mask, `get_importer("coco_masks")` registration, classic `coco` importer unchanged
- [x] Round-trip test: Darwin JSON → COCO export → `coco_masks` import → identical `dense_rle`/`total_pixels`/class-label mapping
- [x] Full suite: 768 passed, 29 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)